### PR TITLE
Payment submission fix

### DIFF
--- a/app/controllers/payments/WaysToPayController.scala
+++ b/app/controllers/payments/WaysToPayController.scala
@@ -55,10 +55,10 @@ class WaysToPayController @Inject()(
     implicit authContext => implicit request =>
         val submissionDetails = for {
           amlsRefNo <- amlsRefBroker.get
-          (status, detailedStatus) <- OptionT.liftF(statusService.getDetailedStatus)
+          (status, detailedStatus) <- OptionT.liftF(statusService.getDetailedStatus(amlsRefNo))
           data@(paymentReference, _, _, e) <- OptionT(submissionResponseService.getSubmissionData(status))
           payRef <- OptionT.fromOption[Future](paymentReference)
-        } yield (amlsRefNo, payRef, data, detailedStatus.fold[String]("")(_.safeId.getOrElse("")))
+        } yield (amlsRefNo, payRef, data, detailedStatus.fold[String](throw new Exception("No safeID available"))(_.safeId.getOrElse(throw new Exception("No safeID available"))))
 
         Form2[WaysToPay](request.body) match {
           case ValidForm(_, data) => data match {

--- a/app/services/SubmissionResponseService.scala
+++ b/app/services/SubmissionResponseService.scala
@@ -72,7 +72,7 @@ trait SubmissionResponseService extends FeeCalculations with DataCacheService {
    ac: AuthContext
   ): Future[Option[SubmissionData]] = {
     cacheConnector.fetchAll flatMap {
-      getDataForAmendment(_) getOrElse Future.failed(new Exception("Cannot get amendment response"))
+      getDataForAmendment(_) getOrElse OptionT.liftF(getSubscription).value// Future.failed(new Exception("Cannot get amendment response"))
     }
   }
 

--- a/app/services/SubmissionResponseService.scala
+++ b/app/services/SubmissionResponseService.scala
@@ -72,7 +72,7 @@ trait SubmissionResponseService extends FeeCalculations with DataCacheService {
    ac: AuthContext
   ): Future[Option[SubmissionData]] = {
     cacheConnector.fetchAll flatMap {
-      getDataForAmendment(_) getOrElse OptionT.liftF(getSubscription).value// Future.failed(new Exception("Cannot get amendment response"))
+      getDataForAmendment(_) getOrElse OptionT.liftF(getSubscription).value
     }
   }
 

--- a/test/controllers/payments/WaysToPayControllerSpec.scala
+++ b/test/controllers/payments/WaysToPayControllerSpec.scala
@@ -95,7 +95,7 @@ class WaysToPayControllerSpec extends PlaySpec with MockitoSugar with GenericTes
     } thenReturn Future.successful(paymentGen.sample.get)
 
     when {
-      controller.statusService.getDetailedStatus(any(), any(), any())
+      controller.statusService.getDetailedStatus(any())(any(), any(), any())
     } thenReturn Future.successful((submissionStatus, Some(readStatusResponse)))
 
     when {

--- a/test/services/SubmissionResponseServiceSpec.scala
+++ b/test/services/SubmissionResponseServiceSpec.scala
@@ -393,6 +393,30 @@ class SubmissionResponseServiceSpec extends PlaySpec
 
         }
       }
+
+      "fall back to getting the subcription response, if the amendment response isn't available" in new Fixture {
+        when {
+          cache.getEntry[AmendVariationRenewalResponse](eqTo(AmendVariationRenewalResponse.key))(any())
+        } thenReturn None
+
+        when {
+          cache.getEntry[SubscriptionResponse](eqTo(SubscriptionResponse.key))(any())
+        } thenReturn Some(subscriptionResponse)
+
+        when {
+          cache.getEntry[Seq[TradingPremises]](eqTo(TradingPremises.key))(any())
+        } thenReturn Some(Seq(TradingPremises()))
+
+        when {
+          cache.getEntry[Seq[ResponsiblePeople]](eqTo(ResponsiblePeople.key))(any())
+        } thenReturn Some(Seq(ResponsiblePeople()))
+
+        val result = await(TestSubmissionResponseService.getAmendment)
+
+        result mustBe defined
+
+        verify(cache).getEntry[SubscriptionResponse](eqTo(SubscriptionResponse.key))(any())
+      }
     }
 
     "getVariation is called" must {


### PR DESCRIPTION
The main change here was to:

* Continue to send the AMLS ref number through to the getDetailedStatus call
* `getAmendment` now falls back to `getSubmission` if there was no amendment data