### PR TITLE
Amls 3222 typeclasses

### DIFF
--- a/app/services/SubmissionResponseService.scala
+++ b/app/services/SubmissionResponseService.scala
@@ -22,8 +22,8 @@ import cats.data.OptionT
 import cats.implicits._
 import config.ApplicationConfig
 import connectors.DataCacheConnector
-import models.businessmatching.{BusinessActivities, BusinessActivity, BusinessMatching, TrustAndCompanyServices, MoneyServiceBusiness => MSB}
-import models.confirmation.{BreakdownRow, Currency, SubmissionData}
+import models.businessmatching.{BusinessMatching, MoneyServiceBusiness => MSB}
+import models.confirmation.{Currency, SubmissionData}
 import models.renewal.Renewal
 import models.responsiblepeople.ResponsiblePeople
 import models.status._
@@ -32,6 +32,8 @@ import models.{AmendVariationRenewalResponse, SubmissionResponse, SubscriptionRe
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.frontend.auth.AuthContext
+import typeclasses.confirmation.BreakdownRowInstances._
+import typeclasses.confirmation.BreakdownRows
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -58,10 +60,9 @@ class SubmissionResponseService @Inject()(
           businessMatching <- cache.getEntry[BusinessMatching](BusinessMatching.key)
           businessActivities <- businessMatching.activities
         } yield {
-          val subQuantity = subscriptionQuantity(subscription)
           val paymentReference = subscription.getPaymentReference
           val total = subscription.getTotalFees
-          val rows = getBreakdownRows(subscription, premises, people, businessActivities, subQuantity)
+          val rows = BreakdownRows.generateBreakdownRows[SubmissionResponse](subscription, Some(businessActivities), Some(premises), Some(people))
           val amlsRefNo = subscription.amlsRefNo
           Future.successful(SubmissionData(paymentReference.some, Currency.fromBD(total), rows, Some(amlsRefNo), None))
         }) getOrElse Future.failed(new Exception("Cannot get subscription response"))
@@ -94,7 +95,7 @@ class SubmissionResponseService @Inject()(
         } yield {
           val paymentReference = variationResponse.paymentReference
           val total = variationResponse.getTotalFees
-          val rows = getVariationBreakdownRows(variationResponse, businessActivities)
+          val rows = BreakdownRows.generateBreakdownRows[AmendVariationRenewalResponse](variationResponse, Some(businessActivities), None, None)
           val difference = variationResponse.difference map Currency.fromBD
           Future.successful(Some(SubmissionData(paymentReference, Currency.fromBD(total), rows, None, difference)))
         }) getOrElse Future.failed(new Exception("Cannot get subscription response"))
@@ -114,16 +115,13 @@ class SubmissionResponseService @Inject()(
           renewal <- cache.getEntry[AmendVariationRenewalResponse](AmendVariationRenewalResponse.key)
         } yield {
           val totalFees: BigDecimal = renewal.getTotalFees
-          val rows = getRenewalBreakdown(renewal)
+          val rows = BreakdownRows.generateBreakdownRows[AmendVariationRenewalResponse](renewal, None, None, None)
           val paymentRef = renewal.paymentReference
           val difference = renewal.difference
           Future.successful(Some(SubmissionData(paymentRef, Currency(totalFees), rows, None, difference map Currency.fromBD)))
         }) getOrElse Future.failed(new Exception("Cannot get amendment response"))
     }
   }
