### PR TITLE
AMLS-3948 Altered 'empty bank details' filter

### DIFF
--- a/app/models/bankdetails/BankDetails.scala
+++ b/app/models/bankdetails/BankDetails.scala
@@ -131,7 +131,12 @@ object BankDetails {
     val deletedFilter = (bd: BankDetails) => bd.status.contains(StatusConstants.Deleted)
     val completeFilter = (bd: BankDetails) => bd.isComplete
     val noBankAccountFilter = (bd: BankDetails) => bd.bankAccountType.contains(NoBankAccountUsed)
-    val emptyModelFilter = (bd: BankDetails) => bd == BankDetails()
+
+    val emptyModelFilter: BankDetails => Boolean = {
+      case BankDetails(None, None, None, _, _, _, _) => true
+      case _ => false
+    }
+
     val visibleAccountsFilter = (bd: BankDetails) => !deletedFilter(bd) && !noBankAccountFilter(bd) && !emptyModelFilter(bd)
 
     implicit class ZippedSyntax(zipped: Seq[(BankDetails, Int)]) {

--- a/test/controllers/bankdetails/YourBankAccountsControllerSpec.scala
+++ b/test/controllers/bankdetails/YourBankAccountsControllerSpec.scala
@@ -191,6 +191,19 @@ class YourBankAccountsControllerSpec extends AmlsSpec with MockitoSugar {
       contentAsString(result) must not include Messages("bankdetails.yourbankaccounts.noaccountname")
     }
 
+    "filters out empty but accepted bank accounts" in new Fixture {
+      mockCacheFetch[Seq[BankDetails]](Some(Seq(
+        BankDetails(hasAccepted = true)
+      )))
+
+      mockApplicationStatus(SubmissionReady)
+
+      val result = controller.get()(request)
+
+      status(result) mustBe OK
+
+      contentAsString(result) must not include Messages("bankdetails.yourbankaccounts.noaccountname")
+    }
   }
 }
 


### PR DESCRIPTION
It now caters for the fact that a bank detail model might be empty but hasAccepted = true, which is the case for the data in the QA environment.