### PR TITLE
Amls 4125

### DIFF
--- a/app/views/msb/which_currencies.scala.html
+++ b/app/views/msb/which_currencies.scala.html
@@ -33,7 +33,6 @@
     @form(f, controllers.msb.routes.WhichCurrenciesController.post(edit)) {
 
         @hint(
-            id = "currencies[0]",
             hint = "msb.which_currencies.uptoThree.hint",
             hint2 = "msb.which_currencies.uptoThree.hint2"
         )

--- a/public/amls.js
+++ b/public/amls.js
@@ -97,7 +97,7 @@ $(function () {
           select: _select,
           change: _change
         });
-        _this.element.attr('id', 'input-' + _this.element.attr('id'))
+        _this.element.attr('id', 'select-' + _this.element.attr('id'))
     }
   });
 

--- a/public/amls.js
+++ b/public/amls.js
@@ -86,8 +86,9 @@ $(function () {
         }
       };
 
+
       input = $('<input>')
-          .attr('id', 'input-'+ _this.element.attr('id'))
+          .attr('id', _this.element.attr('id'))
         .insertAfter(this.element)
         .val(value)
         .addClass('form-control')
@@ -96,6 +97,7 @@ $(function () {
           select: _select,
           change: _change
         });
+        _this.element.attr('id', 'input-' + _this.element.attr('id'))
     }
   });
 


### PR DESCRIPTION
Fix for the following error:

On the renewals largest amounts screen, clicking the error message at the top does not move to the correct field. This also stops the GA field error working as it is based on the errorgroup tag which is missing.

All inputs were being created with 'input-' prepended to the add. This did not match the validation error urls generated by the model. The prepended text has been removed. The parent selector id has been changed such that ids do not clash. 

![screen shot 2018-07-13 at 09 42 52](https://user-images.githubusercontent.com/40767309/42695466-5ac788be-86ad-11e8-8f20-7b22317c5cda.png)


The fix has been applied to the js file for the entire front end and as a result will fix all affected pages. 