### PR TITLE
AMLS-2950: API 1b Business Name retrieval

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -46,6 +46,8 @@ trait ApplicationConfig {
   def showChangeOfficerLink: Boolean
 
   def sendPostcodeKnownFact: Boolean
+
+  def businessNameLookup: Boolean
 }
 
 object ApplicationConfig extends ApplicationConfig with ServicesConfig {
@@ -106,16 +108,17 @@ object ApplicationConfig extends ApplicationConfig with ServicesConfig {
     value
   }
 
-  override def release7:Boolean = {
+  override def release7: Boolean = {
     val value = getConfBool("feature-toggle.release7", false)
     value
   }
 
-  override def renewalsToggle:Boolean = getConfBool("feature-toggle.renewals", false)
+  override def renewalsToggle: Boolean = getConfBool("feature-toggle.renewals", false)
 
   override def refreshProfileToggle = getConfBool("feature-toggle.refresh-profile", false)
 
   val paymentsUrlLookupToggleName = "feature-toggle.payments-url-lookup"
+
   override def paymentsUrlLookupToggle = getConfBool(paymentsUrlLookupToggleName, false)
 
   override def allowWithdrawalToggle = getConfBool("feature-toggle.allow-withdrawal", false)
@@ -134,5 +137,7 @@ object ApplicationConfig extends ApplicationConfig with ServicesConfig {
 
   override def showChangeOfficerLink = getConfBool("feature-toggle.change-officer", false)
 
-    override def sendPostcodeKnownFact = getConfBool("feature-toggle.gg-knownfacts-postcode", false)
+  override def sendPostcodeKnownFact = getConfBool("feature-toggle.gg-knownfacts-postcode", false)
+
+  override def businessNameLookup = getConfBool("feature-toggle.business-name-lookup", false)
 }

--- a/app/utils/BusinessName.scala
+++ b/app/utils/BusinessName.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import cats.implicits._
+import cats.data.OptionT
+import config.ApplicationConfig
+import connectors.{AmlsConnector, DataCacheConnector}
+import models.businessmatching.BusinessMatching
+import uk.gov.hmrc.play.frontend.auth.AuthContext
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object BusinessName {
+
+  def getNameFromCache(implicit hc: HeaderCarrier, ac: AuthContext, cache: DataCacheConnector, ec: ExecutionContext) =
+    for {
+      bm <- OptionT(cache.fetch[BusinessMatching](BusinessMatching.key))
+      rd <- OptionT.fromOption[Future](bm.reviewDetails)
+    } yield rd.businessName
+
+  def getNameFromAmls(safeId: String)(implicit hc: HeaderCarrier, ac: AuthContext, amls: AmlsConnector, ec: ExecutionContext) =
+    OptionT.liftF(amls.registrationDetails(safeId)) map {_.companyName}
+
+  def getName(safeId: Option[String])(implicit hc: HeaderCarrier, ac: AuthContext, ec: ExecutionContext, cache: DataCacheConnector, amls: AmlsConnector) = {
+    if (ApplicationConfig.businessNameLookup) {
+      safeId.fold(getNameFromCache)(v => getNameFromAmls(v))
+    } else {
+      getNameFromCache
+    }
+  }
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -101,6 +101,7 @@ microservice {
       return-link = true
       change-officer = true
       gg-knownfacts-postcode = false
+      business-name-lookup = true
     }
     amls {
       host = localhost

--- a/test/controllers/StatusControllerSpec.scala
+++ b/test/controllers/StatusControllerSpec.scala
@@ -76,9 +76,14 @@ class StatusControllerSpec extends GenericTestHelper with MockitoSugar with OneA
 
     when(controller.statusService.getDetailedStatus(any(), any(), any()))
       .thenReturn(Future.successful((NotCompleted, None)))
+
+    when {
+      controller.dataCache.fetch[BusinessMatching](eqTo(BusinessMatching.key))(any(), any(), any())
+    } thenReturn Future.successful(Some(BusinessMatching(Some(reviewDetails), None)))
   }
 
   val amlsRegistrationNumber = "XAML00000567890"
+
   val feeResponse = FeeResponse(
     SubscriptionResponseType,
     amlsRegistrationNumber,
@@ -90,6 +95,7 @@ class StatusControllerSpec extends GenericTestHelper with MockitoSugar with OneA
     None,
     new DateTime(2017, 12, 1, 1, 3, DateTimeZone.UTC)
   )
+
   val reviewDetails = ReviewDetails("BusinessName", Some(BusinessType.LimitedCompany),
     Address("line1", "line2", Some("line3"), Some("line4"), Some("AA1 1AA"), Country("United Kingdom", "GB")), "XE0001234567890")
 
@@ -105,9 +111,6 @@ class StatusControllerSpec extends GenericTestHelper with MockitoSugar with OneA
 
       when(controller.enrolmentsService.amlsRegistrationNumber(any(), any(), any()))
         .thenReturn(Future.successful(None))
-
-      when(cacheMap.getEntry[BusinessMatching](Matchers.contains(BusinessMatching.key))(any()))
-        .thenReturn(Some(BusinessMatching(Some(reviewDetails), None)))
 
       val statusResponse = mock[ReadStatusResponse]
       when(statusResponse.safeId) thenReturn Some("X12345678")
@@ -125,7 +128,6 @@ class StatusControllerSpec extends GenericTestHelper with MockitoSugar with OneA
     "show correct content" when {
 
       "application status is NotCompleted" in new Fixture {
-
 
         when(controller.landingService.cacheMap(any(), any(), any()))
           .thenReturn(Future.successful(Some(cacheMap)))
@@ -748,6 +750,10 @@ class StatusControllerWithoutWithdrawalSpec extends GenericTestHelper with OneAp
 
     when(controller.statusService.getDetailedStatus(any(), any(), any()))
       .thenReturn(Future.successful(SubmissionReadyForReview, statusResponse.some))
+
+    when {
+      controller.dataCache.fetch[BusinessMatching](eqTo(BusinessMatching.key))(any(), any(), any())
+    } thenReturn Future.successful(Some(BusinessMatching(Some(reviewDetails), None)))
   }
 
   "The status controller" must {
@@ -803,6 +809,10 @@ class StatusControllerWithoutDeRegisterSpec extends GenericTestHelper with OneAp
 
     when(controller.statusService.getDetailedStatus(any(), any(), any()))
       .thenReturn(Future.successful(SubmissionDecisionApproved, statusResponse.some))
+
+    when {
+      controller.dataCache.fetch[BusinessMatching](eqTo(BusinessMatching.key))(any(), any(), any())
+    } thenReturn Future.successful(Some(BusinessMatching(Some(reviewDetails), None)))
   }
 
   "The status controller" must {
@@ -856,6 +866,9 @@ class StatusControllerWithoutChangeOfficerSpec extends GenericTestHelper with On
     when(controller.enrolmentsService.amlsRegistrationNumber(any(), any(), any()))
       .thenReturn(Future.successful(None))
 
+    when {
+      controller.dataCache.fetch[BusinessMatching](eqTo(BusinessMatching.key))(any(), any(), any())
+    } thenReturn Future.successful(Some(BusinessMatching(Some(reviewDetails), None)))
   }
 
   "The status controller" must {

--- a/test/controllers/StatusControllerWithoutAmendmentsSpec.scala
+++ b/test/controllers/StatusControllerWithoutAmendmentsSpec.scala
@@ -16,26 +16,21 @@
 
 package controllers
 
-import connectors.{AmlsConnector, AmlsNotificationConnector, DataCacheConnector, FeeConnector}
-import models.ResponseType.{AmendOrVariationResponseType, SubscriptionResponseType}
+import connectors.{AmlsConnector, DataCacheConnector, FeeConnector}
 import models.businesscustomer.{Address, ReviewDetails}
 import models.businessmatching.{BusinessMatching, BusinessType}
 import models.status._
-import models.{AmendVariationRenewalResponse, Country, FeeResponse, ReadStatusResponse, SubscriptionResponse}
-import org.joda.time.{DateTime, DateTimeZone, LocalDateTime}
+import models.{Country, FeeResponse}
 import org.jsoup.Jsoup
-import org.mockito.Matchers
-import org.mockito.Matchers._
+import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
-import utils.GenericTestHelper
 import play.api.i18n.Messages
 import play.api.test.FakeApplication
 import play.api.test.Helpers._
 import services._
 import uk.gov.hmrc.http.cache.client.CacheMap
-import uk.gov.hmrc.play.http.NotFoundException
-import utils.AuthorisedFixture
+import utils.{AuthorisedFixture, GenericTestHelper}
 
 import scala.concurrent.Future
 class StatusControllerWithoutAmendmentsSpec extends GenericTestHelper with MockitoSugar {
@@ -68,7 +63,7 @@ class StatusControllerWithoutAmendmentsSpec extends GenericTestHelper with Mocki
       when(controller.landingService.cacheMap(any(), any(), any()))
         .thenReturn(Future.successful(Some(cacheMap)))
 
-      when(cacheMap.getEntry[BusinessMatching](Matchers.contains(BusinessMatching.key))(any()))
+      when(cacheMap.getEntry[BusinessMatching](contains(BusinessMatching.key))(any()))
         .thenReturn(Some(BusinessMatching(Some(reviewDtls), None)))
 
       when(controller.enrolmentsService.amlsRegistrationNumber(any(), any(), any()))
@@ -79,6 +74,10 @@ class StatusControllerWithoutAmendmentsSpec extends GenericTestHelper with Mocki
 
       when(controller.feeConnector.feeResponse(any())(any(), any(), any(), any()))
         .thenReturn(Future.successful(mock[FeeResponse]))
+
+      when {
+        controller.dataCache.fetch[BusinessMatching](eqTo(BusinessMatching.key))(any(), any(), any())
+      } thenReturn Future.successful(Some(BusinessMatching(Some(reviewDtls), None)))
 
       val result = controller.get()(request)
       status(result) must be(OK)

--- a/test/utils/BusinessNameSpec.scala
+++ b/test/utils/BusinessNameSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import connectors.{AmlsConnector, DataCacheConnector}
+import models.registrationdetails.RegistrationDetails
+import org.scalatest.MustMatchers
+import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
+import play.api.inject.guice.GuiceApplicationBuilder
+import org.mockito.Mockito._
+import org.mockito.Matchers.{eq => eqTo, _}
+import cats.implicits._
+import models.businesscustomer.ReviewDetails
+import models.businessmatching.BusinessMatching
+import org.scalatest.concurrent.ScalaFutures
+import uk.gov.hmrc.play.frontend.auth.AuthContext
+import uk.gov.hmrc.play.http.HeaderCarrier
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class BusinessNameSpec extends PlaySpec with MustMatchers with OneAppPerSuite with MockitoSugar with ScalaFutures {
+
+  override implicit lazy val app = new GuiceApplicationBuilder()
+    .configure("microservice.services.feature-toggle.business-name-lookup" -> true)
+    .build()
+
+  trait Fixture {
+    implicit val amlsConnector = mock[AmlsConnector]
+    implicit val cacheConnector = mock[DataCacheConnector]
+    implicit val headerCarrier = HeaderCarrier()
+    implicit val authContext = mock[AuthContext]
+
+    val safeId = "X87FUDIKJJKJH87364"
+  }
+
+  "The BusinessName helper utility" must {
+    "get the business name from amls" in new Fixture {
+      when {
+        amlsConnector.registrationDetails(eqTo(safeId))(any(), any())
+      } thenReturn Future.successful(RegistrationDetails("Test Business", isIndividual = false))
+
+      whenReady(BusinessName.getName(safeId.some).value) { result =>
+        result mustBe "Test Business".some
+      }
+    }
+
+    "get the name from the data cache" when {
+      "the safeId is not available" in new Fixture {
+
+        val reviewDetails = mock[ReviewDetails]
+        when(reviewDetails.businessName) thenReturn "Test Business from the cache"
+
+        when {
+          cacheConnector.fetch[BusinessMatching](eqTo(BusinessMatching.key))(any(), any(), any())
+        } thenReturn Future.successful(BusinessMatching(reviewDetails = reviewDetails.some).some)
+
+        whenReady(BusinessName.getName(None).value) { result =>
+          result mustBe "Test Business from the cache".some
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Added a feature toggle around contacting API 1b, defaulted to 'off'
* Refactored the code that retrieves the business name either from API 1b or from the data cache into a helper, and applied to `NotificationController`
* Refactored the status controller to also use this new helper + associated tests