### PR TITLE
AMLS-2981: Fixed 'back to registration progress' link on several pages

### DIFF
--- a/app/controllers/businessmatching/BusinessAppliedForPSRNumberController.scala
+++ b/app/controllers/businessmatching/BusinessAppliedForPSRNumberController.scala
@@ -37,12 +37,13 @@ trait BusinessAppliedForPSRNumberController extends BaseController {
   def get(edit: Boolean = false) = Authorised.async {
     implicit authContext => implicit request =>
       businessMatchingService.getModel.value map {
-        response =>
+        maybeBM =>
           val form: Form2[BusinessAppliedForPSRNumber] = (for {
-            bm <- response
+            bm <- maybeBM
             number <- bm.businessAppliedForPSRNumber
           } yield Form2[BusinessAppliedForPSRNumber](number)).getOrElse(EmptyForm)
-          Ok(business_applied_for_psr_number(form, edit))
+
+          Ok(business_applied_for_psr_number(form, edit, maybeBM.fold(false)(_.hasAccepted)))
       }
   }
 

--- a/app/controllers/businessmatching/CompanyRegistrationNumberController.scala
+++ b/app/controllers/businessmatching/CompanyRegistrationNumberController.scala
@@ -38,7 +38,8 @@ trait CompanyRegistrationNumberController extends BaseController {
             businessMatching <- response
             registrationNumber <- businessMatching.companyRegistrationNumber
           } yield Form2[CompanyRegistrationNumber](registrationNumber)).getOrElse(EmptyForm)
-          Ok(company_registration_number(form, edit))
+
+          Ok(company_registration_number(form, edit, response.fold(false)(_.hasAccepted)))
       }
   }
 

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -47,10 +47,11 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
             } yield {
               val form = Form2[BusinessActivities](businessActivities)
               val (newActivities, existing) = getActivityValues(form, isPreSubmission, Some(businessActivities.businessActivities))
-              Ok(register_services(form, edit, newActivities, existing, isPreSubmission))
+
+              Ok(register_services(form, edit, newActivities, existing, isPreSubmission, businessMatching.hasAccepted))
             }) getOrElse {
               val (newActivities, existing) = getActivityValues(EmptyForm, isPreSubmission, None)
-              Ok(register_services(EmptyForm, edit, newActivities, existing, isPreSubmission))
+              Ok(register_services(EmptyForm, edit, newActivities, existing, isPreSubmission, false))
             }
           }
         }

