### PR TITLE
AMLS-2981: Added new 'preAppComplete' flag to Business Matching

### DIFF
--- a/app/controllers/businessmatching/BusinessAppliedForPSRNumberController.scala
+++ b/app/controllers/businessmatching/BusinessAppliedForPSRNumberController.scala
@@ -37,14 +37,12 @@ trait BusinessAppliedForPSRNumberController extends BaseController {
   def get(edit: Boolean = false) = Authorised.async {
     implicit authContext =>
       implicit request =>
-        businessMatchingService.preApplicationComplete flatMap { preApplicationComplete =>
-          (businessMatchingService.getModel map { bm =>
-            val form: Form2[BusinessAppliedForPSRNumber] = (for {
-              number <- bm.businessAppliedForPSRNumber
-            } yield Form2[BusinessAppliedForPSRNumber](number)).getOrElse(EmptyForm)
-
-            Ok(business_applied_for_psr_number(form, edit, preApplicationComplete))
-          }) getOrElse Ok(business_applied_for_psr_number(EmptyForm, edit, preApplicationComplete))
+        businessMatchingService.getModel.value map { maybeBm =>
+          val form: Form2[BusinessAppliedForPSRNumber] = (for {
+            bm <- maybeBm
+            number <- bm.businessAppliedForPSRNumber
+          } yield Form2[BusinessAppliedForPSRNumber](number)).getOrElse(EmptyForm)
+          Ok(business_applied_for_psr_number(form, edit, maybeBm.fold(false)(_.preAppComplete)))
         }
   }
 

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -41,14 +41,13 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
       implicit request =>
         statusService.isPreSubmission flatMap { isPreSubmission =>
           (for {
-            isComplete <- OptionT.liftF(businessMatchingService.preApplicationComplete)
             businessMatching <- businessMatchingService.getModel
             businessActivities <- OptionT.fromOption[Future](businessMatching.activities)
           } yield {
             val form = Form2[BusinessActivities](businessActivities)
             val (newActivities, existing) = getActivityValues(form, isPreSubmission, Some(businessActivities.businessActivities))
 
-            Ok(register_services(form, edit, newActivities, existing, isPreSubmission, isComplete))
+            Ok(register_services(form, edit, newActivities, existing, isPreSubmission, businessMatching.preAppComplete))
           }) getOrElse {
             val (newActivities, existing) = getActivityValues(EmptyForm, isPreSubmission, None)
             Ok(register_services(EmptyForm, edit, newActivities, existing, isPreSubmission, showReturnLink = false))

--- a/app/controllers/businessmatching/SummaryController.scala
+++ b/app/controllers/businessmatching/SummaryController.scala
@@ -65,7 +65,7 @@ trait SummaryController extends BaseController {
         businessMatching <- businessMatchingService.getModel
         businessActivities <- OptionT.fromOption[Future](businessMatching.activities)
         status <- OptionT.liftF(statusService.getStatus)
-        _ <- businessMatchingService.updateModel(businessMatching.copy(hasAccepted = true))
+        _ <- businessMatchingService.updateModel(businessMatching.copy(hasAccepted = true, preAppComplete = true))
         _ <- businessMatchingService.commitVariationData map (_ => true) orElse OptionT.some(false)
       } yield {
         if(goToUpdateServices(businessActivities.additionalActivities, status)){

--- a/app/controllers/responsiblepeople/TrainingController.scala
+++ b/app/controllers/responsiblepeople/TrainingController.scala
@@ -71,7 +71,7 @@ trait TrainingController extends RepeatingSection with BaseController {
       case Some(cacheMap) => {
         (edit, cacheMap.getEntry[BusinessMatching](BusinessMatching.key)) match {
           case (true, _) => Redirect(routes.DetailedAnswersController.get(index, edit, flow))
-          case (false, Some(BusinessMatching(_, Some(BusinessActivities(acts, _, _, _)),_,_,_,_, _, _)))
+          case (false, Some(BusinessMatching(_, Some(BusinessActivities(acts, _, _, _)),_,_,_,_, _, _, _)))
             if acts.exists(act => act == MoneyServiceBusiness || act == TrustAndCompanyServices)
           => Redirect(routes.FitAndProperController.get(index, false, flow))
           case (false, _) => Redirect(routes.PersonRegisteredController.get(index, flow))

--- a/app/models/businessmatching/BusinessMatching.scala
+++ b/app/models/businessmatching/BusinessMatching.scala
@@ -31,7 +31,8 @@ case class BusinessMatching(
                              companyRegistrationNumber: Option[CompanyRegistrationNumber] = None,
                              businessAppliedForPSRNumber: Option[BusinessAppliedForPSRNumber] = None,
                              hasChanged: Boolean = false,
-                             hasAccepted: Boolean = false
+                             hasAccepted: Boolean = false,
+                             preAppComplete: Boolean = false
                            ) {
 
   def activities(p: BusinessActivities): BusinessMatching =
@@ -86,9 +87,9 @@ case class BusinessMatching(
 
   def isComplete: Boolean =
     this match {
-      case BusinessMatching(Some(x), Some(activity), _, _, _, _, _, _) if !ApplicationConfig.hasAcceptedToggle
+      case BusinessMatching(Some(x), Some(activity), _, _, _, _, _, _, true) if !ApplicationConfig.hasAcceptedToggle
         && isbusinessTypeComplete(x.businessType) && msbComplete(activity) => true
-      case BusinessMatching(Some(x), Some(activity), _, _, _, _, _, true)
+      case BusinessMatching(Some(x), Some(activity), _, _, _, _, _, true, true)
         if isbusinessTypeComplete(x.businessType) && msbComplete(activity) => true
       case _ => false
     }
@@ -124,9 +125,9 @@ object BusinessMatching {
       __.read(Reads.optionNoError[CompanyRegistrationNumber]) and
       __.read(Reads.optionNoError[BusinessAppliedForPSRNumber]) and
       (__ \ "hasChanged").readNullable[Boolean].map(_.getOrElse(false)) and
-      (__ \ "hasAccepted").readNullable[Boolean].map(_.getOrElse(false))
+      (__ \ "hasAccepted").readNullable[Boolean].map(_.getOrElse(false)) and
+      (__ \ "preAppComplete").readNullable[Boolean].map(_.getOrElse(false))
     ) (BusinessMatching.apply _)
-
 
   implicit val writes: Writes[BusinessMatching] =
     Writes[BusinessMatching] {
@@ -140,7 +141,7 @@ object BusinessMatching {
           Json.toJson(model.businessAppliedForPSRNumber).asOpt[JsObject]
         ).flatten.fold(Json.obj()) {
           _ ++ _
-        } + ("hasChanged" -> JsBoolean(model.hasChanged)) + ("hasAccepted" -> JsBoolean(model.hasAccepted))
+        } + ("hasChanged" -> JsBoolean(model.hasChanged)) + ("hasAccepted" -> JsBoolean(model.hasAccepted)) + ("preAppComplete" -> JsBoolean(model.preAppComplete))
     }
 
   implicit def default(businessMatching: Option[BusinessMatching]): BusinessMatching =

--- a/app/services/LandingService.scala
+++ b/app/services/LandingService.scala
@@ -193,7 +193,9 @@ trait LandingService {
           None,
           activities.dateOfChange
         ))
-      }, hasAccepted = true
+      },
+      hasAccepted = true,
+      preAppComplete = true
     )
   }
 

--- a/app/services/businessmatching/BusinessMatchingService.scala
+++ b/app/services/businessmatching/BusinessMatchingService.scala
@@ -27,7 +27,7 @@ import models.businessmatching._
 import models.estateagentbusiness.EstateAgentBusiness
 import models.hvd.Hvd
 import models.moneyservicebusiness.{MoneyServiceBusiness => Msb}
-import models.status.{NotCompleted, SubmissionReady}
+import models.status.{NotCompleted, SubmissionDecisionApproved, SubmissionReady, SubmissionReadyForReview}
 import models.tcsp.Tcsp
 import services.StatusService
 import uk.gov.hmrc.http.HeaderCarrier
@@ -42,8 +42,11 @@ class BusinessMatchingService @Inject()(
                                          dataCacheConnector: DataCacheConnector
                                        ) {
 
-  def preApplicationComplete(implicit ac: AuthContext, hc: HeaderCarrier, ex: ExecutionContext): Future[Boolean] =
-    OptionT(dataCacheConnector.fetch[BusinessMatching](BusinessMatching.key)) map (_.isComplete) getOrElse false
+  def preApplicationComplete(implicit ac: AuthContext, hc: HeaderCarrier, ex: ExecutionContext): Future[Boolean] = {
+    for {
+      bm <- OptionT(dataCacheConnector.fetch[BusinessMatching](BusinessMatching.key))
+    } yield bm.preAppComplete
+  } getOrElse false
 
   def getModel(implicit ac:AuthContext, hc: HeaderCarrier, ec: ExecutionContext): OptionT[Future, BusinessMatching] = {
     lazy val originalModel = OptionT(dataCacheConnector.fetch[BusinessMatching](BusinessMatching.key))

--- a/test/controllers/businessmatching/BusinessAppliedForPSRNumberControllerSpec.scala
+++ b/test/controllers/businessmatching/BusinessAppliedForPSRNumberControllerSpec.scala
@@ -59,10 +59,6 @@ class BusinessAppliedForPSRNumberControllerSpec extends GenericTestHelper
     when {
       controller.businessMatchingService.updateModel(any())(any(), any(), any())
     } thenReturn OptionT.some[Future, CacheMap](mockCacheMap)
-
-    when {
-      controller.businessMatchingService.preApplicationComplete(any(), any(), any())
-    } thenReturn Future.successful(false)
   }
 
   val emptyCache = CacheMap("", Map.empty)

--- a/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
@@ -84,11 +84,6 @@ class RegisterServicesControllerSpec extends GenericTestHelper with MockitoSugar
     when {
       controller.businessMatchingService.updateModel(any())(any(),any(),any())
     } thenReturn OptionT.some[Future, CacheMap](mockCacheMap)
-
-    when {
-      controller.businessMatchingService.preApplicationComplete(any(), any(), any())
-    } thenReturn Future.successful(false)
-
   }
 
   "RegisterServicesController" when {

--- a/test/controllers/businessmatching/ServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/ServicesControllerSpec.scala
@@ -61,10 +61,6 @@ class ServicesControllerSpec extends GenericTestHelper with ScalaFutures with Mo
       controller.businessMatchingService.updateModel(any())(any(), any(), any())
     } thenReturn cacheMapT
 
-    when {
-      controller.businessMatchingService.preApplicationComplete(any(), any(), any())
-    } thenReturn Future.successful(false)
-
     def setupModel(model: Option[BusinessMatching]) = when {
       controller.businessMatchingService.getModel(any(), any(), any())
     } thenReturn (model match {

--- a/test/controllers/businessmatching/SummaryControllerSpec.scala
+++ b/test/controllers/businessmatching/SummaryControllerSpec.scala
@@ -26,6 +26,7 @@ import models.businessmatching._
 import models.businessmatching.updateservice._
 import models.status.{SubmissionDecisionApproved, SubmissionReady}
 import org.jsoup.Jsoup
+import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -137,8 +138,12 @@ class SummaryControllerSpec extends GenericTestHelper with BusinessMatchingGener
 
           status(result) mustBe SEE_OTHER
           redirectLocation(result) mustBe Some(controllers.routes.RegistrationProgressController.get().url)
-        }
 
+          val captor = ArgumentCaptor.forClass(classOf[BusinessMatching])
+          verify(mockBusinessMatchingService).updateModel(captor.capture())(any(), any(), any())
+          captor.getValue.hasAccepted mustBe true
+          captor.getValue.preAppComplete mustBe true
+        }
       }
 
       "return Internal Server Error if the business matching model can't be updated" in new Fixture {

--- a/test/models/businessmatching/BusinessMatchingSpec.scala
+++ b/test/models/businessmatching/BusinessMatchingSpec.scala
@@ -74,7 +74,8 @@ class BusinessMatchingSpec extends PlaySpec with MockitoSugar with BusinessMatch
       "regNumber" -> "123456"
       ,
       "hasChanged" -> false,
-      "hasAccepted" -> true
+      "hasAccepted" -> true,
+      "preAppComplete" -> true
     )
 
     val businessMatching = BusinessMatching(
@@ -84,7 +85,8 @@ class BusinessMatchingSpec extends PlaySpec with MockitoSugar with BusinessMatch
       Some(typeOfBusinessModel),
       Some(companyRegistrationNumberModel),
       Some(businessAppliedForPSRNumberModel),
-      hasAccepted = true)
+      hasAccepted = true,
+      preAppComplete = true)
 
     "READ the JSON successfully and return the domain Object" in {
       Json.fromJson[BusinessMatching](jsonBusinessMatching - "hasChanged") must be(JsSuccess(businessMatching))
@@ -144,7 +146,8 @@ class BusinessMatchingSpec extends PlaySpec with MockitoSugar with BusinessMatch
             None,
             Some(businessAppliedForPSRNumberModel),
             hasChanged = false,
-            hasAccepted = true
+            hasAccepted = true,
+            preAppComplete = true
           )
 
           businessMatching.isComplete mustBe true
@@ -160,7 +163,8 @@ class BusinessMatchingSpec extends PlaySpec with MockitoSugar with BusinessMatch
             None,
             Some(businessAppliedForPSRNumberModel),
             hasChanged = false,
-            hasAccepted = true
+            hasAccepted = true,
+            preAppComplete = true
           )
 
           businessMatching.isComplete mustBe true
@@ -177,7 +181,8 @@ class BusinessMatchingSpec extends PlaySpec with MockitoSugar with BusinessMatch
             Some(companyRegistrationNumberModel),
             Some(businessAppliedForPSRNumberModel),
             hasChanged = false,
-            hasAccepted = true
+            hasAccepted = true,
+            preAppComplete = true
           )
 
           businessMatching.isComplete mustBe true
@@ -194,7 +199,8 @@ class BusinessMatchingSpec extends PlaySpec with MockitoSugar with BusinessMatch
             Some(companyRegistrationNumberModel),
             Some(businessAppliedForPSRNumberModel),
             hasChanged = false,
-            hasAccepted = true
+            hasAccepted = true,
+            preAppComplete = true
           )
 
           businessMatching.isComplete mustBe true
