### PR TITLE
AMLS-2828: Change officer flow

### DIFF
--- a/app/controllers/changeofficer/Flow.scala
+++ b/app/controllers/changeofficer/Flow.scala
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-import javax.inject.Inject
+package controllers.changeofficer
 
-import filters.{ChangeOfficerFeatureFilter, ConfirmationFilter}
-import play.api.http.DefaultHttpFilters
+object Flow {
 
-class Filters @Inject()(confirmationFilter: ConfirmationFilter, changeOfficerFeatureFilter: ChangeOfficerFeatureFilter)
-  extends DefaultHttpFilters(confirmationFilter, changeOfficerFeatureFilter)
+  val journeyUrls = Seq(
+    controllers.changeofficer.routes.StillEmployedController.get().url,
+    controllers.changeofficer.routes.RoleInBusinessController.get().url,
+    controllers.changeofficer.routes.RemoveResponsiblePersonController.get().url,
+    controllers.changeofficer.routes.NewOfficerController.get().url,
+    controllers.changeofficer.routes.FurtherUpdatesController.get().url
+  )
 
+}

--- a/app/filters/ChangeOfficerFeatureFilter.scala
+++ b/app/filters/ChangeOfficerFeatureFilter.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import javax.inject.Inject
+
+import akka.stream.Materializer
+import play.api.mvc.{Filter, RequestHeader, Result}
+import uk.gov.hmrc.play.config.inject.ServicesConfig
+import play.api.mvc.Results._
+
+import scala.concurrent.Future
+
+class ChangeOfficerFeatureFilter @Inject()(config: ServicesConfig)(implicit val mat: Materializer) extends Filter {
+  override def apply(f: (RequestHeader) => Future[Result])(request: RequestHeader) = {
+    import utils.Strings._
+    println(request.path in Console.YELLOW)
+    println(controllers.changeofficer.Flow.journeyUrls.toString in Console.CYAN)
+
+    if (controllers.changeofficer.Flow.journeyUrls.contains(request.path)) {
+      if (config.getConfBool("feature-toggle.change-officer", false)) {
+        f(request)
+      } else {
+        Future.successful(NotFound)
+      }
+    } else {
+      f(request)
+    }
+  }
+}

--- a/app/filters/ChangeOfficerFeatureFilter.scala
+++ b/app/filters/ChangeOfficerFeatureFilter.scala
@@ -26,19 +26,15 @@ import play.api.mvc.Results._
 import scala.concurrent.Future
 
 class ChangeOfficerFeatureFilter @Inject()(config: ServicesConfig)(implicit val mat: Materializer) extends Filter {
-  override def apply(f: (RequestHeader) => Future[Result])(request: RequestHeader) = {
-    import utils.Strings._
-    println(request.path in Console.YELLOW)
-    println(controllers.changeofficer.Flow.journeyUrls.toString in Console.CYAN)
-
+  override def apply(nextAction: (RequestHeader) => Future[Result])(request: RequestHeader) = {
     if (controllers.changeofficer.Flow.journeyUrls.contains(request.path)) {
       if (config.getConfBool("feature-toggle.change-officer", false)) {
-        f(request)
+        nextAction(request)
       } else {
         Future.successful(NotFound)
       }
     } else {
-      f(request)
+      nextAction(request)
     }
   }
 }

--- a/test/filters/ChangeOfficerFeatureFilterSpec.scala
+++ b/test/filters/ChangeOfficerFeatureFilterSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import akka.stream.Materializer
+import org.scalatest.TestData
+import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.play.{OneAppPerSuite, OneAppPerTest, PlaySpec}
+import play.api.Environment
+import uk.gov.hmrc.play.config.inject.ServicesConfig
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.{Action, Results}
+import play.api.test.FakeRequest
+import play.api.test._
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.filters.MicroserviceFilterSupport
+
+class ChangeOfficerFeatureOnFilterSpec extends PlaySpec with MockitoSugar with OneAppPerSuite with Results with MicroserviceFilterSupport {
+
+  override lazy val app = new GuiceApplicationBuilder()
+    .configure("microservice.services.feature-toggle.change-officer" -> true)
+    .build()
+
+  lazy val filter = app.injector.instanceOf[ChangeOfficerFeatureFilter]
+  val nextAction = Action(Ok("ok"))
+
+  "ChangeOfficerFeatureOnFilter" must {
+    "allow access to the change officer journey" when {
+      "the feature is turned on" in {
+
+        controllers.changeofficer.Flow.journeyUrls foreach { url =>
+          val requestHeader = FakeRequest("GET", url)
+          val result = filter(nextAction)(requestHeader).run()
+
+          status(result) mustBe OK
+        }
+      }
+    }
+  }
+}
+
+class ChangeOfficerFeatureOffFilterSpec extends PlaySpec with MockitoSugar with OneAppPerSuite with Results with MicroserviceFilterSupport {
+
+  override lazy val app = new GuiceApplicationBuilder()
+    .configure("microservice.services.feature-toggle.change-officer" -> false)
+    .build()
+
+  lazy val filter = app.injector.instanceOf[ChangeOfficerFeatureFilter]
+  val nextAction = Action(Ok("ok"))
+
+  "ChangeOfficerFeatureOffFilter" must {
+    "allow access to the change officer journey" when {
+      "the feature is turned off" in {
+
+        controllers.changeofficer.Flow.journeyUrls foreach { url =>
+          val requestHeader = FakeRequest("GET", url)
+          val result = filter(nextAction)(requestHeader).run()
+          status(result) mustBe NOT_FOUND
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR implements a request filter that prevents the user from accessing the 'change nominated officer' flow when the feature is toggled off.