### PR TITLE
Amls 4158

### DIFF
--- a/app/controllers/msb/MostTransactionsController.scala
+++ b/app/controllers/msb/MostTransactionsController.scala
@@ -73,7 +73,7 @@ class MostTransactionsController @Inject()(val authConnector: AuthConnector = AM
                 register <- cacheMap.getEntry[ServiceChangeRegister](ServiceChangeRegister.key) orElse Some(ServiceChangeRegister())
               } yield {
                 cacheConnector.save[MoneyServiceBusiness](MoneyServiceBusiness.key,
-                  msb.mostTransactions(data)
+                  msb.mostTransactions(Some(data))
                 ) flatMap {
                   _ => routing(services.msbServices, register, msb, edit)
                 }

--- a/app/controllers/msb/MostTransactionsController.scala
+++ b/app/controllers/msb/MostTransactionsController.scala
@@ -44,16 +44,13 @@ class MostTransactionsController @Inject()(val authConnector: AuthConnector = AM
   def get(edit: Boolean = false) = Authorised.async {
     implicit authContext =>
       implicit request =>
-        ControllerHelper.allowedToEdit(MsbActivity, Some(TransmittingMoney)) flatMap {
-          case true => cacheConnector.fetch[MoneyServiceBusiness](MoneyServiceBusiness.key) map {
-            response =>
-              val form = (for {
-                msb <- response
-                transactions <- msb.mostTransactions
-              } yield Form2[MostTransactions](transactions)).getOrElse(EmptyForm)
-              Ok(views.html.msb.most_transactions(form, edit))
-          }
-          case false => Future.successful(NotFound(notFoundView))
+        cacheConnector.fetch[MoneyServiceBusiness](MoneyServiceBusiness.key) map {
+          response =>
+            val form = (for {
+              msb <- response
+              transactions <- msb.mostTransactions
+            } yield Form2[MostTransactions](transactions)).getOrElse(EmptyForm)
+            Ok(views.html.msb.most_transactions(form, edit))
         }
   }
 

--- a/app/controllers/msb/SendMoneyToOtherCountryController.scala
+++ b/app/controllers/msb/SendMoneyToOtherCountryController.scala
@@ -65,15 +65,16 @@ class SendMoneyToOtherCountryController @Inject()(val dataCacheConnector: DataCa
                 register <- cache.getEntry[ServiceChangeRegister](ServiceChangeRegister.key) orElse Some(ServiceChangeRegister())
               } yield {
                 data.money match {
-                  case true => dataCacheConnector.save(MoneyServiceBusiness.key, msb
-                    .sendMoneyToOtherCountry(data)) map {
-                      _ => routing(data.money, services.msbServices,register, msb, edit)
+                  case true => dataCacheConnector.save(MoneyServiceBusiness.key, msb.sendMoneyToOtherCountry(data)) map {
+                    _ => routing(data.money, services.msbServices,register, msb, edit)
                   }
-                  case _ => dataCacheConnector.save(MoneyServiceBusiness.key, msb
+                  case _ => val newModel = msb
                     .sendMoneyToOtherCountry(data)
                     .sendTheLargestAmountsOfMoney(None)
-                    .mostTransactions(None)) map {
-                      _ => routing(data.money, services.msbServices,register, msb, edit)
+                    .mostTransactions(None)
+
+                    dataCacheConnector.save(MoneyServiceBusiness.key, newModel) map {
+                    _ => routing(data.money, services.msbServices,register, newModel, edit)
                   }
                 }
               }

--- a/app/controllers/msb/SendMoneyToOtherCountryController.scala
+++ b/app/controllers/msb/SendMoneyToOtherCountryController.scala
@@ -64,8 +64,17 @@ class SendMoneyToOtherCountryController @Inject()(val dataCacheConnector: DataCa
                 services <- bm.msbServices
                 register <- cache.getEntry[ServiceChangeRegister](ServiceChangeRegister.key) orElse Some(ServiceChangeRegister())
               } yield {
-                dataCacheConnector.save(MoneyServiceBusiness.key, msb.sendMoneyToOtherCountry(data)) map { _ =>
-                  routing(data.money, services.msbServices,register, msb, edit)
+                data.money match {
+                  case true => dataCacheConnector.save(MoneyServiceBusiness.key, msb
+                    .sendMoneyToOtherCountry(data)) map {
+                      _ => routing(data.money, services.msbServices,register, msb, edit)
+                  }
+                  case _ => dataCacheConnector.save(MoneyServiceBusiness.key, msb
+                    .sendMoneyToOtherCountry(data)
+                    .sendTheLargestAmountsOfMoney(None)
+                    .mostTransactions(None)) map {
+                      _ => routing(data.money, services.msbServices,register, msb, edit)
+                  }
                 }
               }
               result.map(_.flatMap(identity)) getOrElse Future.failed(new Exception("Unable to retrieve sufficient data"))

--- a/app/controllers/msb/SendTheLargestAmountsOfMoneyController.scala
+++ b/app/controllers/msb/SendTheLargestAmountsOfMoneyController.scala
@@ -69,7 +69,7 @@ class SendTheLargestAmountsOfMoneyController @Inject()(val authConnector: AuthCo
             msb <-
             cacheConnector.fetch[MoneyServiceBusiness](MoneyServiceBusiness.key)
             _ <- cacheConnector.save[MoneyServiceBusiness](MoneyServiceBusiness.key,
-              msb.sendTheLargestAmountsOfMoney(data)
+              msb.sendTheLargestAmountsOfMoney(Some(data))
             )
           } yield edit match {
             case true if msb.mostTransactions.isDefined =>

--- a/app/controllers/msb/SendTheLargestAmountsOfMoneyController.scala
+++ b/app/controllers/msb/SendTheLargestAmountsOfMoneyController.scala
@@ -40,22 +40,13 @@ class SendTheLargestAmountsOfMoneyController @Inject()(val authConnector: AuthCo
 
   def get(edit: Boolean = false) = Authorised.async {
     implicit authContext => implicit request =>
-      ControllerHelper.allowedToEdit(MsbActivity, Some(TransmittingMoney)) flatMap {
-        case true => cacheConnector.fetch[MoneyServiceBusiness](MoneyServiceBusiness.key) map {
-          response =>
-            val form: Form2[SendTheLargestAmountsOfMoney] = (for {
-              msb <- response
-              amount <- msb.sendTheLargestAmountsOfMoney
-            } yield Form2[SendTheLargestAmountsOfMoney](amount)).getOrElse(EmptyForm)
-            Ok(send_largest_amounts_of_money(form, edit))
-        }
-        case _ => cacheConnector.fetch[ServiceChangeRegister](ServiceChangeRegister.key) map {
-          case Some(r) if r.addedSubSectors.fold(false)(_.contains(CurrencyExchange)) =>
-            Redirect(routes.CETransactionsInNext12MonthsController.get(edit))
-          case Some(r) if r.addedSubSectors.fold(false)(_.contains(ForeignExchange)) =>
-            Redirect(routes.FXTransactionsInNext12MonthsController.get(edit))
-          case _ => Redirect(routes.SummaryController.get())
-        }
+      cacheConnector.fetch[MoneyServiceBusiness](MoneyServiceBusiness.key) map {
+        response =>
+          val form: Form2[SendTheLargestAmountsOfMoney] = (for {
+            msb <- response
+            amount <- msb.sendTheLargestAmountsOfMoney
+          } yield Form2[SendTheLargestAmountsOfMoney](amount)).getOrElse(EmptyForm)
+          Ok(send_largest_amounts_of_money(form, edit))
       }
   }
 

--- a/app/models/moneyservicebusiness/MoneyServiceBusiness.scala
+++ b/app/models/moneyservicebusiness/MoneyServiceBusiness.scala
@@ -41,41 +41,41 @@ case class MoneyServiceBusiness(
                                ) {
 
   def throughput(p: ExpectedThroughput): MoneyServiceBusiness =
-    this.copy(throughput = Some(p), hasChanged = hasChanged || !this.throughput.contains(p), hasAccepted = this.throughput.contains(p))
+    this.copy(throughput = Some(p), hasChanged = hasChanged || !this.throughput.contains(p), hasAccepted = hasAccepted && this.throughput.contains(p))
 
   def whichCurrencies(p: WhichCurrencies): MoneyServiceBusiness =
-    this.copy(whichCurrencies = Some(p), hasChanged = hasChanged || !this.whichCurrencies.contains(p), hasAccepted = this.whichCurrencies.contains(p))
+    this.copy(whichCurrencies = Some(p), hasChanged = hasChanged || !this.whichCurrencies.contains(p), hasAccepted = hasAccepted && this.whichCurrencies.contains(p))
 
   def businessUseAnIPSP(p: BusinessUseAnIPSP): MoneyServiceBusiness =
-    this.copy(businessUseAnIPSP = Some(p), hasChanged = hasChanged || !this.businessUseAnIPSP.contains(p), hasAccepted = this.businessUseAnIPSP.contains(p))
+    this.copy(businessUseAnIPSP = Some(p), hasChanged = hasChanged || !this.businessUseAnIPSP.contains(p), hasAccepted = hasAccepted && this.businessUseAnIPSP.contains(p))
 
   def identifyLinkedTransactions(p: IdentifyLinkedTransactions): MoneyServiceBusiness =
-    this.copy(identifyLinkedTransactions = Some(p), hasChanged = hasChanged || !this.identifyLinkedTransactions.contains(p), hasAccepted = this.identifyLinkedTransactions.contains(p))
+    this.copy(identifyLinkedTransactions = Some(p), hasChanged = hasChanged || !this.identifyLinkedTransactions.contains(p), hasAccepted = hasAccepted && this.identifyLinkedTransactions.contains(p))
 
   def fundsTransfer(p: FundsTransfer): MoneyServiceBusiness =
-    this.copy(fundsTransfer = Some(p), hasChanged = hasChanged || !this.fundsTransfer.contains(p), hasAccepted = this.fundsTransfer.contains(p))
+    this.copy(fundsTransfer = Some(p), hasChanged = hasChanged || !this.fundsTransfer.contains(p), hasAccepted = hasAccepted && this.fundsTransfer.contains(p))
 
   def branchesOrAgents(p: BranchesOrAgents): MoneyServiceBusiness =
-    this.copy(branchesOrAgents = Some(p), hasChanged = hasChanged || !this.branchesOrAgents.contains(p), hasAccepted = this.branchesOrAgents.contains(p))
+    this.copy(branchesOrAgents = Some(p), hasChanged = hasChanged || !this.branchesOrAgents.contains(p), hasAccepted = hasAccepted && this.branchesOrAgents.contains(p))
 
   def sendMoneyToOtherCountry(p: SendMoneyToOtherCountry): MoneyServiceBusiness =
-    this.copy(sendMoneyToOtherCountry = Some(p), hasChanged = hasChanged || !this.sendMoneyToOtherCountry.contains(p), hasAccepted = this.sendMoneyToOtherCountry.contains(p))
+    this.copy(sendMoneyToOtherCountry = Some(p), hasChanged = hasChanged || !this.sendMoneyToOtherCountry.contains(p), hasAccepted = hasAccepted && this.sendMoneyToOtherCountry.contains(p))
 
   def sendTheLargestAmountsOfMoney(p: Option[SendTheLargestAmountsOfMoney]): MoneyServiceBusiness =
     this.copy(sendTheLargestAmountsOfMoney = p, hasChanged = hasChanged || !this.sendTheLargestAmountsOfMoney.equals(p),
-      hasAccepted = this.sendTheLargestAmountsOfMoney.equals(p))
+      hasAccepted = hasAccepted && this.sendTheLargestAmountsOfMoney.equals(p))
 
   def mostTransactions(p: Option[MostTransactions]): MoneyServiceBusiness =
-    this.copy(mostTransactions = p, hasChanged = hasChanged || !this.mostTransactions.equals(p), hasAccepted = this.mostTransactions.equals(p))
+    this.copy(mostTransactions = p, hasChanged = hasChanged || !this.mostTransactions.equals(p), hasAccepted = hasAccepted && this.mostTransactions.equals(p))
 
   def transactionsInNext12Months(p: TransactionsInNext12Months): MoneyServiceBusiness =
-    this.copy(transactionsInNext12Months = Some(p), hasChanged = hasChanged || !this.transactionsInNext12Months.contains(p), hasAccepted = this.transactionsInNext12Months.contains(p))
+    this.copy(transactionsInNext12Months = Some(p), hasChanged = hasChanged || !this.transactionsInNext12Months.contains(p), hasAccepted = hasAccepted && this.transactionsInNext12Months.contains(p))
 
   def ceTransactionsInNext12Months(p: CETransactionsInNext12Months): MoneyServiceBusiness =
-    this.copy(ceTransactionsInNext12Months = Some(p), hasChanged = hasChanged || !this.ceTransactionsInNext12Months.contains(p), hasAccepted = this.ceTransactionsInNext12Months.contains(p))
+    this.copy(ceTransactionsInNext12Months = Some(p), hasChanged = hasChanged || !this.ceTransactionsInNext12Months.contains(p), hasAccepted = hasAccepted && this.ceTransactionsInNext12Months.contains(p))
 
   def fxTransactionsInNext12Months(p: FXTransactionsInNext12Months): MoneyServiceBusiness =
-    this.copy(fxTransactionsInNext12Months = Some(p), hasChanged = hasChanged || !this.fxTransactionsInNext12Months.contains(p), hasAccepted = this.fxTransactionsInNext12Months.contains(p))
+    this.copy(fxTransactionsInNext12Months = Some(p), hasChanged = hasChanged || !this.fxTransactionsInNext12Months.contains(p), hasAccepted = hasAccepted && this.fxTransactionsInNext12Months.contains(p))
 
   private def allComplete: Boolean =
     this.throughput.isDefined &&

--- a/app/models/moneyservicebusiness/MoneyServiceBusiness.scala
+++ b/app/models/moneyservicebusiness/MoneyServiceBusiness.scala
@@ -61,11 +61,12 @@ case class MoneyServiceBusiness(
   def sendMoneyToOtherCountry(p: SendMoneyToOtherCountry): MoneyServiceBusiness =
     this.copy(sendMoneyToOtherCountry = Some(p), hasChanged = hasChanged || !this.sendMoneyToOtherCountry.contains(p), hasAccepted = this.sendMoneyToOtherCountry.contains(p))
 
-  def sendTheLargestAmountsOfMoney(p: SendTheLargestAmountsOfMoney): MoneyServiceBusiness =
-    this.copy(sendTheLargestAmountsOfMoney = Some(p), hasChanged = hasChanged || !this.sendTheLargestAmountsOfMoney.contains(p), hasAccepted = this.sendTheLargestAmountsOfMoney.contains(p))
+  def sendTheLargestAmountsOfMoney(p: Option[SendTheLargestAmountsOfMoney]): MoneyServiceBusiness =
+    this.copy(sendTheLargestAmountsOfMoney = p, hasChanged = hasChanged || !this.sendTheLargestAmountsOfMoney.equals(p),
+      hasAccepted = this.sendTheLargestAmountsOfMoney.equals(p))
 
-  def mostTransactions(p: MostTransactions): MoneyServiceBusiness =
-    this.copy(mostTransactions = Some(p), hasChanged = hasChanged || !this.mostTransactions.contains(p), hasAccepted = this.mostTransactions.contains(p))
+  def mostTransactions(p: Option[MostTransactions]): MoneyServiceBusiness =
+    this.copy(mostTransactions = p, hasChanged = hasChanged || !this.mostTransactions.equals(p), hasAccepted = this.mostTransactions.equals(p))
 
   def transactionsInNext12Months(p: TransactionsInNext12Months): MoneyServiceBusiness =
     this.copy(transactionsInNext12Months = Some(p), hasChanged = hasChanged || !this.transactionsInNext12Months.contains(p), hasAccepted = this.transactionsInNext12Months.contains(p))

--- a/test/controllers/msb/MostTransactionsControllerSpec.scala
+++ b/test/controllers/msb/MostTransactionsControllerSpec.scala
@@ -107,13 +107,15 @@ class MostTransactionsControllerSpec extends AmlsSpec with MockitoSugar {
       }
     }
 
-    "redirect to Page not found" when {
-      "application is in variation mode" in new Fixture {
-        mockIsNewActivity(false)
+    "continue to show the correct view" when {
+      "application is in variation mode and no service has been added" in new Fixture {
         mockApplicationStatus(SubmissionDecisionApproved)
+        mockCacheFetch[MoneyServiceBusiness](None, Some(MoneyServiceBusiness.key))
+        mockIsNewActivity(false)
 
         val result = controller.get()(request)
-        status(result) must be(NOT_FOUND)
+        status(result) must be(OK)
+        contentAsString(result) must include(Messages("msb.most.transactions.title"))
       }
     }
 

--- a/test/controllers/msb/SendMoneyToOtherCountryControllerSpec.scala
+++ b/test/controllers/msb/SendMoneyToOtherCountryControllerSpec.scala
@@ -152,6 +152,8 @@ class SendMoneyToOtherCountryControllerSpec extends AmlsSpec with MockitoSugar {
 
       val outgoingModel = incomingModel.copy(
         sendMoneyToOtherCountry = Some(SendMoneyToOtherCountry(false)),
+        sendTheLargestAmountsOfMoney = None,
+        mostTransactions = None,
         hasChanged = true
       )
 
@@ -163,7 +165,6 @@ class SendMoneyToOtherCountryControllerSpec extends AmlsSpec with MockitoSugar {
 
       when(mockCacheMap.getEntry[BusinessMatching](BusinessMatching.key))
         .thenReturn(Some(BusinessMatching(msbServices = msbServices)))
-
 
       when(controller.dataCacheConnector.save[MoneyServiceBusiness](eqTo(MoneyServiceBusiness.key), eqTo(outgoingModel))
         (any(), any(), any())).thenReturn(Future.successful(emptyCache))

--- a/test/controllers/msb/SendTheLargestAmountsOfMoneyControllerSpec.scala
+++ b/test/controllers/msb/SendTheLargestAmountsOfMoneyControllerSpec.scala
@@ -78,7 +78,7 @@ class SendTheLargestAmountsOfMoneyControllerSpec extends AmlsSpec with MockitoSu
     }
 
     "continue to show the correct view" when {
-      "application is in variation mode but the service has just been added" in new Fixture {
+      "application is in variation mode and a service has just been added" in new Fixture {
         mockApplicationStatus(SubmissionDecisionApproved)
         mockCacheFetch[MoneyServiceBusiness](None, Some(MoneyServiceBusiness.key))
         mockIsNewActivity(true, Some(MoneyServiceBusinessActivity))
@@ -89,47 +89,15 @@ class SendTheLargestAmountsOfMoneyControllerSpec extends AmlsSpec with MockitoSu
       }
     }
 
-
-    "redirect to Page not found" when {
-      "application is in variation mode" in new Fixture {
-        mockIsNewActivity(false)
+    "continue to show the correct view" when {
+      "application is in variation mode and no service has been added" in new Fixture {
         mockApplicationStatus(SubmissionDecisionApproved)
+        mockCacheFetch[MoneyServiceBusiness](None, Some(MoneyServiceBusiness.key))
+        mockIsNewActivity(false)
 
         val result = controller.get()(request)
-        redirectLocation(result) mustBe Some(routes.SummaryController.get().url)
-      }
-    }
-
-    "redirect to CETransactionsInNext12Months" when {
-      "page is not editable and CurrencyExchange has been added" in new Fixture {
-        mockIsNewActivity(false)
-        mockApplicationStatus(SubmissionDecisionApproved)
-        mockCacheFetch(Some(ServiceChangeRegister(None, Some(Set(CurrencyExchange)))))
-
-        val result = controller.get()(request)
-        redirectLocation(result) mustBe Some(routes.CETransactionsInNext12MonthsController.get().url)
-      }
-    }
-
-    "redirect to CETransactionsInNext12Months" when {
-      "page is not editable and CurrencyExchange and ForeignExchange has been added" in new Fixture {
-        mockIsNewActivity(false)
-        mockApplicationStatus(SubmissionDecisionApproved)
-        mockCacheFetch(Some(ServiceChangeRegister(None, Some(Set(CurrencyExchange, ForeignExchange)))))
-
-        val result = controller.get()(request)
-        redirectLocation(result) mustBe Some(routes.CETransactionsInNext12MonthsController.get().url)
-      }
-    }
-
-    "redirect to FXTransactionsInNext12Months" when {
-      "page is not editable and ForeignExchange has been added" in new Fixture {
-        mockIsNewActivity(false)
-        mockApplicationStatus(SubmissionDecisionApproved)
-        mockCacheFetch(Some(ServiceChangeRegister(None, Some(Set(ForeignExchange)))))
-
-        val result = controller.get()(request)
-        redirectLocation(result) mustBe Some(routes.FXTransactionsInNext12MonthsController.get().url)
+        status(result) must be(OK)
+        contentAsString(result) must include(Messages("msb.send.the.largest.amounts.of.money.title"))
       }
     }
 


### PR DESCRIPTION
pre-application variation 
Its assumed the user is registered for MT and adds a new sub-sector. When they return to the application progess page and start the incomplete MSB section we ask again Do you send money to other countries?' if the user changes their answer from No to Yes the system doesn't ask 'Where do you expect to send the largest amounts of money?' and Where do you expect to send the most transactions? which it should be doing.

This ticket is to ensure if a user adds an additional sub sector and then changes their answer from No to Yes for Do you send money to other countries? that we ask *Where do you expect to send the largest amounts of money? and *Where do you expect to send the most transactions?

Correct behaviour

Scenario 1
Given a user is registered for MT and adds a new sub-sector. When they go through the incomplete MSB section we ask again Do you send money to other countries?' if they user changes their answer from No to Yes we should ask 'Where do you expect to send the largest amounts of money?' and then ask Where do you expect to send the most transactions? screenshot 1

Scenario 2
Given a user is registered for MT and adds a new sub-sector. When they go through the incomplete MSB section we ask again Do you send money to other countries?' if they user changes their answer from Yes to No we should remove the data for 'Where do you expect to send the largest amounts of money?' and Where do you expect to send the most transactions? and remove these questions from CYA

## How Has This Been Tested?

Unit testing, manual testing in development and automation has been corrected for this scenario and executed against development (this branch). 

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
