### PR TITLE
Bumped library version according to service catalogue

### DIFF
--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -12,7 +12,7 @@ private object AppDependencies {
   import play.sbt.PlayImport._
   import play.core.PlayVersion
 
-  private val frontendBootstrapVersion = "8.25.0"
+  private val frontendBootstrapVersion = "8.26.0"
   private val playPartialsVersion = "6.1.0"
   private val httpCachingClientVersion = "7.1.0"
   private val playWhitelistFilterVersion = "2.0.0"


### PR DESCRIPTION
## Description

Bumped version of `frontend-bootstrap` to 8.26.0 according to the [service catalog library report](https://catalogue.tax.service.gov.uk/service/amls-frontend)

## Related / Dependant PRs?

n/a

## How Has This Been Tested?

* Unit test suite run
* Smoke test through partial acceptance test regression run

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [ ] Appropriate labels added.