### PR TITLE
AMLS-3238: Replace GG admin enrol with BAS TAX enrolment 

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -73,8 +73,6 @@ object ApplicationConfig extends ApplicationConfig with ServicesConfig {
   lazy val notificationsUrl = baseUrl("amls-notification")
   lazy val allNotificationsUrl = s"$notificationsUrl/amls-notification"
 
-  lazy val authUrl = baseUrl("auth")
-
   def businessCustomerUrl = getConfigString("business-customer.url")
 
   lazy val whitelist = Play.configuration.getStringSeq("whitelist") getOrElse Seq.empty
@@ -124,4 +122,6 @@ class AppConfig @Inject()(
   def showFeesToggle = config.getConfBool("feature-toggle.show-fees", defBool = false)
 
   def enrolmentStoreToggle = config.getConfBool("feature-toggle.enrolment-store", defBool = false)
+
+  def authUrl = config.baseUrl("auth")
 }

--- a/app/connectors/AuthConnector.scala
+++ b/app/connectors/AuthConnector.scala
@@ -16,7 +16,9 @@
 
 package connectors
 
-import config.{ApplicationConfig, WSHttp}
+import javax.inject.Inject
+
+import config.{AppConfig, ApplicationConfig, WSHttp}
 import models.auth.UserDetailsResponse
 import models.enrolment.GovernmentGatewayEnrolment
 import org.apache.http.HttpStatus
@@ -53,18 +55,15 @@ object Authority {
 }
 // $COVERAGE-ON$
 
-trait AuthConnector {
+class AuthConnector @Inject()(val http: WSHttp, config: AppConfig) {
 
-  private[connectors] def authUrl: String
-
-  private[connectors] val http : CoreGet
+  private lazy val authUrl = config.authUrl
 
   def enrollments(uri: String)(implicit
                                headerCarrier: HeaderCarrier,
                                ec: ExecutionContext): Future[List[GovernmentGatewayEnrolment]] = {
 
     http.GET[List[GovernmentGatewayEnrolment]](authUrl + uri)
-
   }
 
   def getCurrentAuthority(implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[Authority] = {
@@ -86,9 +85,3 @@ trait AuthConnector {
   }
 }
 
-object AuthConnector extends AuthConnector {
-  // $COVERAGE-OFF$
-  override private[connectors] lazy val authUrl = ApplicationConfig.authUrl
-  override private[connectors] lazy val http = WSHttp
-  // $COVERAGE-ON$
-}

--- a/app/connectors/AuthConnector.scala
+++ b/app/connectors/AuthConnector.scala
@@ -17,6 +17,7 @@
 package connectors
 
 import config.{ApplicationConfig, WSHttp}
+import models.auth.UserDetailsResponse
 import models.enrolment.GovernmentGatewayEnrolment
 import org.apache.http.HttpStatus
 import play.api.libs.json.Json
@@ -75,6 +76,13 @@ trait AuthConnector {
 
   def getIds(authority: Authority)(implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[Ids] = {
     http.GET[Ids](s"$authUrl/${authority.normalisedIds}")
+  }
+
+  def userDetails(implicit hc: HeaderCarrier, ac: AuthContext, ec: ExecutionContext): Future[UserDetailsResponse] = {
+    ac.userDetailsUri match {
+      case Some(uri) => http.GET[UserDetailsResponse](uri)
+      case _ => Future.failed(new Exception("No user details Uri available"))
+    }
   }
 }
 

--- a/app/models/enrolment/EnrolmentKey.scala
+++ b/app/models/enrolment/EnrolmentKey.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.enrolment
+
+sealed trait EnrolmentKey {
+  protected val serviceName: String
+  protected val identifier: String
+  protected val value: String
+
+  def key: String = s"$serviceName~$identifier~$value"
+}
+
+case class AmlsEnrolmentKey(amlsRefNumber: String) extends EnrolmentKey {
+  override protected val serviceName: String = "HMRC-MLR-ORG"
+  override protected val identifier: String = "MLRRefNumber"
+  override protected val value: String = amlsRefNumber
+}

--- a/app/models/enrolment/EnrolmentStoreEnrolment.scala
+++ b/app/models/enrolment/EnrolmentStoreEnrolment.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.enrolment
+
+import play.api.libs.json.Json
+
+case class EnrolmentStoreEnrolment(userId: String, friendlyName: String, `type`: String, verifiers: Seq[EnrolmentIdentifier])
+
+object EnrolmentStoreEnrolment {
+  implicit val format = Json.writes[EnrolmentStoreEnrolment]
+
+  def apply(userId: String, amlsRefNumber: String, postCode: String): EnrolmentStoreEnrolment =
+    EnrolmentStoreEnrolment(userId, "AMLS Enrolment", "principal", Seq(
+      EnrolmentIdentifier("Postcode", postCode)
+    ))
+
+}

--- a/app/modules/Module.scala
+++ b/app/modules/Module.scala
@@ -34,7 +34,6 @@ class Module extends AbstractModule {
     bind(classOf[KeystoreConnector]).toInstance(KeystoreConnector)
     bind(classOf[DataCacheConnector]).toInstance(DataCacheConnector)
     bind(classOf[HmrcAuthConnector]).to(classOf[config.FrontendAuthConnector])
-    bind(classOf[connectors.AuthConnector]).toInstance(AuthConnector)
     bind(classOf[AmlsNotificationConnector]).toInstance(AmlsNotificationConnector)
     bind(classOf[StatusService]).toInstance(StatusService)
     bind(classOf[AmlsConnector]).toInstance(AmlsConnector)

--- a/app/services/AuthEnrolmentsService.scala
+++ b/app/services/AuthEnrolmentsService.scala
@@ -17,7 +17,7 @@
 package services
 
 import connectors.AuthConnector
-import play.api.Logger
+import play.api.{Logger, Play}
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -58,7 +58,7 @@ trait AuthEnrolmentsService {
 
 object AuthEnrolmentsService extends AuthEnrolmentsService {
   // $COVERAGE-OFF$
-  override private[services] val authConnector = AuthConnector
+  override private[services] lazy val authConnector = Play.current.injector.instanceOf[AuthConnector]
   // $COVERAGE-ON$
 
 }

--- a/test/connectors/EnrolmentStoreConnectorSpec.scala
+++ b/test/connectors/EnrolmentStoreConnectorSpec.scala
@@ -48,4 +48,14 @@ class EnrolmentStoreConnectorSpec extends PlaySpec with MustMatchers with ScalaF
 
   }
 
+  "enrol" when {
+    "called" must {
+      "call the UserDetails service to get the group id" in new Fixture {
+
+
+
+      }
+    }
+  }
+
 }

--- a/test/models/enrolment/EnrolmentKeySpec.scala
+++ b/test/models/enrolment/EnrolmentKeySpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.enrolment
+
+import generators.AmlsReferenceNumberGenerator
+import org.scalatest.MustMatchers
+import org.scalatestplus.play.PlaySpec
+
+class EnrolmentKeySpec extends PlaySpec with MustMatchers with AmlsReferenceNumberGenerator {
+
+  "The enrolment key" must {
+    "be in the correct format" in {
+      val enrolKey = AmlsEnrolmentKey(amlsRegistrationNumber)
+
+      enrolKey.key mustBe s"HMRC-MLR-ORG~MLRRefNumber~$amlsRegistrationNumber"
+    }
+  }
+
+}

--- a/test/models/enrolment/EnrolmentStoreEnrolmentSpec.scala
+++ b/test/models/enrolment/EnrolmentStoreEnrolmentSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.enrolment
+
+import generators.{AmlsReferenceNumberGenerator, BaseGenerator}
+import org.scalatest.MustMatchers
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.Json
+
+class EnrolmentStoreEnrolmentSpec extends PlaySpec with MustMatchers with BaseGenerator with AmlsReferenceNumberGenerator {
+
+  trait Fixture {
+
+    //noinspection ScalaStyle
+    val userId = numSequence(10).sample.get
+    val postCode = postcodeGen.sample.get
+    val refNumber = amlsRefNoGen.sample.get
+
+  }
+
+  "The model" must {
+    "serialize to the correct Json" in new Fixture {
+      val model = EnrolmentStoreEnrolment(userId, refNumber, postCode)
+
+      val expectedJson = Json.obj(
+        "userId" -> userId,
+        "friendlyName" -> "AMLS Enrolment",
+        "type" -> "principal",
+        "verifiers" -> Seq(
+          EnrolmentIdentifier("Postcode", postCode)
+        )
+      )
+
+      Json.toJson(model) mustBe expectedJson
+    }
+  }
+
+}


### PR DESCRIPTION
This PR includes:

* Various models (+ specs) required for the new enrolment call
* Refactored AuthConnector to support DI
* Added `userDetails` method to AuthConnector