### PR TITLE
HOTFIX: Remove cache from the right place on redirect

### DIFF
--- a/test/controllers/LandingControllerSpec.scala
+++ b/test/controllers/LandingControllerSpec.scala
@@ -216,6 +216,7 @@ class LandingControllerWithoutAmendmentsSpec extends AmlsSpec {
 
           when(controller.landingService.cacheMap(any(), any(), any())) thenReturn Future.successful(Some(CacheMap("", Map.empty)))
           when(emptyCacheMap.getEntry[BusinessMatching](BusinessMatching.key)).thenReturn(None)
+          when(controller.cacheConnector.remove(any(), any())).thenReturn(Future.successful(true))
 
           val result = controller.get()(request)
           status(result) must be(SEE_OTHER)
@@ -233,6 +234,7 @@ class LandingControllerWithoutAmendmentsSpec extends AmlsSpec {
 
           when(controller.landingService.cacheMap(any(), any(), any())) thenReturn Future.successful(Some(CacheMap("", Map.empty)))
           when(emptyCacheMap.getEntry[BusinessMatching](BusinessMatching.key)).thenReturn(Some(testBusinessMatching))
+          when(controller.cacheConnector.remove(any(), any())).thenReturn(Future.successful(true))
 
           val result = controller.get()(request)
           status(result) must be(SEE_OTHER)
@@ -243,24 +245,21 @@ class LandingControllerWithoutAmendmentsSpec extends AmlsSpec {
 
       "pre application must remove save4later" when {
         "the business matching is incomplete" in new Fixture {
-          val cachmap = mock[CacheMap]
+          val cacheMap = mock[CacheMap]
           val httpResponse = mock[HttpResponse]
-
           val complete = mock[BusinessMatching]
 
-          when(httpResponse.status) thenReturn (NO_CONTENT)
+          when(httpResponse.status) thenReturn NO_CONTENT
+          when(controller.cacheConnector.remove(any(), any())).thenReturn(Future.successful(true))
 
-          when(controller.shortLivedCache.remove(any())(any(), any())) thenReturn Future.successful(httpResponse)
-
-          when(controller.landingService.cacheMap(any(), any(), any())) thenReturn Future.successful(Some(cachmap))
+          when(controller.landingService.cacheMap(any(), any(), any())) thenReturn Future.successful(Some(cacheMap))
           when(complete.isComplete) thenReturn false
-          when(cachmap.getEntry[BusinessMatching](any())(any())).thenReturn(Some(complete))
-          when(cachmap.getEntry[AboutTheBusiness](AboutTheBusiness.key)).thenReturn(Some(completeATB))
+          when(cacheMap.getEntry[BusinessMatching](any())(any())).thenReturn(Some(complete))
+          when(cacheMap.getEntry[AboutTheBusiness](AboutTheBusiness.key)).thenReturn(Some(completeATB))
 
           val result = controller.get()(request)
           status(result) must be(SEE_OTHER)
           redirectLocation(result) mustBe Some(controllers.routes.LandingController.get().url)
-
         }
       }
 


### PR DESCRIPTION
Since migrating to Mongo, it does not make sense to the use the ShortLivedCache.remove method, as this only removes data from Save4Later.

This commit changes that to remove it from the data cache connector, which will ultimately remove the data from Mongo and Save4Later.

This could potentially fix a live issue we're seeing where the start page constantly redirects to itself.

## Related / Dependant PRs?

n/a

## How Has This Been Tested?

On `master`, manually removed data from the database and ran `/`, which resulted in a redirect loop. Switched to the hotfix branch and re-ran the test, confirmed that the user is now correctly redirected to the business matching section without a redirect loop.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.