### PR TITLE
AMLS-3904 Updated flow from 'What you need' page

### DIFF
--- a/app/controllers/bankdetails/BankAccountAddController.scala
+++ b/app/controllers/bankdetails/BankAccountAddController.scala
@@ -34,7 +34,7 @@ class BankAccountAddController @Inject()(
     implicit authContext => implicit request =>
       addData[BankDetails](None).map { idx =>
         if (displayGuidance) {
-          Redirect(routes.WhatYouNeedController.get(idx))
+          Redirect(routes.WhatYouNeedController.get())
         } else {
           Redirect(routes.BankAccountTypeController.get(idx))
         }

--- a/app/controllers/bankdetails/WhatYouNeedController.scala
+++ b/app/controllers/bankdetails/WhatYouNeedController.scala
@@ -16,25 +16,17 @@
 
 package controllers.bankdetails
 
-import config.AMLSAuthConnector
-import connectors.DataCacheConnector
 import controllers.BaseController
+import javax.inject.Inject
+import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import views.html.bankdetails._
 
 import scala.concurrent.Future
 
-trait WhatYouNeedController extends BaseController {
+class WhatYouNeedController @Inject()(val authConnector: AuthConnector) extends BaseController {
 
-  val dataCacheConnector: DataCacheConnector
-
-  def get(index:Int) = Authorised.async {
+  def get = Authorised.async {
     implicit authContext => implicit request =>
-      Future.successful(Ok(what_you_need(index)))
+      Future.successful(Ok(what_you_need()))
   }
-}
-
-object WhatYouNeedController extends WhatYouNeedController {
-  // $COVERAGE-OFF$
-  override val authConnector = AMLSAuthConnector
-  override val dataCacheConnector = DataCacheConnector
 }

--- a/app/models/bankdetails/BankDetails.scala
+++ b/app/models/bankdetails/BankDetails.scala
@@ -87,7 +87,7 @@ object BankDetails {
               case bdModel if !bdModel.isComplete => true
               case _ => false
             }
-            Section(msgKey, Started, anyChanged(bds), controllers.bankdetails.routes.WhatYouNeedController.get(index + 1))
+            Section(msgKey, Started, anyChanged(bds), controllers.bankdetails.routes.WhatYouNeedController.get)
           }
         }
       }

--- a/app/views/bankdetails/what_you_need.scala.html
+++ b/app/views/bankdetails/what_you_need.scala.html
@@ -16,7 +16,7 @@
 
 @import include._
 @import forms2._
-@()(implicit request: Request[_],m:Messages)
+@(nextUrl: Call)(implicit request: Request[_], m:Messages)
 
 @header = {
     @heading("title.wyn", "summary.bankdetails")
@@ -39,12 +39,12 @@
     <p>@Messages("bankdetails.whatyouneed.enter_details_hint")</p>
 
     @anchor(
-        attrHref = controllers.bankdetails.routes.BankAccountTypeController.get(1).toString,
+        attrHref = nextUrl.url,
         attrRole = true,
         linkText = Messages("button.continue"),
         visuallyhidden = Messages("summary.bankdetails"),
         returnLink = true,
-        id=Some("bankwhatyouneed-button")
+        id = Some("bankwhatyouneed-button")
     )
 }
 

--- a/app/views/bankdetails/what_you_need.scala.html
+++ b/app/views/bankdetails/what_you_need.scala.html
@@ -16,7 +16,7 @@
 
 @import include._
 @import forms2._
-@(index:Int)(implicit request: Request[_],m:Messages)
+@()(implicit request: Request[_],m:Messages)
 
 @header = {
     @heading("title.wyn", "summary.bankdetails")
@@ -39,7 +39,7 @@
     <p>@Messages("bankdetails.whatyouneed.enter_details_hint")</p>
 
     @anchor(
-        attrHref = controllers.bankdetails.routes.BankAccountTypeController.get(index).toString,
+        attrHref = controllers.bankdetails.routes.BankAccountTypeController.get(1).toString,
         attrRole = true,
         linkText = Messages("button.continue"),
         visuallyhidden = Messages("summary.bankdetails"),

--- a/conf/bankDetails.routes
+++ b/conf/bankDetails.routes
@@ -1,4 +1,4 @@
-GET         /what-you-need/:index                                        controllers.bankdetails.WhatYouNeedController.get(index: Int)
+GET         /what-you-need                                              @controllers.bankdetails.WhatYouNeedController.get
 
 GET         /add                                                         @controllers.bankdetails.BankAccountAddController.get(displayGuidance : Boolean ?= true)
 

--- a/test/controllers/bankdetails/BankAccountAddControllerSpec.scala
+++ b/test/controllers/bankdetails/BankAccountAddControllerSpec.scala
@@ -51,7 +51,7 @@ class BankAccountAddControllerSpec extends AmlsSpec
           val result = controller.get()(request)
 
           status(result) must be(SEE_OTHER)
-          redirectLocation(result) must be(Some(routes.WhatYouNeedController.get(2).url))
+          redirectLocation(result) must be(Some(routes.WhatYouNeedController.get().url))
         }
 
         "display guidance is false" in new Fixture {

--- a/test/controllers/bankdetails/WhatYouNeedControllerSpec.scala
+++ b/test/controllers/bankdetails/WhatYouNeedControllerSpec.scala
@@ -16,34 +16,69 @@
 
 package controllers.bankdetails
 
+import generators.bankdetails.BankDetailsGenerator
+import models.bankdetails.BankDetails
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalacheck.Gen
 import org.scalatest.concurrent.ScalaFutures
 import play.api.i18n.Messages
 import play.api.test.Helpers._
-import utils.{AmlsSpec, AuthorisedFixture}
+import utils.{AmlsSpec, AuthorisedFixture, DependencyMocks}
 import views.TitleValidator
 
-class WhatYouNeedControllerSpec extends AmlsSpec with ScalaFutures with TitleValidator {
+class WhatYouNeedControllerSpec
+  extends AmlsSpec
+    with ScalaFutures
+    with TitleValidator
+    with BankDetailsGenerator {
 
-  trait Fixture extends AuthorisedFixture { self =>
+  trait Fixture extends AuthorisedFixture with DependencyMocks {
+    self =>
     val request = addToken(authRequest)
-    val controller = new WhatYouNeedController(self.authConnector)
+    val controller = new WhatYouNeedController(self.authConnector, mockCacheConnector)
+
+    def assertHref(url: String)(implicit doc: Document) = {
+      doc.getElementById("bankwhatyouneed-button").attr("href") mustBe url
+    }
   }
 
-  "WhatYouNeedController" when {
+  "The GET action" must {
+    "respond with SEE_OTHER and show the 'what you need' page" in new Fixture {
+      mockCacheFetch(Gen.listOfN(3, bankDetailsGen).sample, Some(BankDetails.key))
 
-    "get is called" must {
+      val result = controller.get()(request)
 
-      "respond with SEE_OTHER and redirect to the 'what you need' page" in new Fixture {
+      status(result) must be(OK)
 
-        val result = controller.get()(request)
+      implicit val doc = Jsoup.parse(contentAsString(result))
+      validateTitle(s"${Messages("title.wyn")} - ${Messages("summary.bankdetails")}")
 
-        status(result) must be(OK)
+      contentAsString(result) must include(Messages("button.continue"))
+    }
 
-        implicit val doc = Jsoup.parse(contentAsString(result))
-        validateTitle(s"${Messages("title.wyn")} - ${Messages("summary.bankdetails")}")
+    "configure the link href correctly," which {
+      "should link to the 'has bank accounts' page" when {
+        "there are no bank accounts currently in the system" in new Fixture {
+          mockCacheFetch[Seq[BankDetails]](None, Some(BankDetails.key))
 
-        contentAsString(result) must include(Messages("button.continue"))
+          val result = controller.get()(request)
+
+          implicit val doc = Jsoup.parse(contentAsString(result))
+
+          assertHref(controllers.bankdetails.routes.HasBankAccountController.get().url)
+        }
+      }
+
+      "should link to the 'bank name' page" when {
+        "there are already bank accounts in the system" in new Fixture {
+          mockCacheFetch(Gen.listOfN(3, bankDetailsGen).sample, Some(BankDetails.key))
+
+          val result = controller.get()(request)
+          implicit val doc = Jsoup.parse(contentAsString(result))
+
+          assertHref(controllers.bankdetails.routes.BankAccountNameController.get(1).url)
+        }
       }
     }
   }

--- a/test/controllers/bankdetails/WhatYouNeedControllerSpec.scala
+++ b/test/controllers/bankdetails/WhatYouNeedControllerSpec.scala
@@ -16,23 +16,18 @@
 
 package controllers.bankdetails
 
-import connectors.DataCacheConnector
+import org.jsoup.Jsoup
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
-import  utils.AmlsSpec
 import play.api.i18n.Messages
 import play.api.test.Helpers._
-import utils.AuthorisedFixture
+import utils.{AmlsSpec, AuthorisedFixture}
+import views.TitleValidator
 
-class WhatYouNeedControllerSpec extends AmlsSpec with MockitoSugar with ScalaFutures {
+class WhatYouNeedControllerSpec extends AmlsSpec with ScalaFutures with TitleValidator {
 
-  trait Fixture extends AuthorisedFixture {
-    self => val request = addToken(authRequest)
-
-    val controller = new WhatYouNeedController {
-      override val dataCacheConnector = mock[DataCacheConnector]
-      override val authConnector = self.authConnector
-    }
+  trait Fixture extends AuthorisedFixture { self =>
+    val request = addToken(authRequest)
+    val controller = new WhatYouNeedController(self.authConnector)
   }
 
   "WhatYouNeedController" when {
@@ -41,15 +36,13 @@ class WhatYouNeedControllerSpec extends AmlsSpec with MockitoSugar with ScalaFut
 
       "respond with SEE_OTHER and redirect to the 'what you need' page" in new Fixture {
 
-        val result = controller.get(1)(request)
+        val result = controller.get()(request)
 
         status(result) must be(OK)
 
-        val pageTitle = Messages("title.wyn") + " - " +
-          Messages("summary.bankdetails") + " - " +
-          Messages("title.amls") + " - " + Messages("title.gov")
+        implicit val doc = Jsoup.parse(contentAsString(result))
+        validateTitle(s"${Messages("title.wyn")} - ${Messages("summary.bankdetails")}")
 
-        contentAsString(result) must include(pageTitle)
         contentAsString(result) must include(Messages("button.continue"))
       }
     }

--- a/test/generators/bankdetails/BankDetailsGenerator.scala
+++ b/test/generators/bankdetails/BankDetailsGenerator.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generators.bankdetails
+
+import generators.BaseGenerator
+import models.bankdetails._
+import org.scalacheck.Gen
+
+// scalastyle:off magic.number
+trait BankDetailsGenerator extends BaseGenerator {
+  val accountGen: Gen[Account] = for {
+    accountNumber <- numSequence(10)
+    sortCode <- numSequence(6)
+    iban <- numSequence(15)
+    account <- Gen.oneOf(Seq(
+      UKAccount(accountNumber, sortCode),
+      NonUKAccountNumber(accountNumber),
+      NonUKIBANNumber(iban)
+    ))
+  } yield account
+
+  val accountTypeGenerator: Gen[BankAccountType] = Gen.oneOf(Seq(PersonalAccount, BelongsToBusiness, BelongsToOtherBusiness, NoBankAccountUsed))
+
+  val bankDetailsGen: Gen[BankDetails] = for {
+    accountType <- accountTypeGenerator
+    name <- stringOfLengthGen(10)
+    account <- accountGen
+  } yield {
+    BankDetails(Some(accountType), Some(name), Some(account), hasAccepted = true)
+  }
+}

--- a/test/models/bankdetails/BankDetailsSpec.scala
+++ b/test/models/bankdetails/BankDetailsSpec.scala
@@ -156,7 +156,7 @@ class BankDetailsSpec extends PlaySpec with MockitoSugar with CharacterSets with
 
     "return a Started Section when model is incomplete" in {
       val incomplete = Seq(accountTypePartialModel)
-      val startedSection = Section("bankdetails", Started, false, controllers.bankdetails.routes.WhatYouNeedController.get(1))
+      val startedSection = Section("bankdetails", Started, false, controllers.bankdetails.routes.WhatYouNeedController.get())
 
       mockCacheGetEntry[Seq[BankDetails]](Some(incomplete), BankDetails.key)
 
@@ -195,7 +195,7 @@ class BankDetailsSpec extends PlaySpec with MockitoSugar with CharacterSets with
 
         mockCacheGetEntry[Seq[BankDetails]](Some(Seq(completeModel, BankDetails(), incompleteModel)), BankDetails.key)
 
-        BankDetails.section(mockCacheMap).call.url must be(controllers.bankdetails.routes.WhatYouNeedController.get(2).url)
+        BankDetails.section(mockCacheMap).call.url must be(controllers.bankdetails.routes.WhatYouNeedController.get().url)
       }
     }
 

--- a/test/views/bankdetails/what_you_needSpec.scala
+++ b/test/views/bankdetails/what_you_needSpec.scala
@@ -30,20 +30,20 @@ class what_you_needSpec extends AmlsSpec with MustMatchers {
 
   "What you need View" must {
     "Have the correct title" in new ViewFixture {
-      def view = views.html.bankdetails.what_you_need(0)
+      def view = views.html.bankdetails.what_you_need()
 
       doc.title must startWith(Messages("title.wyn"))
     }
 
     "Have the correct Headings" in new ViewFixture {
-      def view = views.html.bankdetails.what_you_need(0)
+      def view = views.html.bankdetails.what_you_need()
 
       heading.html must be(Messages("title.wyn"))
       subHeading.html must include(Messages("summary.bankdetails"))
     }
 
     "contain the expected content elements" in new ViewFixture {
-      def view = views.html.bankdetails.what_you_need(0)
+      def view = views.html.bankdetails.what_you_need()
 
       html must include(Messages("bankdetails.whatyouneed.line_1"))
       html must include(Messages("bankdetails.whatyouneed.line_2"))
@@ -51,7 +51,7 @@ class what_you_needSpec extends AmlsSpec with MustMatchers {
     }
 
     "provide the expected hint" in new ViewFixture {
-      def view = views.html.bankdetails.what_you_need(0)
+      def view = views.html.bankdetails.what_you_need()
 
       html must include(Messages("bankdetails.whatyouneed.enter_details_hint"))
     }

--- a/test/views/bankdetails/what_you_needSpec.scala
+++ b/test/views/bankdetails/what_you_needSpec.scala
@@ -26,33 +26,27 @@ class what_you_needSpec extends AmlsSpec with MustMatchers {
 
   trait ViewFixture extends Fixture {
     implicit val requestWithToken = addToken(request)
+
+    def view = views.html.bankdetails.what_you_need(controllers.bankdetails.routes.HasBankAccountController.get())
   }
 
   "What you need View" must {
     "Have the correct title" in new ViewFixture {
-      def view = views.html.bankdetails.what_you_need()
-
       doc.title must startWith(Messages("title.wyn"))
     }
 
     "Have the correct Headings" in new ViewFixture {
-      def view = views.html.bankdetails.what_you_need()
-
       heading.html must be(Messages("title.wyn"))
       subHeading.html must include(Messages("summary.bankdetails"))
     }
 
     "contain the expected content elements" in new ViewFixture {
-      def view = views.html.bankdetails.what_you_need()
-
       html must include(Messages("bankdetails.whatyouneed.line_1"))
       html must include(Messages("bankdetails.whatyouneed.line_2"))
       html must include(Messages("bankdetails.whatyouneed.line_3"))
     }
 
     "provide the expected hint" in new ViewFixture {
-      def view = views.html.bankdetails.what_you_need()
-
       html must include(Messages("bankdetails.whatyouneed.enter_details_hint"))
     }
   }


### PR DESCRIPTION
* Page now correctly routes to either 'bank account name' or 'does this business have a bank account' based on current data
* Removed `index` querystring parameter
* Created a set of ScalaCheck generators for `BankDetails`
