### PR TITLE
AMLS-2979: API11 is failing due to invalid date format & API11 content contains special characters

### DIFF
--- a/app/models/notifications/NotificationDetails.scala
+++ b/app/models/notifications/NotificationDetails.scala
@@ -62,26 +62,28 @@ object NotificationDetails {
 
   val dateTimeFormat = ISODateTimeFormat.dateTimeNoMillis().withZoneUTC
 
+  private val parseDate: String => LocalDate =
+    input => LocalDate.parse(input, DateTimeFormat.forPattern("dd/MM/yyyy"))
+
+  private val extractEndDate: String => Option[LocalDate] = input => {
+    val pattern = """(?i)[\w\s]+-(\d{1,2}/\d{1,2}/\d{4})""".r.unanchored
+    pattern.findFirstMatchIn(input).fold(none[LocalDate])(m => parseDate(m.group(1)).some)
+  }
+
+  private val extractReference: String => Option[String] = input => {
+    val pattern = """(?i)[\w\s]+-([a-z][a-z0-9]+)""".r.unanchored
+    pattern.findFirstMatchIn(input).fold(none[String])(m => m.group(1).some)
+  }
+
   def convertEndDateWithRefMessageText(inputString: String): Option[EndDateDetails] = {
-
-    inputString.split("\\|").toList match {
-      case date :: ref :: Nil => {
-        val dateValue = LocalDate.parse(splitByDash(date), DateTimeFormat.forPattern("dd/MM/yyyy"))
-        Some(EndDateDetails(dateValue, Some(splitByDash(ref))))
-      }
-      case _ => None
-    }
+    for {
+      date <- extractEndDate(inputString)
+      ref <- extractReference(inputString)
+    } yield EndDateDetails(date, ref.some)
   }
 
-  def convertEndDateMessageText(inputString: String): Option[EndDateDetails] = {
-    val pattern = """End Date-(\d{2}/\d{2}/\d{4})""".r.unanchored
-    val matchToDetails: Regex.Match => Option[EndDateDetails] = m => {
-      val date = LocalDate.parse(m.group(1), DateTimeFormat.forPattern("dd/MM/yyyy"))
-      EndDateDetails(date, None).some
-    }
-
-    pattern.findFirstMatchIn(inputString).fold(none[EndDateDetails])(matchToDetails)
-  }
+  def convertEndDateMessageText(inputString: String): Option[EndDateDetails] =
+    extractEndDate(inputString) map { date => EndDateDetails(date, None) }
 
   def convertReminderMessageText(inputString: String): Option[ReminderDetails] = {
     inputString.split("\\|").toList match {

--- a/test/models/notifications/NotificationDetailsSpec.scala
+++ b/test/models/notifications/NotificationDetailsSpec.scala
@@ -119,7 +119,15 @@ class NotificationDetailsSpec extends PlaySpec with MustMatchers {
   "convertEndDateWithRefMessageText" must {
     "convert the input message text into the model when there is both a date and a red in the input string" in {
 
-      val inputString = "parameter1-31/07/2018|parameter2-ABC1234"
+      val inputString = "parameter 1-31/07/2018|parameter 2-ABC1234"
+
+      //noinspection ScalaStyle
+      NotificationDetails.convertEndDateWithRefMessageText(inputString) mustBe Some(EndDateDetails(new LocalDate(2018, 7, 31), Some("ABC1234")))
+
+    }
+
+    "convert the input message text into the model when there are special characters in the input string" in {
+      val inputString = "<![CDATA[<P>parameter 1-31/07/2018|parameter 2-ABC1234</P>]]>"
 
       //noinspection ScalaStyle
       NotificationDetails.convertEndDateWithRefMessageText(inputString) mustBe Some(EndDateDetails(new LocalDate(2018, 7, 31), Some("ABC1234")))
@@ -136,14 +144,14 @@ class NotificationDetailsSpec extends PlaySpec with MustMatchers {
   "convertEndDateMessageText" must {
     "convert the input message text into the model when there is only a date in the input string" in {
 
-      val inputString = "End Date-31/07/2018"
+      val inputString = "parameter 1-31/07/2018"
 
       //noinspection ScalaStyle
       NotificationDetails.convertEndDateMessageText(inputString) mustBe Some(EndDateDetails(new LocalDate(2018, 7, 31), None))
     }
 
     "convert the input message text into the model when there are special characters in the input string" in {
-      val inputString = "<![CDATA[<P>End Date-20/05/2009</P>]]>"
+      val inputString = "<![CDATA[<P>parameter 1-20/05/2009</P>]]>"
 
       //noinspection ScalaStyle
       NotificationDetails.convertEndDateMessageText(inputString) mustBe Some(EndDateDetails(new LocalDate(2009, 5, 20), None))

--- a/test/models/notifications/NotificationDetailsSpec.scala
+++ b/test/models/notifications/NotificationDetailsSpec.scala
@@ -121,6 +121,7 @@ class NotificationDetailsSpec extends PlaySpec with MustMatchers {
 
       val inputString = "parameter1-31/07/2018|parameter2-ABC1234"
 
+      //noinspection ScalaStyle
       NotificationDetails.convertEndDateWithRefMessageText(inputString) mustBe Some(EndDateDetails(new LocalDate(2018, 7, 31), Some("ABC1234")))
 
     }
@@ -135,9 +136,17 @@ class NotificationDetailsSpec extends PlaySpec with MustMatchers {
   "convertEndDateMessageText" must {
     "convert the input message text into the model when there is only a date in the input string" in {
 
-      val inputString = "parameter1-31/07/2018"
+      val inputString = "End Date-31/07/2018"
 
+      //noinspection ScalaStyle
       NotificationDetails.convertEndDateMessageText(inputString) mustBe Some(EndDateDetails(new LocalDate(2018, 7, 31), None))
+    }
+
+    "convert the input message text into the model when there are special characters in the input string" in {
+      val inputString = "<![CDATA[<P>End Date-20/05/2009</P>]]>"
+
+      //noinspection ScalaStyle
+      NotificationDetails.convertEndDateMessageText(inputString) mustBe Some(EndDateDetails(new LocalDate(2009, 5, 20), None))
     }
 
     "return none when supplied with an invalid string" in {


### PR DESCRIPTION
Fixed this issue by refactoring the code that extracts the end date and reference number from the content, by switching to a regex-based strategy instead of string splitting.