### PR TITLE
AMLS-2979: API 11 Special characters

### DIFF
--- a/app/models/notifications/NotificationDetails.scala
+++ b/app/models/notifications/NotificationDetails.scala
@@ -66,12 +66,12 @@ object NotificationDetails {
     input => LocalDate.parse(input, DateTimeFormat.forPattern("dd/MM/yyyy"))
 
   private val extractEndDate: String => Option[LocalDate] = input => {
-    val pattern = """(?i)[\w\s]+-(\d{1,2}/\d{1,2}/\d{4})""".r.unanchored
+    val pattern = """(?i)[\w\s]+\s*-\s*(\d{1,2}/\d{1,2}/\d{4})""".r.unanchored
     pattern.findFirstMatchIn(input).fold(none[LocalDate])(m => parseDate(m.group(1)).some)
   }
 
   private val extractReference: String => Option[String] = input => {
-    val pattern = """(?i)[\w\s]+-([a-z][a-z0-9]+)""".r.unanchored
+    val pattern = """(?i)[\w\s]+\s*-\s*([a-z][a-z0-9]+)""".r.unanchored
     pattern.findFirstMatchIn(input).fold(none[String])(m => m.group(1).some)
   }
 

--- a/test/models/notifications/NotificationDetailsSpec.scala
+++ b/test/models/notifications/NotificationDetailsSpec.scala
@@ -119,7 +119,7 @@ class NotificationDetailsSpec extends PlaySpec with MustMatchers {
   "convertEndDateWithRefMessageText" must {
     "convert the input message text into the model when there is both a date and a red in the input string" in {
 
-      val inputString = "parameter 1-31/07/2018|parameter 2-ABC1234"
+      val inputString = "parameter 1-31/07/2018|parameter 2- ABC1234"
 
       //noinspection ScalaStyle
       NotificationDetails.convertEndDateWithRefMessageText(inputString) mustBe Some(EndDateDetails(new LocalDate(2018, 7, 31), Some("ABC1234")))
@@ -127,7 +127,7 @@ class NotificationDetailsSpec extends PlaySpec with MustMatchers {
     }
 
     "convert the input message text into the model when there are special characters in the input string" in {
-      val inputString = "<![CDATA[<P>parameter 1-31/07/2018|parameter 2-ABC1234</P>]]>"
+      val inputString = "<![CDATA[<P>parameter 1- 31/07/2018|parameter 2-ABC1234</P>]]>"
 
       //noinspection ScalaStyle
       NotificationDetails.convertEndDateWithRefMessageText(inputString) mustBe Some(EndDateDetails(new LocalDate(2018, 7, 31), Some("ABC1234")))


### PR DESCRIPTION
This fixes an issue where responses to `getMessageDetails` calls are returning whitespace around the hyphens between special fields in the response. This PR adds in the capability to take this whitespace into account when extracting dates and reference numbers.