-
-  private def subscriptionQuantity(subscription: SubmissionResponse): Int =
-    if (subscription.getRegistrationFee == 0) 0 else 1
 
   private def getDataForAmendment(option: Option[CacheMap])(implicit authContent: AuthContext, hc: HeaderCarrier, ec: ExecutionContext) = {
     for {
@@ -134,138 +132,12 @@ class SubmissionResponseService @Inject()(
       businessMatching <- cache.getEntry[BusinessMatching](BusinessMatching.key)
       businessActivities <- businessMatching.activities
     } yield {
-      val subQuantity = subscriptionQuantity(amendmentResponse)
       val total = amendmentResponse.totalFees
       val difference = amendmentResponse.difference map Currency.fromBD
       val filteredPremises = TradingPremises.filter(premises)
-      val rows = getBreakdownRows(amendmentResponse, filteredPremises, people, businessActivities, subQuantity)
+      val rows = BreakdownRows.generateBreakdownRows[SubmissionResponse](amendmentResponse, Some(businessActivities), Some(filteredPremises), Some(people))
       val paymentRef = amendmentResponse.paymentReference
       Future.successful(Some(SubmissionData(paymentRef, Currency.fromBD(total), rows, None, difference)))
-    }
-  }
-
-  private def getRenewalBreakdown(renewal: AmendVariationRenewalResponse): Seq[BreakdownRow] = {
-
-    val breakdownRows = Seq.empty
-
-    def renewalRow(count: Int, rowEntity: RowEntity, total: AmendVariationRenewalResponse => BigDecimal): Seq[BreakdownRow] = {
-      if (count > 0) {
-        breakdownRows ++ Seq(BreakdownRow(rowEntity.message, count, rowEntity.feePer, Currency(total(renewal))))
-      } else {
-        Seq.empty
-      }
-    }
-
-    def rpRow: Seq[BreakdownRow] = renewalRow(renewal.addedResponsiblePeople, peopleVariationRow(renewal), renewalPeopleFee)
-
-    def fpRow: Seq[BreakdownRow] = renewalRow(renewal.addedResponsiblePeopleFitAndProper, peopleFPPassed, renewalFitAndProperDeduction)
-
-    def tpFullYearRow: Seq[BreakdownRow] = renewalRow(renewal.addedFullYearTradingPremises, premisesVariationRow(renewal), fullPremisesFee)
-
-    def tpHalfYearRow: Seq[BreakdownRow] = renewalRow(renewal.halfYearlyTradingPremises, premisesHalfYear(renewal), renewalHalfYearPremisesFee)
-
-    def tpZeroRow: Seq[BreakdownRow] = renewalRow(renewal.zeroRatedTradingPremises, PremisesZero, renewalZeroPremisesFee)
-
-    rpRow ++ fpRow ++ tpZeroRow ++ tpHalfYearRow ++ tpFullYearRow
-
-  }
-
-  private def getBreakdownRows
-  (submission: SubmissionResponse,
-   premises: Seq[TradingPremises],
-   people: Seq[ResponsiblePeople],
-   businessActivities: BusinessActivities,
-   subQuantity: Int): Seq[BreakdownRow] = {
-    Seq(
-      BreakdownRow(submissionRow(submission).message, subQuantity, submissionRow(submission).feePer, subQuantity * submissionRow(submission).feePer)
-    ) ++ responsiblePeopleRows(people, submission, businessActivities.businessActivities) ++ Seq(
-      BreakdownRow(premisesRow(submission).message, premises.size, premisesRow(submission).feePer, submission.getPremiseFee)
-    )
-  }
-
-  private def getVariationBreakdownRows
-  (variationResponse: AmendVariationRenewalResponse,
-   businessActivities: BusinessActivities): Seq[BreakdownRow] = {
-    responsiblePeopleVariationRows(variationResponse, businessActivities.businessActivities) ++ tradingPremisesVariationRows(variationResponse)
-  }
-
-  private def responsiblePeopleRows
-  (people: Seq[ResponsiblePeople],
-   subscription: SubmissionResponse,
-   activities: Set[BusinessActivity]): Seq[BreakdownRow] = {
-    if (showBreakdown(subscription.getFpFee, activities)) {
-
-      splitPeopleByFitAndProperTest(people) match {
-        case (passedFP, notFP) =>
-          Seq(
-            BreakdownRow(peopleRow(subscription).message, notFP.size, peopleRow(subscription).feePer, Currency.fromBD(subscription.getFpFee.getOrElse(0)))
-          ) ++ (if (passedFP.nonEmpty) {
-            Seq(
-              BreakdownRow(peopleFPPassed.message, passedFP.size, max(0, peopleFPPassed.feePer), Currency.fromBD(max(0, peopleFPPassed.feePer)))
-            )
-          } else {
-            Seq.empty
-          })
-      }
-    } else {
-      Seq.empty
-    }
-  }
-
-  private def tradingPremisesVariationRows(variationRenewalResponse: AmendVariationRenewalResponse): Seq[BreakdownRow] = {
-    val breakdownRows = Seq.empty
-
-    def variationRow(count: Int, rowEntity: RowEntity, total: AmendVariationRenewalResponse => BigDecimal): Seq[BreakdownRow] = {
-      if (count > 0) {
-        breakdownRows ++ Seq(BreakdownRow(rowEntity.message, count, rowEntity.feePer, Currency(total(variationRenewalResponse))))
-      } else {
-        Seq.empty
-      }
-    }
-
-    def tpFullYearRow: Seq[BreakdownRow] = variationRow(
-      variationRenewalResponse.addedFullYearTradingPremises,
-      premisesVariationRow(variationRenewalResponse),
-      fullPremisesFee
-    )
-
-    def tpHalfYearRow: Seq[BreakdownRow] = variationRow(
-      variationRenewalResponse.halfYearlyTradingPremises,
-      premisesHalfYear(variationRenewalResponse),
-      renewalHalfYearPremisesFee
-    )
-
-    def tpZeroRow: Seq[BreakdownRow] = variationRow(
-      variationRenewalResponse.zeroRatedTradingPremises,
-      PremisesZero,
-      renewalZeroPremisesFee
-    )
-
-    tpZeroRow ++ tpHalfYearRow ++ tpFullYearRow
-  }
-
-  private def responsiblePeopleVariationRows
-  (variationResponse: AmendVariationRenewalResponse,
-   activities: Set[BusinessActivity]): Seq[BreakdownRow] = {
-
-    if (showBreakdown(variationResponse.getFpFee, activities)) {
-
-      val (passedFP, notFP) = (variationResponse.addedResponsiblePeopleFitAndProper, variationResponse.addedResponsiblePeople)
-
-      (if (notFP > 0) {
-        Seq(
-          BreakdownRow(peopleVariationRow(variationResponse).message, notFP, peopleVariationRow(variationResponse).feePer, Currency.fromBD(variationResponse.getFpFee.getOrElse(0)))
-        )
-      } else {
-        Seq.empty
-      }) ++ (if (passedFP > 0) {
-        Seq(BreakdownRow(peopleFPPassed.message, passedFP, max(0, peopleFPPassed.feePer), Currency.fromBD(max(0, peopleFPPassed.feePer))))
-      } else {
-        Seq.empty
-      })
-
-    } else {
-      Seq.empty
     }
   }
 
@@ -284,17 +156,9 @@ class SubmissionResponseService @Inject()(
     }
   }
 