--- a/app/controllers/businessmatching/ServicesController.scala
+++ b/app/controllers/businessmatching/ServicesController.scala
@@ -40,17 +40,14 @@ trait ServicesController extends BaseController {
   def businessMatchingService: BusinessMatchingService
 
   def get(edit: Boolean = false) = Authorised.async {
-    implicit authContext =>
-      implicit request =>
-        businessMatchingService.getModel.value map {
-          maybeBM =>
-            val form = (for {
-              bm <- maybeBM
-              services <- bm.msbServices
-            } yield Form2[MsbServices](services)).getOrElse(EmptyForm)
-
-            Ok(views.html.businessmatching.services(form, edit, maybeBM.fold(false)(_.hasAccepted)))
-        }
+    implicit authContext => implicit request =>
+      (for {
+        preApplicationComplete <- OptionT.liftF(businessMatchingService.preApplicationComplete)
+        bm <- businessMatchingService.getModel
+      } yield {
+        val form = bm.msbServices.fold[Form2[MsbServices]](EmptyForm){s => Form2(s)}
+        Ok(views.html.businessmatching.services(form, edit, preApplicationComplete))
+      }) getOrElse Ok(views.html.businessmatching.services(EmptyForm, edit, showReturnLink = false))
   }
 
   def post(edit: Boolean = false) = Authorised.async {

--- a/app/controllers/businessmatching/ServicesController.scala
+++ b/app/controllers/businessmatching/ServicesController.scala
@@ -43,13 +43,13 @@ trait ServicesController extends BaseController {
     implicit authContext =>
       implicit request =>
         businessMatchingService.getModel.value map {
-          response =>
+          maybeBM =>
             val form = (for {
-              bm <- response
+              bm <- maybeBM
               services <- bm.msbServices
             } yield Form2[MsbServices](services)).getOrElse(EmptyForm)
 
-            Ok(views.html.businessmatching.services(form, edit))
+            Ok(views.html.businessmatching.services(form, edit, maybeBM.fold(false)(_.hasAccepted)))
         }
   }
 

--- a/app/controllers/businessmatching/ServicesController.scala
+++ b/app/controllers/businessmatching/ServicesController.scala
@@ -41,13 +41,14 @@ trait ServicesController extends BaseController {
 
   def get(edit: Boolean = false) = Authorised.async {
     implicit authContext => implicit request =>
-      (for {
-        preApplicationComplete <- OptionT.liftF(businessMatchingService.preApplicationComplete)
-        bm <- businessMatchingService.getModel
-      } yield {
-        val form = bm.msbServices.fold[Form2[MsbServices]](EmptyForm){s => Form2(s)}
-        Ok(views.html.businessmatching.services(form, edit, preApplicationComplete))
-      }) getOrElse Ok(views.html.businessmatching.services(EmptyForm, edit, showReturnLink = false))
+      businessMatchingService.preApplicationComplete flatMap { preApplicationComplete =>
+        (for {
+          bm <- businessMatchingService.getModel
+        } yield {
+          val form = bm.msbServices.fold[Form2[MsbServices]](EmptyForm) { s => Form2(s) }
+          Ok(views.html.businessmatching.services(form, edit, preApplicationComplete))
+        }) getOrElse Ok(views.html.businessmatching.services(EmptyForm, edit, showReturnLink = preApplicationComplete))
+      }
   }
 
   def post(edit: Boolean = false) = Authorised.async {

--- a/app/controllers/businessmatching/SummaryController.scala
+++ b/app/controllers/businessmatching/SummaryController.scala
@@ -52,6 +52,7 @@ trait SummaryController extends BaseController {
               ba.businessActivities ++ ba.additionalActivities.fold[Set[BusinessActivity]](Set.empty)(act => act)
             ))
           )
+
           Ok(summary(EmptyForm, bmWithAdditionalActivities, isPreSubmission(status) || ApplicationConfig.businessMatchingVariationToggle))
         }
 

--- a/app/services/businessmatching/BusinessMatchingService.scala
+++ b/app/services/businessmatching/BusinessMatchingService.scala
@@ -38,6 +38,9 @@ class BusinessMatchingService @Inject()(
                                          dataCacheConnector: DataCacheConnector
                                        ) {
 
+  def preApplicationComplete(implicit ac: AuthContext, hc: HeaderCarrier, ex: ExecutionContext): Future[Boolean] =
+    OptionT(dataCacheConnector.fetch[BusinessMatching](BusinessMatching.key)) map (_.isComplete) getOrElse false
+
   def getModel(implicit ac:AuthContext, hc: HeaderCarrier, ec: ExecutionContext): OptionT[Future, BusinessMatching] = {
     lazy val originalModel = OptionT(dataCacheConnector.fetch[BusinessMatching](BusinessMatching.key))
     lazy val variationModel = OptionT(dataCacheConnector.fetch[BusinessMatching](BusinessMatching.variationKey))

--- a/app/views/businessmatching/business_applied_for_psr_number.scala.html
+++ b/app/views/businessmatching/business_applied_for_psr_number.scala.html
@@ -18,7 +18,7 @@
 @import forms2._
 @import utils.HtmlElementHelpers._
 
-@(f: forms.Form2[_], edit: Boolean)(implicit request: Request[_],m:Messages)
+@(f: forms.Form2[_], edit: Boolean, showReturnLink: Boolean = true)(implicit request: Request[_],m:Messages)
 
 @target = @{
     s"""${f("regNumber").id}-panel"""
@@ -80,6 +80,6 @@
             )
         }
 
-        @submit(edit, returnLink = false)
+        @submit(edit, returnLink = showReturnLink)
    }
 }

--- a/app/views/businessmatching/company_registration_number.scala.html
+++ b/app/views/businessmatching/company_registration_number.scala.html
@@ -19,7 +19,7 @@
 @import include.forms2._
 @import models.aboutthebusiness._
 
