### PR TITLE
AMLS-3948 Included empty bank accounts in the `visibleAccounts` filter

### DIFF
--- a/app/controllers/bankdetails/BankAccountTypeController.scala
+++ b/app/controllers/bankdetails/BankAccountTypeController.scala
@@ -39,8 +39,6 @@ class BankAccountTypeController @Inject()(
   def get(index: Int, edit: Boolean = false) = Authorised.async {
     implicit authContext =>
       implicit request => {
-        val filter: BankDetails => Boolean = details => details.status.contains(StatusConstants.Deleted) || details.bankAccountType.contains(NoBankAccountUsed)
-
         for {
           bankDetail <- getData[BankDetails](index)
           status <- statusService.getStatus

--- a/app/controllers/bankdetails/BankAccountTypeController.scala
+++ b/app/controllers/bankdetails/BankAccountTypeController.scala
@@ -17,12 +17,12 @@
 package controllers.bankdetails
 
 import javax.inject.{Inject, Singleton}
-
 import config.AMLSAuthConnector
 import connectors.DataCacheConnector
 import controllers.BaseController
 import forms.{EmptyForm, Form2, InvalidForm, ValidForm}
 import models.bankdetails._
+import play.api.mvc.{Request, Result}
 import services.StatusService
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import utils.{ControllerHelper, RepeatingSection, StatusConstants}
@@ -44,9 +44,9 @@ class BankAccountTypeController @Inject()(
           status <- statusService.getStatus
         } yield bankDetail match {
           case Some(details@BankDetails(Some(data), _, _, _, _, _, _)) if details.canEdit(status) =>
-            Ok(views.html.bankdetails.bank_account_types(Form2[Option[BankAccountType]](Some(data)), edit, index))
+            Ok(view.apply(Form2[Option[BankAccountType]](Some(data)), edit, index))
           case Some(details) if details.canEdit(status) =>
-            Ok(views.html.bankdetails.bank_account_types(EmptyForm, edit, index))
+            Ok(view.apply(EmptyForm, edit, index))
           case _ => NotFound(notFoundView)
         }
       }
@@ -57,7 +57,7 @@ class BankAccountTypeController @Inject()(
       implicit request => {
         Form2[Option[BankAccountType]](request.body) match {
           case f: InvalidForm =>
-            Future.successful(BadRequest(views.html.bankdetails.bank_account_types(f, edit, index)))
+            Future.successful(BadRequest(view(request)(f, edit, index)))
           case ValidForm(_, data) => {
             for {
               _ <- updateDataStrict[BankDetails](index) { bd =>
@@ -66,18 +66,20 @@ class BankAccountTypeController @Inject()(
                   case _ => bd.bankAccountType(data)
                 }
               }
-            } yield {
-              data match {
-                case Some(NoBankAccountUsed) => Redirect(routes.SummaryController.get(index))
-                case Some(_) if !edit => Redirect(routes.BankAccountIsUKController.get(index))
-                case _ => Redirect(routes.SummaryController.get(index))
-              }
-            }
+            } yield router(data, edit, index)
           }.recoverWith {
             case _: IndexOutOfBoundsException => Future.successful(NotFound(notFoundView))
           }
         }
       }
+  }
+
+  private def view(implicit request: Request[_]) = views.html.bankdetails.bank_account_types.apply _
+
+  private val router = (data: Option[BankAccountType], edit: Boolean, index: Int) => data match {
+    case Some(NoBankAccountUsed) => Redirect(routes.SummaryController.get(index))
+    case Some(_) if !edit => Redirect(routes.BankAccountIsUKController.get(index))
+    case _ => Redirect(routes.SummaryController.get(index))
   }
 
 }

--- a/app/controllers/bankdetails/HasBankAccountController.scala
+++ b/app/controllers/bankdetails/HasBankAccountController.scala
@@ -43,7 +43,7 @@ class HasBankAccountController @Inject()(val authConnector: AuthConnector,
   def get = Authorised.async {
     implicit authContext =>
       implicit request =>
-        Future.successful(Ok(view(request)(EmptyForm)))
+        Future.successful(Ok(view.apply(EmptyForm)))
   }
 
   def post = Authorised.async {
@@ -56,7 +56,7 @@ class HasBankAccountController @Inject()(val authConnector: AuthConnector,
           case ValidForm(_, data) =>
             cacheConnector.save(BankDetails.key, Seq.empty[BankDetails]) map { _ => Redirect(router(data)) }
 
-          case f: InvalidForm => Future.successful(BadRequest(view(request)(f)))
+          case f: InvalidForm => Future.successful(BadRequest(view.apply(f)))
         }
   }
 }

--- a/app/models/bankdetails/BankDetails.scala
+++ b/app/models/bankdetails/BankDetails.scala
@@ -131,7 +131,8 @@ object BankDetails {
     val deletedFilter = (bd: BankDetails) => bd.status.contains(StatusConstants.Deleted)
     val completeFilter = (bd: BankDetails) => bd.isComplete
     val noBankAccountFilter = (bd: BankDetails) => bd.bankAccountType.contains(NoBankAccountUsed)
-    val visibleAccountsFilter = (bd: BankDetails) => !deletedFilter(bd) && !noBankAccountFilter(bd)
+    val emptyModelFilter = (bd: BankDetails) => bd == BankDetails()
+    val visibleAccountsFilter = (bd: BankDetails) => !deletedFilter(bd) && !noBankAccountFilter(bd) && !emptyModelFilter(bd)
 
     implicit class ZippedSyntax(zipped: Seq[(BankDetails, Int)]) {
       def visibleAccounts = zipped filter { case (bd, _) => visibleAccountsFilter(bd) }

--- a/test/controllers/bankdetails/YourBankAccountsControllerSpec.scala
+++ b/test/controllers/bankdetails/YourBankAccountsControllerSpec.scala
@@ -42,6 +42,7 @@ class YourBankAccountsControllerSpec extends AmlsSpec with MockitoSugar {
         false,
         None,
         true)
+
     val completeModel2 = BankDetails(
       Some(BelongsToBusiness),
       Some("Completed Second Account Name"),
@@ -174,6 +175,22 @@ class YourBankAccountsControllerSpec extends AmlsSpec with MockitoSugar {
       contentAsString(result) mustNot include(Messages("bankdetails.yourbankaccounts.incomplete"))
       contentAsString(result) mustNot include(Messages("bankdetails.yourbankaccounts.complete") + "</h2>")
     }
+
+    "filter out empty bank accounts" in new Fixture {
+      mockCacheFetch[Seq[BankDetails]](Some(Seq(
+        BankDetails()
+      )))
+
+      mockApplicationStatus(SubmissionReady)
+
+      val result = controller.get()(request)
+
+      status(result) mustBe OK
+
+
+      contentAsString(result) must not include Messages("bankdetails.yourbankaccounts.noaccountname")
+    }
+
   }
 }
 


### PR DESCRIPTION
The 'Your Bank Accounts' page makes use of this filter, thus empty bank accounts should now be hidden from that view.

Also tidied up a couple of the controllers with the `bankdetails` package to rid the 'cyclomatic complexity' warnings.