@@ -210,7 +216,8 @@ class BusinessMatchingSpec extends PlaySpec with MockitoSugar with BusinessMatch
             Some(companyRegistrationNumberModel),
             Some(businessAppliedForPSRNumberModel),
             hasChanged = false,
-            hasAccepted = true
+            hasAccepted = true,
+            preAppComplete = true
           )
 
           businessMatching.isComplete must be(true)
@@ -226,7 +233,8 @@ class BusinessMatchingSpec extends PlaySpec with MockitoSugar with BusinessMatch
             Some(companyRegistrationNumberModel),
             None,
             hasChanged = false,
-            hasAccepted = true
+            hasAccepted = true,
+            preAppComplete = true
           )
 
           businessMatching.isComplete must be(true)

--- a/test/services/businessmatching/BusinessMatchingServiceSpec.scala
+++ b/test/services/businessmatching/BusinessMatchingServiceSpec.scala
@@ -615,6 +615,8 @@ class BusinessMatchingServiceSpec extends PlaySpec
     "called" must {
       "return true" when {
         "in the right status" in new Fixture {
+          mockCacheFetch[BusinessMatching](Some(BusinessMatching(preAppComplete = true)))
+
           val result = await(service.preApplicationComplete)
 
           result mustBe true

--- a/test/services/businessmatching/BusinessMatchingServiceSpec.scala
+++ b/test/services/businessmatching/BusinessMatchingServiceSpec.scala
@@ -611,4 +611,16 @@ class BusinessMatchingServiceSpec extends PlaySpec
 
   }
 
+  "preApplicationComplete" when {
+    "called" must {
+      "return true" when {
+        "in the right status" in new Fixture {
+          val result = await(service.preApplicationComplete)
+
+          result mustBe true
+        }
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
This flag was added as there's currently no other way to tell whether the user has initially completed the business matching section or not.
This was playing havoc with the 'return to application progress' links inside business matching, which was previously based on the 'hasAccepted'
flag being true. Problem is, the state of that flag changes as you go through and edit the questions in business matching, meaning that the
registration progress link would appear to show randomly on some pages and not others. This should hopefully fix that.

I've taken care to make sure that the flag is defaulted to true when the data is read from API 5.