-@(f: Form2[_], edit: Boolean)(implicit request: Request[_],m:Messages, lang: Lang)
+@(f: Form2[_], edit: Boolean, showReturnLink: Boolean = true)(implicit request: Request[_],m:Messages, lang: Lang)
 
 @header = {
     @errorSummary(f)
@@ -45,6 +45,6 @@
                 labelText = "businessmatching.registrationnumber.lbl"
             )
 
-        @submit(edit,returnLink = false)
+        @submit(edit, returnLink = showReturnLink)
     }
 }

--- a/app/views/businessmatching/register_services.scala.html
+++ b/app/views/businessmatching/register_services.scala.html
@@ -19,7 +19,7 @@
 @import include.forms2._
 @import config.ApplicationConfig
 
-@(f: Form2[_], edit: Boolean, newActivities: Set[String], existing: Set[String], isPreSubmission: Boolean)(implicit request: Request[_],m:Messages, lang: Lang)
+@(f: Form2[_], edit: Boolean, newActivities: Set[String], existing: Set[String], isPreSubmission: Boolean, showReturnLink: Boolean = true)(implicit request: Request[_],m:Messages, lang: Lang)
 
 @header = { @isPreSubmission match {
     case true => {
@@ -100,7 +100,7 @@
             }
         }
 
-        @submit(edit, returnLink = !isPreSubmission)
+        @submit(edit, returnLink = showReturnLink)
 
     }
 

--- a/app/views/businessmatching/services.scala.html
+++ b/app/views/businessmatching/services.scala.html
@@ -18,7 +18,7 @@
 @import include._
 @import include.forms2._
 
-@(f: Form2[_], edit: Boolean)(implicit request: Request[_],m:Messages)
+@(f: Form2[_], edit: Boolean, showReturnLink: Boolean = true)(implicit request: Request[_],m:Messages)
 
 @header = {
     @errorSummary(f)
@@ -68,7 +68,7 @@
             }
       }
 
-      @submit(edit, returnLink = false)
+      @submit(edit, returnLink = showReturnLink)
 
     }
 }

--- a/app/views/businessmatching/updateservice/change_services.scala.html
+++ b/app/views/businessmatching/updateservice/change_services.scala.html
@@ -18,7 +18,7 @@
 @import forms2._
 @import utils.HtmlElementHelpers._
 
-@(f: forms.Form2[_], existing: Set[String])(implicit request: Request[_], m:Messages)
+@(f: forms.Form2[_], existing: Set[String], showReturnLink: Boolean = true)(implicit request: Request[_], m:Messages)
 
 @header = {
     @errorSummary(f)
@@ -71,7 +71,7 @@
         }
 
 
-       @submit(buttonMessageKey = Some("button.continue"))
+       @submit(buttonMessageKey = Some("button.continue"), returnLink = showReturnLink)
 
     }
 

--- a/app/views/businessmatching/updateservice/change_services.scala.html
+++ b/app/views/businessmatching/updateservice/change_services.scala.html
@@ -71,7 +71,7 @@
         }
 
 
-       @submit(buttonMessageKey = Some("button.continue"), returnLink = false)
+       @submit(buttonMessageKey = Some("button.continue"))
 
     }
 

--- a/app/views/businessmatching/updateservice/remove_activities.scala.html
+++ b/app/views/businessmatching/updateservice/remove_activities.scala.html
@@ -56,7 +56,7 @@
             }
         </div>
 
-        @submit(returnLink = false)
+        @submit()
 
     }
 

--- a/test/controllers/businessmatching/BusinessAppliedForPSRNumberControllerSpec.scala
+++ b/test/controllers/businessmatching/BusinessAppliedForPSRNumberControllerSpec.scala
@@ -60,6 +60,9 @@ class BusinessAppliedForPSRNumberControllerSpec extends GenericTestHelper
       controller.businessMatchingService.updateModel(any())(any(), any(), any())
     } thenReturn OptionT.some[Future, CacheMap](mockCacheMap)
 
+    when {
+      controller.businessMatchingService.preApplicationComplete(any(), any(), any())
+    } thenReturn Future.successful(false)
   }
 
   val emptyCache = CacheMap("", Map.empty)

