### PR TITLE
AMLS-3932 Filtered out 'no bank account' types

### DIFF
--- a/app/controllers/bankdetails/WhatYouNeedController.scala
+++ b/app/controllers/bankdetails/WhatYouNeedController.scala
@@ -22,9 +22,9 @@ import connectors.DataCacheConnector
 import controllers.BaseController
 import javax.inject.Inject
 import models.bankdetails.BankDetails
+import models.bankdetails.BankDetails.Filters._
 import play.api.mvc.Call
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
-import utils.StatusConstants
 import views.html.bankdetails._
 
 class WhatYouNeedController @Inject()(val authConnector: AuthConnector,
@@ -34,12 +34,11 @@ class WhatYouNeedController @Inject()(val authConnector: AuthConnector,
     implicit authContext =>
       implicit request =>
         val view = what_you_need.apply(_: Call)(request, implicitly)
-        val deletedFilter = (details: BankDetails) => !details.status.contains(StatusConstants.Deleted)
 
         val result = for {
             bankDetails <- OptionT(dataCacheConnector.fetch[Seq[BankDetails]](BankDetails.key))
           } yield {
-            if (bankDetails.exists(deletedFilter)) {
+            if (bankDetails.exists(visibleAccountsFilter)) {
               Ok(view(routes.BankAccountNameController.getNoIndex()))
             } else {
               Ok(view(routes.HasBankAccountController.get()))

--- a/app/controllers/bankdetails/YourBankAccountsController.scala
+++ b/app/controllers/bankdetails/YourBankAccountsController.scala
@@ -18,15 +18,13 @@ package controllers.bankdetails
 
 import config.AMLSAuthConnector
 import connectors.DataCacheConnector
-import controllers.BaseController
 import forms.EmptyForm
-import javax.inject.{Inject, Singleton}
+import javax.inject.Inject
 import models.bankdetails.BankDetails
+import models.bankdetails.BankDetails.Filters._
 import services.StatusService
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
-import utils.StatusConstants
 
-@Singleton
 class YourBankAccountsController @Inject()(
                                             val dataCacheConnector: DataCacheConnector,
                                             val authConnector: AuthConnector = AMLSAuthConnector,
@@ -39,12 +37,12 @@ class YourBankAccountsController @Inject()(
           bankDetails <- dataCacheConnector.fetch[Seq[BankDetails]](BankDetails.key)
         } yield bankDetails match {
           case Some(data) =>
-            val filteredBankDetails = data.zipWithIndex.filterNot(_._1.status.contains(StatusConstants.Deleted))
+            val filteredBankDetails = data.zipWithIndex.visibleAccounts
 
             Ok(views.html.bankdetails.your_bank_accounts(
               EmptyForm,
-              filteredBankDetails.filterNot(_._1.isComplete),
-              filteredBankDetails.filter(_._1.isComplete)
+              filteredBankDetails.incompleteAccounts,
+              filteredBankDetails.completeAccounts
             ))
 
           case _ => Redirect(controllers.routes.RegistrationProgressController.get())

--- a/app/models/bankdetails/BankDetails.scala
+++ b/app/models/bankdetails/BankDetails.scala
@@ -126,4 +126,17 @@ object BankDetails {
 
   implicit def default(details: Option[BankDetails]): BankDetails =
     details.getOrElse(BankDetails())
+
+  object Filters {
+    val deletedFilter = (bd: BankDetails) => bd.status.contains(StatusConstants.Deleted)
+    val completeFilter = (bd: BankDetails) => bd.isComplete
+    val noBankAccountFilter = (bd: BankDetails) => bd.bankAccountType.contains(NoBankAccountUsed)
+    val visibleAccountsFilter = (bd: BankDetails) => !deletedFilter(bd) && !noBankAccountFilter(bd)
+
+    implicit class ZippedSyntax(zipped: Seq[(BankDetails, Int)]) {
+      def visibleAccounts = zipped filter { case (bd, _) => visibleAccountsFilter(bd) }
+      def completeAccounts = zipped filter { case (bd, _) => completeFilter(bd) }
+      def incompleteAccounts = zipped filterNot { case (bd, _) => completeFilter(bd) }
+    }
+  }
 }


### PR DESCRIPTION
To do this, all of the common bank account filters (deleted, completed and visible accounts) have been extracted to a common location inside the BankDetails model.