### PR TITLE
AMLS-3015: Refactored redirect targets for record transactions yes/no

### DIFF
--- a/app/controllers/businessactivities/TransactionRecordController.scala
+++ b/app/controllers/businessactivities/TransactionRecordController.scala
@@ -60,9 +60,10 @@ class TransactionRecordController @Inject()
             businessActivity <- dataCacheConnector.fetch[BusinessActivities](BusinessActivities.key)
             _ <- dataCacheConnector.save[BusinessActivities](BusinessActivities.key, businessActivity.transactionRecord(data))
           } yield (edit, data) match {
-            case (_, true) => Redirect(routes.TransactionTypesController.get(edit))
-            case (true, false) => Redirect(routes.SummaryController.get())
-            case (false, _) => Redirect(routes.IdentifySuspiciousActivityController.get())
+            case (false, true) => Redirect(routes.TransactionTypesController.get())
+            case (false, false) => Redirect(routes.IdentifySuspiciousActivityController.get())
+            case (true, true) if businessActivity.transactionRecordTypes.isEmpty => Redirect(routes.TransactionTypesController.get(edit))
+            case _ => Redirect(routes.SummaryController.get())
           }
         }
       }

--- a/test/controllers/businessactivities/TransactionRecordControllerSpec.scala
+++ b/test/controllers/businessactivities/TransactionRecordControllerSpec.scala
@@ -121,6 +121,21 @@ class TransactionRecordControllerSpec extends GenericTestHelper with MockitoSuga
           status(result) must be(SEE_OTHER)
           redirectLocation(result) must be(Some(routes.TransactionTypesController.get(edit = true).url))
         }
+
+        "given valid data in edit mode, 'yes' is selected and the next question has already been asked" in new Fixture {
+          val newRequest = request.withFormUrlEncodedBody(
+            "isRecorded" -> "true"
+          )
+
+          mockCacheFetch(Some(BusinessActivities(
+            transactionRecord = Some(true),
+            transactionRecordTypes = Some(TransactionTypes(Set(Paper)))
+          )))
+
+          val result = controller.post(true)(newRequest)
+          status(result) mustBe SEE_OTHER
+          redirectLocation(result) mustBe Some(routes.SummaryController.get.url)
+        }
       }
 
       "reset the transaction types if 'no' is selected" in new Fixture {


### PR DESCRIPTION
Primary change was to *not* ask how the user records transactions, if they're editing the 'Do you record transactions...' question, selected 'yes' and have already answered the following question.