--- a/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
@@ -85,6 +85,10 @@ class RegisterServicesControllerSpec extends GenericTestHelper with MockitoSugar
       controller.businessMatchingService.updateModel(any())(any(),any(),any())
     } thenReturn OptionT.some[Future, CacheMap](mockCacheMap)
 
+    when {
+      controller.businessMatchingService.preApplicationComplete(any(), any(), any())
+    } thenReturn Future.successful(false)
+
   }
 
   "RegisterServicesController" when {

--- a/test/controllers/businessmatching/ServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/ServicesControllerSpec.scala
@@ -61,6 +61,10 @@ class ServicesControllerSpec extends GenericTestHelper with ScalaFutures with Mo
       controller.businessMatchingService.updateModel(any())(any(), any(), any())
     } thenReturn cacheMapT
 
+    when {
+      controller.businessMatchingService.preApplicationComplete(any(), any(), any())
+    } thenReturn Future.successful(false)
+
     def setupModel(model: Option[BusinessMatching]) = when {
       controller.businessMatchingService.getModel(any(), any(), any())
     } thenReturn (model match {

--- a/test/controllers/businessmatching/updateservice/ChangeServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/updateservice/ChangeServicesControllerSpec.scala
@@ -39,14 +39,18 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 class ChangeServicesControllerSpec extends GenericTestHelper with MockitoSugar {
 
-  trait Fixture extends AuthorisedFixture with DependencyMocks { self =>
+  trait Fixture extends AuthorisedFixture with DependencyMocks {
+    self =>
 
     val request = addToken(authRequest)
+
+    val bmService = mock[BusinessMatchingService]
 
     lazy val app = new GuiceApplicationBuilder()
       .disable[com.kenshoo.play.metrics.PlayModule]
       .overrides(bind[DataCacheConnector].to(mockCacheConnector))
       .overrides(bind[AuthConnector].to(self.authConnector))
+      .overrides(bind[BusinessMatchingService].to(bmService))
       .build()
 
     val controller = app.injector.instanceOf[ChangeServicesController]
@@ -57,6 +61,10 @@ class ChangeServicesControllerSpec extends GenericTestHelper with MockitoSugar {
     val bmEmpty = Some(BusinessMatching())
 
     mockCacheGetEntry[BusinessMatching](Some(bm), BusinessMatching.key)
+
+    when {
+      bmService.preApplicationComplete(any(), any(), any())
+    } thenReturn Future.successful(false)
 
   }
 
@@ -118,7 +126,7 @@ class ChangeServicesControllerSpec extends GenericTestHelper with MockitoSugar {
       }
 
       "redirect to RemoveActivitiesInformationController" when {
-        "there is a single service" in new Fixture{
+        "there is a single service" in new Fixture {
 
           mockCacheGetEntry[BusinessMatching](
             Some(BusinessMatching(activities = Some(BusinessActivities(Set(MoneyServiceBusiness))))),

--- a/test/views/businessmatching/business_applied_for_psr_numberSpec.scala
+++ b/test/views/businessmatching/business_applied_for_psr_numberSpec.scala
@@ -38,7 +38,7 @@ class business_applied_for_psr_numberSpec extends GenericTestHelper with MustMat
 
       val form2: ValidForm[BusinessAppliedForPSRNumber] = Form2(BusinessAppliedForPSRNumberYes("1234"))
 
-      def view = views.html.businessmatching.business_applied_for_psr_number(form2, true)
+      def view = views.html.businessmatching.business_applied_for_psr_number(form2, edit = true)
 
       doc.title must startWith(Messages("businessmatching.psr.number.title") + " - " + Messages("summary.businessmatching"))
       heading.html must be(Messages("businessmatching.psr.number.title"))
@@ -54,7 +54,7 @@ class business_applied_for_psr_numberSpec extends GenericTestHelper with MustMat
           (Path \ "regNumber-panel") -> Seq(ValidationError("second not a message Key"))
         ))
 
-      def view = views.html.businessmatching.business_applied_for_psr_number(form2, true)
+      def view = views.html.businessmatching.business_applied_for_psr_number(form2, edit = true)
 
       errorSummary.html() must include("not a message Key")
       errorSummary.html() must include("second not a message Key")
@@ -66,11 +66,12 @@ class business_applied_for_psr_numberSpec extends GenericTestHelper with MustMat
         .getElementsByClass("error-notification").first().html() must include("second not a message Key")
 
     }
+
     "hide the return to progress link"in new ViewFixture {
       val form2: ValidForm[BusinessAppliedForPSRNumber] = Form2(BusinessAppliedForPSRNumberYes("1234"))
 
-      def view = views.html.businessmatching.business_applied_for_psr_number(form2, true)
-      doc.body().text() must not include (Messages("link.return.registration.progress"))
+      def view = views.html.businessmatching.business_applied_for_psr_number(form2, edit = true, showReturnLink = false)
+      doc.body().text() must not include Messages("link.return.registration.progress")
     }
   }
 }

--- a/test/views/businessmatching/company_registration_numberSpec.scala
+++ b/test/views/businessmatching/company_registration_numberSpec.scala
@@ -37,7 +37,7 @@ class company_registration_numberSpec extends GenericTestHelper with MustMatcher
 
       val form2: ValidForm[CompanyRegistrationNumber] = Form2(CompanyRegistrationNumber("12345678"))
 
-      def view = views.html.businessmatching.company_registration_number(form2, true)
+      def view = views.html.businessmatching.company_registration_number(form2, edit = true)
 
       doc.title must startWith(Messages("businessmatching.registrationnumber.title") + " - " + Messages("summary.businessmatching"))
       heading.html must be(Messages("businessmatching.registrationnumber.title"))
@@ -52,7 +52,7 @@ class company_registration_numberSpec extends GenericTestHelper with MustMatcher
           (Path \ "companyRegistrationNumber") -> Seq(ValidationError("not a message Key"))
         ))
 
-      def view = views.html.businessmatching.company_registration_number(form2, true)
+      def view = views.html.businessmatching.company_registration_number(form2, edit = true)
 
       errorSummary.html() must include("not a message Key")
 
@@ -61,12 +61,13 @@ class company_registration_numberSpec extends GenericTestHelper with MustMatcher
         .getElementsByClass("error-notification").first().html() must include("not a message Key")
 
     }
-    "hide the return to progress link"in new ViewFixture {
+
+    "hide the return to progress link when requested" in new ViewFixture {
       val form2: ValidForm[CompanyRegistrationNumber] = Form2(CompanyRegistrationNumber("12345678"))
 
-      def view = views.html.businessmatching.company_registration_number(form2, true)
-      doc.body().text() must not include(Messages("link.return.registration.progress"))
+      def view = views.html.businessmatching.company_registration_number(form2, edit = true, showReturnLink = false)
 
+      doc.body().text() must not include Messages("link.return.registration.progress")
     }
   }
 }

