### PR TITLE
Bumped library versions according to service catalogue

### DIFF
--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -12,7 +12,7 @@ private object AppDependencies {
   import play.sbt.PlayImport._
   import play.core.PlayVersion
 
-  private val frontendBootstrapVersion = "8.24.0"
+  private val frontendBootstrapVersion = "8.25.0"
   private val playPartialsVersion = "6.1.0"
   private val httpCachingClientVersion = "7.1.0"
   private val playWhitelistFilterVersion = "2.0.0"
@@ -20,7 +20,7 @@ private object AppDependencies {
   private val flexmarkVersion = "0.19.1"
   private val okHttpVersion = "3.9.1"
   private val jsonEncryptionVersion = "3.2.0"
-  private val playReactivemongoVersion = "6.0.0"
+  private val playReactivemongoVersion = "6.2.0"
 
   private val playJars = ExclusionRule(organization = "com.typesafe.play")
 

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -9,7 +9,7 @@ import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 trait MicroService {
 
   import uk.gov.hmrc._
-  import DefaultBuildSettings._
+  import DefaultBuildSettings.{scalaSettings, defaultSettings, addTestReportOption}
   import TestPhases._
   import uk.gov.hmrc.SbtAutoBuildPlugin
   import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,9 +5,9 @@ resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/
 
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.8.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.10.0")
 


### PR DESCRIPTION
# PR Details

Bumped library versions according to service catalogue.

## Description

Platform libraries are periodically updated, and service teams are required to keep up to date with progression of these libraries. This PR updates our platform libraries to be in line with the latest available.

## Related / Dependant PRs?

There are related PRs for `amls` and `amls-notification`, but none of these pull requests are dependent on each other:

https://github.com/hmrc/amls-notification/pull/40
https://github.com/hmrc/amls/pull/192

## How Has This Been Tested?

* Successful unit test run
* Partial acceptance smoke test to verify that services start and run

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ x ] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ x ] Requires acceptance test run.
- [ x ] Appropriate labels added.