### PR TITLE
Update shell script for running service locally to fix Save4Later issue

### DIFF
--- a/run-local-no-inappconf.sh
+++ b/run-local-no-inappconf.sh
@@ -1,1 +1,1 @@
-sbt -jvm-debug 5005 "run 9222" -Dapplication.router=testOnlyDoNotUseInAppConf.Routes
+sbt -jvm-debug 5005 -Dapplication.router=testOnlyDoNotUseInAppConf.Routes "run 9222"


### PR DESCRIPTION
Changed the order of operations in the shell script file to fix the Drop Save4Later issue which affected my locally running front end.

Updated script was tested on Jack's machine and still worked.