### PR TITLE
Business Name cache fallback

### DIFF
--- a/app/utils/BusinessName.scala
+++ b/app/utils/BusinessName.scala
@@ -16,17 +16,15 @@
 
 package utils
 
-import cats.implicits._
 import cats.data.OptionT
-import config.ApplicationConfig
+import cats.implicits._
 import connectors.{AmlsConnector, DataCacheConnector}
 import models.businessmatching.BusinessMatching
-import models.registrationdetails.RegistrationDetails
 import play.api.Logger
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 
 import scala.concurrent.{ExecutionContext, Future}
-import uk.gov.hmrc.http.HeaderCarrier
 
 object BusinessName {
 

--- a/app/views/status/status_supervised.scala.html
+++ b/app/views/status/status_supervised.scala.html
@@ -38,23 +38,25 @@
 
     <div class="grid-layout grid-layout--stacked">
         <div class="grid-layout__column grid-layout__column--2-3">
-            @businessName.map {bn =>
-                <div class="panel-indent panel-indent--gutter panel-border-wide">
-                    <p class="heading-small">@Messages("status.business")</p><p>@bn</p>
-                    @endDate.map { date =>
-                        <p class="heading-small">@Messages("lbl.registration.status")</p>
-                        <p>@Messages("status.submissiondecisionsupervised.enddate.text", DateHelper.formatDate(date))<br/>
-                            @if(allowDeRegister) {
-                                <a href="@controllers.deregister.routes.DeRegisterApplicationController.get()">@m("status.deregister.link-text")</a>
-                            }
-                        </p>
-                    }
-                    @if(showChangeOfficer){
-                        @change_officer(name)
-                    }
-                    <p class="heading-small">@Messages("status.referenceno")</p><p>@regNo</p>
-                </div>
-            }
+            <div class="panel-indent panel-indent--gutter panel-border-wide">
+                @businessName.map { bn =>
+                    <p class="heading-small">@Messages("status.business")</p> <p>@bn</p>
+                }
+
+                @endDate.map { date =>
+                    <p class="heading-small">@Messages("lbl.registration.status")</p>
+                    <p>@Messages("status.submissiondecisionsupervised.enddate.text", DateHelper.formatDate(date))<br/>
+                        @if(allowDeRegister) {
+                            <a href="@controllers.deregister.routes.DeRegisterApplicationController.get()">@m("status.deregister.link-text")</a>
+                        }
+                    </p>
+                }
+
+                @if(showChangeOfficer){
+                    @change_officer(name)
+                }
+                <p class="heading-small">@Messages("status.referenceno")</p><p>@regNo</p>
+            </div>
         </div>
         <div class="grid-layout__column grid-layout__column--1-3">
             @if(ApplicationConfig.notificationsToggle){


### PR DESCRIPTION
To protect users from a failing API 1b call, `BusinessName` has been modified so that it falls back to using the name in the cache if the call to API 1b (through AMLS middle tier) fails.