--- a/test/views/businessmatching/register_servicesSpec.scala
+++ b/test/views/businessmatching/register_servicesSpec.scala
@@ -36,7 +36,7 @@ class register_servicesSpec extends GenericTestHelper with MustMatchers  {
 
         val form2: ValidForm[BusinessActivities] = Form2(BusinessActivities(Set(AccountancyServices)))
 
-        def view = views.html.businessmatching.register_services(form2, true, Set("01"), Set.empty, true)
+        def view = views.html.businessmatching.register_services(form2, edit = true, Set("01"), Set.empty, isPreSubmission = true)
 
         doc.title must startWith(Messages("businessmatching.registerservices.title") + " - " + Messages("summary.businessmatching"))
         heading.html must be(Messages("businessmatching.registerservices.title"))
@@ -47,7 +47,7 @@ class register_servicesSpec extends GenericTestHelper with MustMatchers  {
 
         val form2: ValidForm[BusinessActivities] = Form2(BusinessActivities(Set(AccountancyServices)))
 
-        def view = views.html.businessmatching.register_services(form2, true, Set("01"), Set.empty, false)
+        def view = views.html.businessmatching.register_services(form2, edit = true, Set("01"), Set.empty, isPreSubmission = false)
 
         doc.title must startWith(Messages("businessmatching.registerservices.other.title") + " - " + Messages("summary.businessmatching"))
         heading.html must be(Messages("businessmatching.registerservices.other.title"))
@@ -59,7 +59,7 @@ class register_servicesSpec extends GenericTestHelper with MustMatchers  {
     "notify of services already selected" when {
       "status is post submission" in new ViewFixture {
 
-        def view = views.html.businessmatching.register_services(EmptyForm, true, Set("01"), Set.empty, false)
+        def view = views.html.businessmatching.register_services(EmptyForm, edit = true, Set("01"), Set.empty, isPreSubmission = false)
 
         html must include(Messages("businessmatching.registerservices.existing"))
 
@@ -73,7 +73,7 @@ class register_servicesSpec extends GenericTestHelper with MustMatchers  {
           (Path \ "businessActivities") -> Seq(ValidationError("not a message Key"))
         ))
 
-      def view = views.html.businessmatching.register_services(form2, true, Set("01"), Set.empty, true)
+      def view = views.html.businessmatching.register_services(form2, edit = true, Set("01"), Set.empty, isPreSubmission = true)
 
       errorSummary.html() must include("not a message Key")
 
@@ -82,9 +82,9 @@ class register_servicesSpec extends GenericTestHelper with MustMatchers  {
 
     }
     "hide the return to progress link" in new ViewFixture {
-      def view = views.html.businessmatching.register_services(EmptyForm, true, Set("01"), Set.empty, true)
+      def view = views.html.businessmatching.register_services(EmptyForm, edit = true, Set("01"), Set.empty, isPreSubmission = true, showReturnLink = false)
 
-      doc.body().text() must not include (Messages("link.return.registration.progress"))
+      doc.body().text() must not include Messages("link.return.registration.progress")
     }
   }
 }

--- a/test/views/businessmatching/servicesSpec.scala
+++ b/test/views/businessmatching/servicesSpec.scala
@@ -37,7 +37,7 @@ class servicesSpec extends GenericTestHelper with MustMatchers  {
 
       val form2: ValidForm[MsbServices] = Form2(MsbServices(Set(TransmittingMoney)))
 
-      def view = views.html.businessmatching.services(form2, true)
+      def view = views.html.businessmatching.services(form2, edit = true)
 
       doc.title must startWith(Messages("msb.services.title") + " - " + Messages("summary.businessmatching"))
       heading.html must be(Messages("msb.services.title"))
@@ -52,7 +52,7 @@ class servicesSpec extends GenericTestHelper with MustMatchers  {
           (Path \ "msbServices") -> Seq(ValidationError("not a message Key"))
         ))
 
-      def view = views.html.businessmatching.services(form2, true)
+      def view = views.html.businessmatching.services(form2, edit = true)
 
       errorSummary.html() must include("not a message Key")
 
@@ -63,8 +63,8 @@ class servicesSpec extends GenericTestHelper with MustMatchers  {
     "hide the return to progress link"in new ViewFixture {
       val form2: ValidForm[MsbServices] = Form2(MsbServices(Set(TransmittingMoney)))
 
-      def view = views.html.businessmatching.services(form2, true)
-      doc.body().text() must not include (Messages("link.return.registration.progress"))
+      def view = views.html.businessmatching.services(form2, edit = true, showReturnLink = false)
+      doc.body().text() must not include Messages("link.return.registration.progress")
     }
   }
 }

--- a/test/views/businessmatching/updateservice/change_servicesSpec.scala
+++ b/test/views/businessmatching/updateservice/change_servicesSpec.scala
@@ -56,5 +56,11 @@ class change_servicesSpec extends GenericTestHelper with MustMatchers  {
       doc.getElementById("changeServices")
         .getElementsByClass("error-notification").first().html() must include("not a message Key")
     }
+
+    "not show the return link when specified" in new ViewFixture {
+      def view = views.html.businessmatching.updateservice.change_services(EmptyForm,Set.empty[String])
+
+      doc.body().text() must not include Messages("link.return.registration.progress")
+    }
   }
 }


### PR DESCRIPTION
Tended to be broken when going through the 'new service variation' flow as opposed to coming in through business matching as a new user.