### PR TITLE
AMLS-4219: Remove Save4Later cache entry on migration event

### DIFF
--- a/app/connectors/cache/DataCacheConnectorMigrator.scala
+++ b/app/connectors/cache/DataCacheConnectorMigrator.scala
@@ -29,7 +29,7 @@ import scala.concurrent.Future
 
 class DataCacheConnectorMigrator(primaryCache: CacheConnector, fallbackCache: CacheConnector) extends CacheConnector with Conversions {
 
-  private def log(msg: String): Unit = Logger.info(s"[DataCacheConnectorMigrator] $msg")
+  private def warn(msg: String): Unit = Logger.warn(s"[DataCacheConnectorMigrator] $msg")
 
   /**
     * Fetches T from the primary cache. If the data is not available in the primary cache, the data is

--- a/test/connectors/cache/DataCacheConnectorMigratorSpec.scala
+++ b/test/connectors/cache/DataCacheConnectorMigratorSpec.scala
@@ -106,6 +106,10 @@ class DataCacheConnectorMigratorSpec extends AmlsSpec
           primaryConnector.saveAll(emptyCache)
         } thenReturn Future.successful(Cache(emptyCache))
 
+        when {
+          fallbackConnector.remove(any(), any())
+        } thenReturn Future.successful(true)
+
         val result = migrator.fetchAll
 
         whenReady(result) { result =>
@@ -129,6 +133,10 @@ class DataCacheConnectorMigratorSpec extends AmlsSpec
         when {
           primaryConnector.saveAll(cache)
         } thenReturn Future.successful(Cache("", Map.empty))
+
+        when {
+          fallbackConnector.remove(any(), any())
+        } thenReturn Future.successful(true)
 
         val result = migrator.fetch[Model](key)
 
@@ -182,16 +190,11 @@ class DataCacheConnectorMigratorSpec extends AmlsSpec
         primaryConnector.remove(any(), any())
       } thenReturn Future.successful(true)
 
-      when {
-        fallbackConnector.remove(any(), any())
-      } thenReturn Future.successful(true)
-
       val result = migrator.remove
 
       whenReady(result) { _ mustBe true }
 
       verify(primaryConnector).remove(any(), any())
-      verify(fallbackConnector).remove(any(), any())
     }
 
     "update the data in the new connector" in new Fixture {


### PR DESCRIPTION
This fixes a live issue where users coming into the service for the first time (or at least having not previously submitted) would constantly have their Save4Later data migrated whenever a database read was performed.

To fix this, the Save4Later cache is now removed when the migration has completed, which means that there is no longer anything to migrate from once it has been done once and their data would never again be overwritten.

## Related / Dependant PRs?

n/a

## How Has This Been Tested?

* Manual testing locally by creating some data in Save4Later, turning Mongo 'on' and then attempting to fill out an additional section of the application
* Unit testing to verify that the data in `fallbackCache` is removed once the migration has taken place

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.