### PR TITLE
AMLS-4026 | AMLS-4093 | Validate FX question is answered on renewal submission | AMLS-4195 | BUG- Renewal does not validate MSB Question TotalThroughput

### DIFF
--- a/app/models/renewal/Renewal.scala
+++ b/app/models/renewal/Renewal.scala
@@ -19,7 +19,7 @@ package models.renewal
 import cats.data.Validated.{Invalid, Valid}
 import jto.validation.{Path, Rule, ValidationError}
 import models.ValidationRule
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.Json
 
 case class Renewal(
                     involvedInOtherActivities: Option[InvolvedInOther] = None,
@@ -144,6 +144,11 @@ object Renewal {
         r.mostTransactions.isEmpty => Valid(r)
 
       case _ => Invalid(Seq(Path -> Seq(ValidationError("Invalid model state for money transmitting"))))
+    }
+
+    val aspRule: ValidationRule[Renewal] = Rule[Renewal, Renewal] {
+      case r if r.customersOutsideUK.isDefined => Valid(r)
+      case _ => Invalid(Seq(Path -> Seq(ValidationError("Invalid model state for accountancy service provider"))))
     }
 
     val hvdRule: ValidationRule[Renewal] = Rule[Renewal, Renewal] {

--- a/app/models/renewal/Renewal.scala
+++ b/app/models/renewal/Renewal.scala
@@ -122,6 +122,11 @@ object Renewal {
       case _ => Invalid(Seq(Path \ "involvedInOtherActivities" -> Seq(ValidationError("Invalid state"))))
     }
 
+    val msbRule: ValidationRule[Renewal] = Rule[Renewal, Renewal] {
+      case r if r.totalThroughput.isDefined => Valid(r)
+      case _ => Invalid(Seq(Path -> Seq(ValidationError("Invalid model state for money service business"))))
+    }
+
     val currencyExchangeRule: ValidationRule[Renewal] = Rule[Renewal, Renewal] {
       case r if r.whichCurrencies.isDefined && r.ceTransactionsInLast12Months.isDefined => Valid(r)
       case _ => Invalid(Seq(Path -> Seq(ValidationError("Invalid model state for currency exchange"))))

--- a/app/models/renewal/Renewal.scala
+++ b/app/models/renewal/Renewal.scala
@@ -140,7 +140,6 @@ object Renewal {
 
       case r if (r.sendMoneyToOtherCountry.isEmpty || r.sendMoneyToOtherCountry.exists(_.money == false)) &&
         r.transactionsInLast12Months.isDefined &&
-        r.mostTransactions.isEmpty &&
         r.mostTransactions.isEmpty => Valid(r)
 
       case _ => Invalid(Seq(Path -> Seq(ValidationError("Invalid model state for money transmitting"))))

--- a/app/services/RenewalService.scala
+++ b/app/services/RenewalService.scala
@@ -89,6 +89,7 @@ class RenewalService @Inject()(dataCache: DataCacheConnector) {
 
     val validationRule = compileOpt {
       Seq(
+        Some(msbRule),
         if (msbServices.exists(_.msbServices.contains(TransmittingMoney))) Some(moneyTransmitterRule) else None,
         if (msbServices.exists(_.msbServices.contains(CurrencyExchange))) Some(currencyExchangeRule) else None,
         if (msbServices.exists(_.msbServices.contains(ForeignExchange))) Some(foreignExchangeRule) else None,

--- a/app/services/RenewalService.scala
+++ b/app/services/RenewalService.scala
@@ -91,6 +91,7 @@ class RenewalService @Inject()(dataCache: DataCacheConnector) {
       Seq(
         if (msbServices.exists(_.msbServices.contains(TransmittingMoney))) Some(moneyTransmitterRule) else None,
         if (msbServices.exists(_.msbServices.contains(CurrencyExchange))) Some(currencyExchangeRule) else None,
+        if (msbServices.exists(_.msbServices.contains(ForeignExchange))) Some(foreignExchangeRule) else None,
         Some(standardRule)
       )
     }

--- a/app/services/RenewalService.scala
+++ b/app/services/RenewalService.scala
@@ -71,7 +71,7 @@ class RenewalService @Inject()(dataCache: DataCacheConnector) {
       activities.businessActivities collect {
         case MoneyServiceBusiness => checkCompletionOfMsb(renewal, businessMatching.msbServices)
         case HighValueDealing => checkCompletionOfHvd(renewal)
-        case AccountancyServices => renewal.customersOutsideUK.isDefined
+        case AccountancyServices => checkCompletionOfAsp(renewal)
       } match {
         case s if s.nonEmpty => s.forall(identity)
 
@@ -91,6 +91,22 @@ class RenewalService @Inject()(dataCache: DataCacheConnector) {
       Seq(
         if (msbServices.exists(_.msbServices.contains(TransmittingMoney))) Some(moneyTransmitterRule) else None,
         if (msbServices.exists(_.msbServices.contains(CurrencyExchange))) Some(currencyExchangeRule) else None,
+        Some(standardRule)
+      )
+    }
+
+    // Validate the renewal object using the composed chain of validation rules
+    validationRule.validate(renewal) match {
+      case Valid(_) => true
+      case r => false
+    }
+  }
+
+  private def checkCompletionOfAsp(renewal: Renewal) = {
+
+    val validationRule = compileOpt {
+      Seq(
+        Some(aspRule),
         Some(standardRule)
       )
     }

--- a/test/services/LandingServiceSpec.scala
+++ b/test/services/LandingServiceSpec.scala
@@ -38,13 +38,10 @@ import models.{AmendVariationRenewalResponse, Country, SubscriptionResponse, Vie
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
-import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
-import play.api.http.Status.OK
 import play.api.libs.json.Writes
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.cache.client.CacheMap
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.frontend.auth.{AuthContext, LoggedInUser}
 import utils.AmlsSpec
 
@@ -292,7 +289,7 @@ class LandingServiceSpec extends AmlsSpec with ScalaFutures with FutureAwaits wi
       Some(SendTheLargestAmountsOfMoney(Country("United Kingdom", "GB"),None,None)),
       Some(MostTransactions(List(Country("United Kingdom", "GB")))),
       Some(CETransactionsInLast12Months("12345678963")),
-      None,
+      Some(FXTransactionsInLast12Months("3987654321")),
       false)
 
     val cacheMap = CacheMap("", Map.empty)

--- a/test/services/RenewalServiceSpec.scala
+++ b/test/services/RenewalServiceSpec.scala
@@ -62,31 +62,45 @@ class RenewalServiceSpec extends AmlsSpec with MockitoSugar {
       dataCache.fetch[Renewal](eqTo(Renewal.key))(any(), any(), any())
     } thenReturn Future.successful(Some(renewalModel))
 
-//    val completeModel = Renewal(
-//      Some(InvolvedInOtherYes("test")),
-//      Some(BusinessTurnover.First),
-//      Some(AMLSTurnover.First),
-//      Some(CustomersOutsideUK(Some(Seq(Country("United Kingdom", "GB"))))),
-//      Some(PercentageOfCashPaymentOver15000.First),
-//      Some(ReceiveCashPayments(Some(PaymentMethods(true, true, Some("other"))))),
-//      Some(TotalThroughput("01")),
-//      Some(WhichCurrencies(Seq("EUR"), None, None, None, None)),
-//      Some(TransactionsInLast12Months("1500")),
-//      Some(SendTheLargestAmountsOfMoney(Country("us", "US"))),
-//      Some(MostTransactions(Seq(Country("United Kingdom", "GB")))),
-//      Some(CETransactionsInLast12Months("123")),
-//      Some(FXTransactionsInLast12Months("456")),
-//      true,
-//      Some(SendMoneyToOtherCountry(true))
-//    )
-
-    def aspComplete(renewalModel: Renewal) = ???
-    def hvdComplete(renewalModel: Renewal) = ???
-    def msbBasicComplete(renewalModel: Renewal) = ???
-    def mtComplete(renewalModel: Renewal) = ???
-    def ceComplete(renewalModel: Renewal) = ???
-    def fxComplete(renewalModel: Renewal) = ???
-    def standardComplete(renewalModel: Renewal) = ???
+    def aspComplete(renewalModel: Renewal): Renewal = {
+      renewalModel.copy(
+        customersOutsideUK = Some(CustomersOutsideUK(Some(Seq(Country("United Kingdom", "GB")))))
+      )
+    }
+    def hvdComplete(renewalModel: Renewal): Renewal = {
+      renewalModel.copy(
+        customersOutsideUK = Some(CustomersOutsideUK(Some(Seq(Country("United Kingdom", "GB"))))),
+        percentageOfCashPaymentOver15000 = Some(PercentageOfCashPaymentOver15000.First),
+        receiveCashPayments = Some(ReceiveCashPayments(Some(PaymentMethods(true, true, Some("other")))))
+      )
+    }
+    def mtComplete(renewalModel: Renewal): Renewal = {
+      renewalModel.copy(
+        sendMoneyToOtherCountry = Some(SendMoneyToOtherCountry(true)),
+        transactionsInLast12Months = Some(TransactionsInLast12Months("1500")),
+        sendTheLargestAmountsOfMoney = Some(SendTheLargestAmountsOfMoney(Country("us", "US"))),
+        mostTransactions = Some(MostTransactions(Seq(Country("United Kingdom", "GB"))))
+      )
+    }
+    def ceComplete(renewalModel: Renewal): Renewal = {
+      renewalModel.copy(
+        whichCurrencies = Some(WhichCurrencies(Seq("EUR"), None, None, None, None)),
+        ceTransactionsInLast12Months = Some(CETransactionsInLast12Months("123"))
+      )
+    }
+    def fxComplete(renewalModel: Renewal): Renewal = {
+      renewalModel.copy(
+        fxTransactionsInLast12Months = Some(FXTransactionsInLast12Months("456"))
+      )
+    }
+    def standardComplete(renewalModel: Renewal): Renewal = {
+      renewalModel.copy(
+        involvedInOtherActivities = Some(InvolvedInOtherYes("test")),
+        turnover = Some(AMLSTurnover.First),
+        businessTurnover = Some(BusinessTurnover.First),
+        hasAccepted = true
+      )
+    }
   }
 
   "The renewal service" must {
@@ -106,23 +120,13 @@ class RenewalServiceSpec extends AmlsSpec with MockitoSugar {
       "the renewal is complete and has been started" in new Fixture {
         setupBusinessMatching(Set(MoneyServiceBusiness, HighValueDealing), Set(CurrencyExchange, TransmittingMoney))
 
-        val completeModel = Renewal(
-          Some(InvolvedInOtherYes("test")),
-          Some(BusinessTurnover.First),
-          Some(AMLSTurnover.First),
-          Some(CustomersOutsideUK(Some(Seq(Country("United Kingdom", "GB"))))),
-          Some(PercentageOfCashPaymentOver15000.First),
-          Some(ReceiveCashPayments(Some(PaymentMethods(true, true, Some("other"))))),
-          Some(TotalThroughput("01")),
-          Some(WhichCurrencies(Seq("EUR"), None, None, None, None)),
-          Some(TransactionsInLast12Months("1500")),
-          Some(SendTheLargestAmountsOfMoney(Country("us", "US"))),
-          Some(MostTransactions(Seq(Country("United Kingdom", "GB")))),
-          Some(CETransactionsInLast12Months("123")),
-          Some(FXTransactionsInLast12Months("456")),
-          true,
-          Some(SendMoneyToOtherCountry(true))
-        )
+        var completeModel: Renewal = Renewal(hasChanged = true)
+        completeModel = standardComplete(completeModel)
+        completeModel = aspComplete(completeModel)
+        completeModel = hvdComplete(completeModel)
+        completeModel = mtComplete(completeModel)
+        completeModel = ceComplete(completeModel)
+        completeModel = fxComplete(completeModel)
 
         setUpRenewal(completeModel)
 

--- a/test/services/RenewalServiceSpec.scala
+++ b/test/services/RenewalServiceSpec.scala
@@ -61,6 +61,32 @@ class RenewalServiceSpec extends AmlsSpec with MockitoSugar {
     def setUpRenewal(renewalModel: Renewal) = when {
       dataCache.fetch[Renewal](eqTo(Renewal.key))(any(), any(), any())
     } thenReturn Future.successful(Some(renewalModel))
+
+//    val completeModel = Renewal(
+//      Some(InvolvedInOtherYes("test")),
+//      Some(BusinessTurnover.First),
+//      Some(AMLSTurnover.First),
+//      Some(CustomersOutsideUK(Some(Seq(Country("United Kingdom", "GB"))))),
+//      Some(PercentageOfCashPaymentOver15000.First),
+//      Some(ReceiveCashPayments(Some(PaymentMethods(true, true, Some("other"))))),
+//      Some(TotalThroughput("01")),
+//      Some(WhichCurrencies(Seq("EUR"), None, None, None, None)),
+//      Some(TransactionsInLast12Months("1500")),
+//      Some(SendTheLargestAmountsOfMoney(Country("us", "US"))),
+//      Some(MostTransactions(Seq(Country("United Kingdom", "GB")))),
+//      Some(CETransactionsInLast12Months("123")),
+//      Some(FXTransactionsInLast12Months("456")),
+//      true,
+//      Some(SendMoneyToOtherCountry(true))
+//    )
+
+    def aspComplete(renewalModel: Renewal) = ???
+    def hvdComplete(renewalModel: Renewal) = ???
+    def msbBasicComplete(renewalModel: Renewal) = ???
+    def mtComplete(renewalModel: Renewal) = ???
+    def ceComplete(renewalModel: Renewal) = ???
+    def fxComplete(renewalModel: Renewal) = ???
+    def standardComplete(renewalModel: Renewal) = ???
   }
 
   "The renewal service" must {

--- a/test/services/RenewalServiceSpec.scala
+++ b/test/services/RenewalServiceSpec.scala
@@ -24,21 +24,16 @@ import models.registrationprogress.{Completed, NotStarted, Section, Started}
 import models.renewal._
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
-import org.scalatest.MustMatchers
 import org.scalatest.mock.MockitoSugar
-import org.scalatestplus.play.OneAppPerSuite
-import play.api.inject.bind
-import play.api.inject.guice.GuiceInjectorBuilder
 import play.api.mvc.Call
-import play.api.test.FakeApplication
 import play.api.test.Helpers._
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.frontend.auth.AuthContext
-import utils.{AuthorisedFixture, AmlsSpec}
+import utils.{AmlsSpec, AuthorisedFixture}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import uk.gov.hmrc.http.HeaderCarrier
 
 
 class RenewalServiceSpec extends AmlsSpec with MockitoSugar {
@@ -52,29 +47,7 @@ class RenewalServiceSpec extends AmlsSpec with MockitoSugar {
 
     val service = new RenewalService(dataCache)
 
-    val completeModel = Renewal(
-      Some(InvolvedInOtherYes("test")),
-      Some(BusinessTurnover.First),
-      Some(AMLSTurnover.First),
-      Some(CustomersOutsideUK(Some(Seq(Country("United Kingdom", "GB"))))),
-      Some(PercentageOfCashPaymentOver15000.First),
-      Some(ReceiveCashPayments(Some(PaymentMethods(true, true, Some("other"))))),
-      Some(TotalThroughput("01")),
-      Some(WhichCurrencies(Seq("EUR"), None, None, None, None)),
-      Some(TransactionsInLast12Months("1500")),
-      Some(SendTheLargestAmountsOfMoney(Country("us", "US"))),
-      Some(MostTransactions(Seq(Country("United Kingdom", "GB")))),
-      Some(CETransactionsInLast12Months("123")),
-      None,
-      true,
-      Some(SendMoneyToOtherCountry(true))
-    )
-
     val mockCacheMap = mock[CacheMap]
-
-    //val msbModel = moneyServiceBusiness(sendMoneyToOtherCountry = Some(SendMoneyToOtherCountry(true)))
-    //val msbModelDoNotSendMoneyToOtherCountries = moneyServiceBusiness(sendMoneyToOtherCountry = Some(SendMoneyToOtherCountry(false)))
-
   }
 
   "The renewal service" must {
@@ -106,6 +79,24 @@ class RenewalServiceSpec extends AmlsSpec with MockitoSugar {
             ))),
             msbServices = Some(BusinessMatchingMsbServices(Set(CurrencyExchange, TransmittingMoney)))
           )))
+
+        val completeModel = Renewal(
+          Some(InvolvedInOtherYes("test")),
+          Some(BusinessTurnover.First),
+          Some(AMLSTurnover.First),
+          Some(CustomersOutsideUK(Some(Seq(Country("United Kingdom", "GB"))))),
+          Some(PercentageOfCashPaymentOver15000.First),
+          Some(ReceiveCashPayments(Some(PaymentMethods(true, true, Some("other"))))),
+          Some(TotalThroughput("01")),
+          Some(WhichCurrencies(Seq("EUR"), None, None, None, None)),
+          Some(TransactionsInLast12Months("1500")),
+          Some(SendTheLargestAmountsOfMoney(Country("us", "US"))),
+          Some(MostTransactions(Seq(Country("United Kingdom", "GB")))),
+          Some(CETransactionsInLast12Months("123")),
+          Some(FXTransactionsInLast12Months("456")),
+          true,
+          Some(SendMoneyToOtherCountry(true))
+        )
 
         when {
           dataCache.fetch[Renewal](eqTo(Renewal.key))(any(), any(), any())

--- a/test/services/RenewalServiceSpec.scala
+++ b/test/services/RenewalServiceSpec.scala
@@ -155,30 +155,20 @@ class RenewalServiceSpec extends AmlsSpec with MockitoSugar {
     }
   }
 
-  "isRenewalComplete" must {
+  "isRenewalCompleteOld" must {
     "be true" when {
       "it is an HVD and customers outside the UK is set" in new Fixture {
         setupBusinessMatching(Set(HighValueDealing))
 
-        val model = Renewal(
-          Some(InvolvedInOtherYes("test")),
-          Some(BusinessTurnover.First),
-          Some(AMLSTurnover.First),
-          Some(CustomersOutsideUK(Some(Seq(Country("United Kingdom", "GB"))))),
-          Some(PercentageOfCashPaymentOver15000.First),
-          Some(ReceiveCashPayments(Some(PaymentMethods(true, true, Some("other"))))),
-          None,
-          None,
-          None,
-          None,
-          None,
-          None,
-          None,
-          hasChanged = true,
-          None
+        var model: Renewal = Renewal(hasChanged = true)
+        model = standardComplete(model)
+        val hvdComplete = model.copy(
+          customersOutsideUK = Some(CustomersOutsideUK(Some(Seq(Country("United Kingdom", "GB"))))),
+          percentageOfCashPaymentOver15000 = Some(PercentageOfCashPaymentOver15000.First),
+          receiveCashPayments = Some(ReceiveCashPayments(Some(PaymentMethods(true, true, Some("other")))))
         )
 
-        await(service.isRenewalComplete(model)) mustBe true
+        await(service.isRenewalComplete(hvdComplete)) mustBe true
       }
 
       "it is an ASP and customers outside the UK is set" in new Fixture {


### PR DESCRIPTION
# PR Details

Validate FX question is answered on renewal submission

## Description

*Flattens RenewalServiceSpec
*Increases unit tests in RenewalServiceSpec
*Moves ASP rules to Renewal model
* Adds validation for FX answer if renewing FX
* BUG- Renewal does not validate MSB Question TotalThroughput

## Related / Dependant PRs?

N/A

## How Has This Been Tested?

* Unit tests

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.