### PR TITLE
AMLS-3323 | Refactored Print link to an include (printLink.scala.html…

### DIFF
--- a/app/views/confirmation/footer.scala.html
+++ b/app/views/confirmation/footer.scala.html
@@ -29,6 +29,9 @@
     <li>@messages("confirmation.payment.info.keep_up_to_date.item3")</li>
 </ul>
 
-<a href="javascript:window.print()" class="print-link print-hidden js-visible">Print</a>
+@printLink(linkId="confirmation-print",
+           gaTag=Some("confirmation:click:print")
+          )
+
 
 <a class="button" href="@controllers.routes.LandingController.get()" role="button">@Messages("confirmation.payment.continue_button.text")</a>

--- a/app/views/include/printLink.scala.html
+++ b/app/views/include/printLink.scala.html
@@ -1,0 +1,26 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(linkId: String,
+ linkMessageKey: String = "link.print",
+ gaTag: Option[String] = None
+ )(implicit lang:Lang,  m: Messages)
+
+@if(gaTag.isDefined) {
+    <a id="@linkId" href="javascript:window.print()" class="print-link print-hidden js-visible" data-journey-click="@gaTag.get">@Messages(linkMessageKey)</a>
+} else {
+    <a id="@linkId" href="javascript:window.print()" class="print-link print-hidden js-visible">@Messages(linkMessageKey)</a>
+}

--- a/app/views/payments/bank_details.scala.html
+++ b/app/views/payments/bank_details.scala.html
@@ -97,7 +97,9 @@
         </div>
     </div>
 
-    <a id="bank-details-print" href="javascript:window.print()" class="print-link print-hidden js-visible">Print</a>
+    @printLink(linkId="bank-details-print",
+    gaTag=Some("bank-details:click:print")
+    )
 
     <p><a class="button" href="@controllers.routes.ConfirmationController.bacsConfirmation()">@Messages("button.continue")</a></p>
 

--- a/app/views/status/status_renewal_submitted.scala.html
+++ b/app/views/status/status_renewal_submitted.scala.html
@@ -81,5 +81,7 @@
 
 @before_you_go()
 
-<a href="javascript:window.print()" class="print-link print-hidden js-visible">Print</a>
+    @printLink(linkId="status-renewal-submitted-print",
+               gaTag=Some("status-renewal-submitted:click:print")
+    )
 }

--- a/app/views/status/status_submitted.scala.html
+++ b/app/views/status/status_submitted.scala.html
@@ -91,6 +91,8 @@
 
     @before_you_go()
 
-    <a href="javascript:window.print()" class="print-link print-hidden js-visible">Print</a>
+    @printLink(linkId="status-submitted-print",
+               gaTag=Some("status-submitted:click:print")
+    )
 
 }

--- a/app/views/status/status_supervised.scala.html
+++ b/app/views/status/status_supervised.scala.html
@@ -93,5 +93,7 @@
         @before_you_go()
     }
 
-    <a href="javascript:window.print()" class="print-link print-hidden js-visible">Print</a>
+    @printLink(linkId="status-supervised-submitted-print",
+               gaTag=Some("status-supervised-submitted:click:print")
+    )
 }

--- a/conf/messages
+++ b/conf/messages
@@ -477,6 +477,7 @@ lbl.hint.vat = It's 9 numbers with no letters, punctuation or other characters.
 link.return.registration.progress = Return to application progress
 link.return.renewal.progress = Return to renewal progress
 link.renewal.progress.change.answers = Change your answers
+link.print = Print
 
 ############################### Login Page ###############################
 amls.Login.title = AMLS


### PR DESCRIPTION
…). Re-used in all existing javascript print links. GA events created confirmation:click:print, bank-details:click:print, status-renewal-submitted:click:print, status-supervised-submitted:click:print and status-submitted:click:print