-  private val max = (x: BigDecimal, y: BigDecimal) => if (x > y) x else y
-
-  private val showBreakdown = (fpFee: Option[BigDecimal], activities: Set[BusinessActivity]) =>
-    fpFee.fold(activities.exists(act => act == MSB || act == TrustAndCompanyServices)) { _ => true }
-
-  private val splitPeopleByFitAndProperTest = (people: Seq[ResponsiblePeople]) =>
-    ResponsiblePeople.filter(people).partition(_.hasAlreadyPassedFitAndProper.getOrElse(false))
-
 }
 
-sealed trait FeeCalculations {
+trait FeeCalculations {
 
   def submissionRow(response: SubmissionResponse) = RowEntity("confirmation.submission", response.getRegistrationFee)
 

--- a/app/typeclasses/confirmation/ConfirmationBreakdownRows.scala
+++ b/app/typeclasses/confirmation/ConfirmationBreakdownRows.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package typeclasses.confirmation
+
+import models.{AmendVariationRenewalResponse, SubmissionResponse}
+import models.businessmatching.{BusinessActivities, BusinessActivity, TrustAndCompanyServices, MoneyServiceBusiness => MSB}
+import models.confirmation.{BreakdownRow, Currency}
+import models.responsiblepeople.ResponsiblePeople
+import models.tradingpremises.TradingPremises
+import services.{FeeCalculations, RowEntity}
+import ResponsiblePeopleRowsInstances._
+
+trait ConfirmationBreakdownRows[A] extends FeeCalculations {
+  def apply(
+             value: A,
+             businessActivities: Option[BusinessActivities],
+             premises: Option[Seq[TradingPremises]],
+             people: Option[Seq[ResponsiblePeople]]
+           ): Seq[BreakdownRow]
+
+  def subscriptionQuantity(subscription: SubmissionResponse): Int =
+    if (subscription.getRegistrationFee == 0) 0 else 1
+
+  def tradingPremisesVariationRows(variationRenewalResponse: AmendVariationRenewalResponse): Seq[BreakdownRow] = {
+    val breakdownRows = Seq.empty
+
+    def variationRow(count: Int, rowEntity: RowEntity, total: AmendVariationRenewalResponse => BigDecimal): Seq[BreakdownRow] = {
+      if (count > 0) {
+        breakdownRows ++ Seq(BreakdownRow(rowEntity.message, count, rowEntity.feePer, Currency(total(variationRenewalResponse))))
+      } else {
+        Seq.empty
+      }
+    }
+
+    def tpFullYearRow: Seq[BreakdownRow] = variationRow(
+      variationRenewalResponse.addedFullYearTradingPremises,
+      premisesVariationRow(variationRenewalResponse),
+      fullPremisesFee
+    )
+
+    def tpHalfYearRow: Seq[BreakdownRow] = variationRow(
+      variationRenewalResponse.halfYearlyTradingPremises,
+      premisesHalfYear(variationRenewalResponse),
+      renewalHalfYearPremisesFee
+    )
+
+    def tpZeroRow: Seq[BreakdownRow] = variationRow(
+      variationRenewalResponse.zeroRatedTradingPremises,
+      PremisesZero,
+      renewalZeroPremisesFee
+    )
+
+    tpZeroRow ++ tpHalfYearRow ++ tpFullYearRow
+  }
+}
+
+object BreakdownRowInstances {
+
+  implicit val breakdownRowFromSubscription: ConfirmationBreakdownRows[SubmissionResponse] = {
+    new ConfirmationBreakdownRows[SubmissionResponse] {
+      def apply(
+                 subscription: SubmissionResponse,
+                 businessActivities: Option[BusinessActivities],
+                 premises: Option[Seq[TradingPremises]],
+                 people: Option[Seq[ResponsiblePeople]]
+               ): Seq[BreakdownRow] = {
+
+        businessActivities match {
+          case Some(activities) if people.isDefined =>
+
+            val subQuantity = subscriptionQuantity(subscription)
+            val registrationFeeRow = submissionRow(subscription)
+
+            Seq(
+              BreakdownRow(registrationFeeRow.message, subQuantity, registrationFeeRow.feePer, subQuantity * registrationFeeRow.feePer)
+            ) ++ ResponsiblePeopleRows[SubmissionResponse](subscription, activities.businessActivities, people) ++ Seq(
+              BreakdownRow(premisesRow(subscription).message, premises.size, premisesRow(subscription).feePer, subscription.getPremiseFee)
+            )
+          case _ => Seq.empty[BreakdownRow]
+        }
+      }
+    }
+  }
+
+  implicit val breakdownRowFromVariation: ConfirmationBreakdownRows[AmendVariationRenewalResponse] = {
+    new ConfirmationBreakdownRows[AmendVariationRenewalResponse] {
+      override def apply(
+                          value: AmendVariationRenewalResponse,
+                          businessActivities: Option[BusinessActivities],
+                          premises: Option[Seq[TradingPremises]],
+                          people: Option[Seq[ResponsiblePeople]]) = {
+
+        businessActivities match {
+          case Some(activities) =>
+            ResponsiblePeopleRows[AmendVariationRenewalResponse](value, activities.businessActivities, None) ++ tradingPremisesVariationRows(value)
+          case _ =>
+            val breakdownRows = Seq.empty
+
+            def renewalRow(count: Int, rowEntity: RowEntity, total: AmendVariationRenewalResponse => BigDecimal): Seq[BreakdownRow] = {
+              if (count > 0) {
+                breakdownRows ++ Seq(BreakdownRow(rowEntity.message, count, rowEntity.feePer, Currency(total(value))))
+              } else {
+                Seq.empty
+              }
+            }
+
+            def rpRow: Seq[BreakdownRow] = renewalRow(value.addedResponsiblePeople, peopleVariationRow(value), renewalPeopleFee)
+
+            def fpRow: Seq[BreakdownRow] = renewalRow(value.addedResponsiblePeopleFitAndProper, peopleFPPassed, renewalFitAndProperDeduction)
+
+            def tpFullYearRow: Seq[BreakdownRow] = renewalRow(value.addedFullYearTradingPremises, premisesVariationRow(value), fullPremisesFee)
+
+            def tpHalfYearRow: Seq[BreakdownRow] = renewalRow(value.halfYearlyTradingPremises, premisesHalfYear(value), renewalHalfYearPremisesFee)
+
+            def tpZeroRow: Seq[BreakdownRow] = renewalRow(value.zeroRatedTradingPremises, PremisesZero, renewalZeroPremisesFee)
+
+            rpRow ++ fpRow ++ tpZeroRow ++ tpHalfYearRow ++ tpFullYearRow
+        }
+
+      }
+    }
+  }
+
+}
+
+object BreakdownRows {
+
+  def generateBreakdownRows[A](
+                                value: A,
+                                businessActivities: Option[BusinessActivities],
+                                premises: Option[Seq[TradingPremises]],
+                                people: Option[Seq[ResponsiblePeople]]
+                              )(implicit b: ConfirmationBreakdownRows[A]): Seq[BreakdownRow] = b(value, businessActivities, premises, people)
+
+}

--- a/app/typeclasses/confirmation/ResponsiblePeopleRows.scala
+++ b/app/typeclasses/confirmation/ResponsiblePeopleRows.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package typeclasses.confirmation
+
+import models.{AmendVariationRenewalResponse, SubmissionResponse}
+import models.businessmatching.{BusinessActivity, TrustAndCompanyServices, MoneyServiceBusiness => MSB}
+import models.confirmation.{BreakdownRow, Currency}
+import models.responsiblepeople.ResponsiblePeople
+import services.FeeCalculations
+
+trait ResponsiblePeopleRows[A] extends FeeCalculations {
+  def apply(
+             value: A,
+             activities: Set[BusinessActivity],
+             people: Option[Seq[ResponsiblePeople]]
+           ): Seq[BreakdownRow]
+
+  val showBreakdown = (fpFee: Option[BigDecimal], activities: Set[BusinessActivity]) =>
+    fpFee.fold(activities.exists(act => act == MSB || act == TrustAndCompanyServices)) { _ => true }
+
+  val splitPeopleByFitAndProperTest = (people: Seq[ResponsiblePeople]) =>
+    ResponsiblePeople.filter(people).partition(_.hasAlreadyPassedFitAndProper.getOrElse(false))
+
+  val max = (x: BigDecimal, y: BigDecimal) => if (x > y) x else y
+
+}
+
+object ResponsiblePeopleRowsInstances {
+
+  implicit val responsiblePeopleRowsFromSubscription: ResponsiblePeopleRows[SubmissionResponse] = {
+    new ResponsiblePeopleRows[SubmissionResponse] {
+      def apply(value: SubmissionResponse, activities: Set[BusinessActivity], people: Option[Seq[ResponsiblePeople]]) = {
+
+        people.fold(Seq.empty[BreakdownRow]) { responsiblePeople =>
+          if (showBreakdown(value.getFpFee, activities)) {
+            splitPeopleByFitAndProperTest(responsiblePeople) match {
+              case (passedFP, notFP) =>
+                Seq(
+                  BreakdownRow(peopleRow(value).message, notFP.size, peopleRow(value).feePer, Currency.fromBD(value.getFpFee.getOrElse(0)))
+                ) ++ (if (passedFP.nonEmpty) {
+                  Seq(
+                    BreakdownRow(peopleFPPassed.message, passedFP.size, max(0, peopleFPPassed.feePer), Currency.fromBD(max(0, peopleFPPassed.feePer)))
+                  )
+                } else {
+                  Seq.empty
+                })
+            }
+          } else {
+            Seq.empty
+          }
+        }
+
+      }
+    }
+  }
+
+  implicit val responsiblePeopleRowsFromVariation: ResponsiblePeopleRows[AmendVariationRenewalResponse] = {
+    new ResponsiblePeopleRows[AmendVariationRenewalResponse] {
+      override def apply(
+                          value: AmendVariationRenewalResponse,
+                          activities: Set[BusinessActivity],
+                          people: Option[Seq[ResponsiblePeople]]) = {
+
+        if (showBreakdown(value.getFpFee, activities)) {
+
+          val (passedFP, notFP) = (value.addedResponsiblePeopleFitAndProper, value.addedResponsiblePeople)
+
+          (if (notFP > 0) {
+            Seq(BreakdownRow(
+              peopleVariationRow(value).message,
+              notFP,
+              peopleVariationRow(value).feePer,
+              Currency.fromBD(value.getFpFee.getOrElse(0))
+            ))
+          } else {
+            Seq.empty
+          }) ++ (if (passedFP > 0) {
+            Seq(BreakdownRow(peopleFPPassed.message, passedFP, max(0, peopleFPPassed.feePer), Currency.fromBD(max(0, peopleFPPassed.feePer))))
+          } else {
+            Seq.empty
+          })
+
+        } else {
+          Seq.empty
+        }
+      }
+    }
+  }
+}
+
+object ResponsiblePeopleRows {
+  def apply[A](
+                value: A,
+                activities: Set[BusinessActivity],
+                people: Option[Seq[ResponsiblePeople]])(implicit r: ResponsiblePeopleRows[A]): Seq[BreakdownRow] = r(value, activities, people)
+}


### PR DESCRIPTION
To reduce the chaos in the submissionResponseService, typeclasses have been created and implement to construct breakdownRows for the various submission statuses
No logic has been added or removed, simply shifted and shared therefore, momentarily, unit tests remain in submissionResponseSpec rather than extracted to a typeclassSpec