### PR TITLE
AMLS-2934: Renewal Under Review - MSB - Page getting 404 on edit mode

### DIFF
--- a/app/views/msb/summary.scala.html
+++ b/app/views/msb/summary.scala.html
@@ -120,7 +120,7 @@
             @model.sendMoneyToOtherCountry.map{ otherCountries =>
                 @checkYourAnswers(
                     question = Messages("msb.send.money.title"),
-                    editUrl = controllers.msb.routes.SendMoneyToOtherCountryController.get(true).toString
+                    editUrl = if(isEditable) { controllers.msb.routes.SendMoneyToOtherCountryController.get(true).toString } else ""
                 ) {
                     <p>@otherCountries.money match {
                         case true => {@Messages("lbl.yes")}

--- a/test/controllers/msb/SummaryControllerSpec.scala
+++ b/test/controllers/msb/SummaryControllerSpec.scala
@@ -153,7 +153,7 @@ class SummaryControllerSpec extends GenericTestHelper with MockitoSugar {
         document.getElementsByTag("section").get(3).getElementsByTag("a").hasClass("change-answer") must be(true)
         document.getElementsByTag("section").get(4).getElementsByTag("a").hasClass("change-answer") must be(true)
         document.getElementsByTag("section").get(5).getElementsByTag("a").hasClass("change-answer") must be(false)
-        document.getElementsByTag("section").get(6).getElementsByTag("a").hasClass("change-answer") must be(true)
+        document.getElementsByTag("section").get(6).getElementsByTag("a").hasClass("change-answer") must be(false)
         document.getElementsByTag("section").get(7).getElementsByTag("a").hasClass("change-answer") must be(false)
         document.getElementsByTag("section").get(8).getElementsByTag("a").hasClass("change-answer") must be(false)
         document.getElementsByTag("section").get(9).getElementsByTag("a").hasClass("change-answer") must be(false)


### PR DESCRIPTION
This work is to remove the ability to edit the “Do you send money to other countries?” question from the MSB summary page during a variation.