### PR TITLE
Amls 3884 - Clear section data when changing business activities for new submissions

### DIFF
--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -88,6 +88,7 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
                 isMsb(data, businessMatching.activities)
               )
               _ <- maybeRemoveAccountantForAMLSRegulations(savedModel)
+              // Add a removal clear section here....
             } yield savedModel) flatMap { savedActivities =>
               getData[ResponsiblePerson] flatMap { responsiblePeople =>
                 if(fitAndProperRequired(savedActivities)){

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -125,11 +125,15 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
                                                                                         previousBusinessActivities: Set[BusinessActivity],
                                                                                         currentBusinessActivities: Set[BusinessActivity]
                                                                                 )(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[Asp](previousBusinessActivities, currentBusinessActivities, AccountancyServices, Asp.key, Asp())
-    removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[EstateAgentBusiness](previousBusinessActivities, currentBusinessActivities, EstateAgentBusinessService, EstateAgentBusiness.key, EstateAgentBusiness())
-    removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[Hvd](previousBusinessActivities, currentBusinessActivities, HighValueDealing, Hvd.key, Hvd())
-    removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[MSBModel](previousBusinessActivities, currentBusinessActivities, MoneyServiceBusiness, MSBModel.key, MSBModel())
-    removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[Tcsp](previousBusinessActivities, currentBusinessActivities, TrustAndCompanyServices, Tcsp.key, Tcsp())
+    val result: Future[Any] = for {
+      _ <- removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[Asp](previousBusinessActivities, currentBusinessActivities, AccountancyServices, Asp.key, Asp())
+      _ <- removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[EstateAgentBusiness](previousBusinessActivities, currentBusinessActivities, EstateAgentBusinessService, EstateAgentBusiness.key, EstateAgentBusiness())
+      _ <- removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[Hvd](previousBusinessActivities, currentBusinessActivities, HighValueDealing, Hvd.key, Hvd())
+      _ <- removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[MSBModel](previousBusinessActivities, currentBusinessActivities, MoneyServiceBusiness, MSBModel.key, MSBModel())
+      _ <- removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[Tcsp](previousBusinessActivities, currentBusinessActivities, TrustAndCompanyServices, Tcsp.key, Tcsp())
+    } yield true
+
+    result
   }
 
   private def removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[T](
@@ -140,7 +144,7 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
                                                                                      clearedModel: T
                                                                              )(implicit ac: AuthContext, hc: HeaderCarrier, format: Format[T]) = {
     if (previousBusinessActivities.contains(businessActivity) && !currentBusinessActivities.contains(businessActivity)) {
-      dataCacheConnector.save(key, clearedModel)
+      dataCacheConnector.save(key, clearedModel).map(Some(_))
     } else {
       Future.successful(None)
     }

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -136,13 +136,13 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
                                                                                      previousBusinessActivities: Set[BusinessActivity],
                                                                                      currentBusinessActivities: Set[BusinessActivity],
                                                                                      businessActivity: BusinessActivity,
-                                                                                     section: String,
-                                                                                     thing:T
+                                                                                     key: String,
+                                                                                     clearedModel: T
                                                                              )(implicit ac: AuthContext, hc: HeaderCarrier, format: Format[T]) = {
     val previouslySelected = previousBusinessActivities.contains(businessActivity)
     val currentlySelected = currentBusinessActivities.contains(businessActivity)
     if (previouslySelected && !currentlySelected) {
-      dataCacheConnector.save[T](section, thing )
+      dataCacheConnector.save[T](key, clearedModel)
     } else {
       Future.successful(None)
     }

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -119,19 +119,7 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
   private def clearRemovedSections(previousBusinessActivities: Set[BusinessActivity],
                                    currentBusinessActivities: Set[BusinessActivity]
                                   )(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    val result: Future[Any] = Future.successful(BusinessMatchingActivities.all.map(clearSectionIfRemoved(previousBusinessActivities, currentBusinessActivities, _)))
-    result
-  }
-
-  private def clearSectionIfRemoved(previousBusinessActivities: Set[BusinessActivity],
-                                    currentBusinessActivities: Set[BusinessActivity],
-                                    businessActivity: BusinessActivity
-                                   )(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    if (previousBusinessActivities.contains(businessActivity) && !currentBusinessActivities.contains(businessActivity)) {
-      businessMatchingService.clearSection(businessActivity)
-    } else {
-      Future.successful(None)
-    }
+    Future.successful((previousBusinessActivities diff currentBusinessActivities).map(businessMatchingService.clearSection(_)))
   }
 
   private def maybeRemoveAccountantForAMLSRegulations(bmActivities: BusinessMatchingActivities)

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -120,13 +120,16 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
   private def clearRemovedSections(previousBusinessActivities: Set[BusinessActivity],
                                    currentBusinessActivities: Set[BusinessActivity]
                                   )(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    val sectionsToRemove = if (hasASPorTCSP(previousBusinessActivities) && !hasASPorTCSP(currentBusinessActivities)) {
-      (previousBusinessActivities diff currentBusinessActivities).map(businessMatchingService.clearSection) +
-              dataCacheConnector.save[Supervision](Supervision.key, Supervision())
-    } else {
-      (previousBusinessActivities diff currentBusinessActivities).map(businessMatchingService.clearSection)
-    }
-    Future.sequence(sectionsToRemove)
+    val businessActivitiesWithSections: Set[BusinessActivity] = Set(AccountancyServices, EstateAgentBusinessService, HighValueDealing, MoneyServiceBusiness, TrustAndCompanyServices)
+    val diffActivities: Set[BusinessActivity] = (previousBusinessActivities diff currentBusinessActivities)
+//    val sectionsToRemove = if (hasASPorTCSP(previousBusinessActivities) && !hasASPorTCSP(currentBusinessActivities)) {
+//      (previousBusinessActivities diff currentBusinessActivities).map(businessMatchingService.clearSection) +
+//              dataCacheConnector.save[Supervision](Supervision.key, Supervision())
+//    } else {
+//      (previousBusinessActivities diff currentBusinessActivities).map(businessMatchingService.clearSection)
+//    }
+//    Future.sequence(sectionsToRemove)
+    Future.sequence((diffActivities intersect businessActivitiesWithSections).map(businessMatchingService.clearSection))
   }
 
   private def maybeRemoveAccountantForAMLSRegulations(bmActivities: BusinessMatchingActivities)

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -118,9 +118,8 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
 
   private def clearRemovedSections(previousBusinessActivities: Set[BusinessActivity],
                                    currentBusinessActivities: Set[BusinessActivity]
-                                  )(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    Future.successful((previousBusinessActivities diff currentBusinessActivities).map(businessMatchingService.clearSection(_)))
-  }
+                                  )(implicit ac: AuthContext, hc: HeaderCarrier) =
+    Future.sequence((previousBusinessActivities diff currentBusinessActivities).map(businessMatchingService.clearSection(_)))
 
   private def maybeRemoveAccountantForAMLSRegulations(bmActivities: BusinessMatchingActivities)
                                                      (implicit ac: AuthContext, hc: HeaderCarrier) = {

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -88,8 +88,8 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
                 isMsb(data, businessMatching.activities)
               )
               _ <- maybeRemoveAccountantForAMLSRegulations(savedModel)
-              _ <- removeAspIfNotSelectedAndPreviouslySelected(businessMatching.activities, savedModel.businessActivities)
-              // Add a removal clear section here....
+              _ <- removeAspIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
+                savedModel.businessActivities)
             } yield savedModel) flatMap { savedActivities =>
               getData[ResponsiblePerson] flatMap { responsiblePeople =>
                 if(fitAndProperRequired(savedActivities)){
@@ -116,8 +116,8 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
       .taxMatters(None)
       .copy(hasAccepted = true)
 
-  private def removeAspIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Option[models.businessmatching.BusinessActivities], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    val aspPreviouslySelected = previousBusinessActivities.get.businessActivities.contains(AccountancyServices)
+  private def removeAspIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Set[BusinessActivity], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
+    val aspPreviouslySelected = previousBusinessActivities.contains(AccountancyServices)
     val aspCurrentlySelected = currentBusinessActivities.contains(AccountancyServices)
     if (aspPreviouslySelected && !aspCurrentlySelected) {
       dataCacheConnector.save(Asp.key, Asp())

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -92,16 +92,8 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
                 isMsb(data, businessMatching.activities)
               )
               _ <- maybeRemoveAccountantForAMLSRegulations(savedModel)
-              _ <- removeAspIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
-                savedModel.businessActivities)
-              _ <- removeEabIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
-                savedModel.businessActivities)
-              _ <- removeHvdIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
-                savedModel.businessActivities)
-              _ <- removeMsbIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
-                savedModel.businessActivities)
-              _ <- removeTcspIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
-                savedModel.businessActivities)
+              _ <- removeBusinessActivitiesSectionsIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
+                  savedModel.businessActivities)
             } yield savedModel) flatMap { savedActivities =>
               getData[ResponsiblePerson] flatMap { responsiblePeople =>
                 if(fitAndProperRequired(savedActivities)){
@@ -127,6 +119,17 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
       .accountantForAMLSRegulations(None)
       .taxMatters(None)
       .copy(hasAccepted = true)
+
+  private def removeBusinessActivitiesSectionsIfNotSelectedAndPreviouslySelected(
+                                                                                        previousBusinessActivities: Set[BusinessActivity],
+                                                                                        currentBusinessActivities: Set[BusinessActivity]
+                                                                                )(implicit ac: AuthContext, hc: HeaderCarrier) = {
+      removeAspIfNotSelectedAndPreviouslySelected(previousBusinessActivities, currentBusinessActivities)
+      removeEabIfNotSelectedAndPreviouslySelected(previousBusinessActivities, currentBusinessActivities)
+      removeHvdIfNotSelectedAndPreviouslySelected(previousBusinessActivities, currentBusinessActivities)
+      removeMsbIfNotSelectedAndPreviouslySelected(previousBusinessActivities, currentBusinessActivities)
+      removeTcspIfNotSelectedAndPreviouslySelected(previousBusinessActivities, currentBusinessActivities)
+  }
 
   private def removeAspIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Set[BusinessActivity], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
     val aspPreviouslySelected = previousBusinessActivities.contains(AccountancyServices)

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -33,6 +33,10 @@ import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import utils.RepeatingSection
 import views.html.businessmatching._
 import models.businessactivities.BusinessActivities
+import models.estateagentbusiness.EstateAgentBusiness
+import models.hvd.Hvd
+import models.moneyservicebusiness.{MoneyServiceBusiness => MSBModel}
+import models.tcsp.Tcsp
 
 import scala.concurrent.Future
 
@@ -90,6 +94,14 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
               _ <- maybeRemoveAccountantForAMLSRegulations(savedModel)
               _ <- removeAspIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
                 savedModel.businessActivities)
+              _ <- removeEabIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
+                savedModel.businessActivities)
+              _ <- removeHvdIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
+                savedModel.businessActivities)
+              _ <- removeMsbIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
+                savedModel.businessActivities)
+              _ <- removeTcspIfNotSelectedAndPreviouslySelected(businessMatching.activities.getOrElse(BusinessMatchingActivities(Set())).businessActivities,
+                savedModel.businessActivities)
             } yield savedModel) flatMap { savedActivities =>
               getData[ResponsiblePerson] flatMap { responsiblePeople =>
                 if(fitAndProperRequired(savedActivities)){
@@ -121,6 +133,46 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
     val aspCurrentlySelected = currentBusinessActivities.contains(AccountancyServices)
     if (aspPreviouslySelected && !aspCurrentlySelected) {
       dataCacheConnector.save(Asp.key, Asp())
+    } else {
+      Future.successful(None)
+    }
+  }
+
+  private def removeEabIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Set[BusinessActivity], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
+    val eabPreviouslySelected = previousBusinessActivities.contains(EstateAgentBusinessService)
+    val eabCurrentlySelected = currentBusinessActivities.contains(EstateAgentBusinessService)
+    if (eabPreviouslySelected && !eabCurrentlySelected) {
+      dataCacheConnector.save(EstateAgentBusiness.key, EstateAgentBusiness())
+    } else {
+      Future.successful(None)
+    }
+  }
+
+  private def removeHvdIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Set[BusinessActivity], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
+    val hvdPreviouslySelected = previousBusinessActivities.contains(HighValueDealing)
+    val hvdCurrentlySelected = currentBusinessActivities.contains(HighValueDealing)
+    if (hvdPreviouslySelected && !hvdCurrentlySelected) {
+      dataCacheConnector.save(Hvd.key, Hvd())
+    } else {
+      Future.successful(None)
+    }
+  }
+
+  private def removeMsbIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Set[BusinessActivity], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
+    val msbPreviouslySelected = previousBusinessActivities.contains(MoneyServiceBusiness)
+    val msbCurrentlySelected = currentBusinessActivities.contains(MoneyServiceBusiness)
+    if (msbPreviouslySelected && !msbCurrentlySelected) {
+      dataCacheConnector.save(MSBModel.key, MSBModel())
+    } else {
+      Future.successful(None)
+    }
+  }
+
+  private def removeTcspIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Set[BusinessActivity], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
+    val tcspPreviouslySelected = previousBusinessActivities.contains(TrustAndCompanyServices)
+    val tcspCurrentlySelected = currentBusinessActivities.contains(TrustAndCompanyServices)
+    if (tcspPreviouslySelected && !tcspCurrentlySelected) {
+      dataCacheConnector.save(Tcsp.key, Tcsp())
     } else {
       Future.successful(None)
     }

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -139,10 +139,8 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
                                                                                      key: String,
                                                                                      clearedModel: T
                                                                              )(implicit ac: AuthContext, hc: HeaderCarrier, format: Format[T]) = {
-    val previouslySelected = previousBusinessActivities.contains(businessActivity)
-    val currentlySelected = currentBusinessActivities.contains(businessActivity)
-    if (previouslySelected && !currentlySelected) {
-      dataCacheConnector.save[T](key, clearedModel)
+    if (previousBusinessActivities.contains(businessActivity) && !currentBusinessActivities.contains(businessActivity)) {
+      dataCacheConnector.save(key, clearedModel)
     } else {
       Future.successful(None)
     }

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -119,14 +119,7 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
   private def clearRemovedSections(previousBusinessActivities: Set[BusinessActivity],
                                    currentBusinessActivities: Set[BusinessActivity]
                                   )(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    val result: Future[Any] = for {
-      _ <- clearSectionIfRemoved(previousBusinessActivities, currentBusinessActivities, AccountancyServices)
-      _ <- clearSectionIfRemoved(previousBusinessActivities, currentBusinessActivities, EstateAgentBusinessService)
-      _ <- clearSectionIfRemoved(previousBusinessActivities, currentBusinessActivities, HighValueDealing)
-      _ <- clearSectionIfRemoved(previousBusinessActivities, currentBusinessActivities, MoneyServiceBusiness)
-      _ <- clearSectionIfRemoved(previousBusinessActivities, currentBusinessActivities, TrustAndCompanyServices)
-    } yield true
-
+    val result: Future[Any] = Future.successful(BusinessMatchingActivities.all.map(clearSectionIfRemoved(previousBusinessActivities, currentBusinessActivities, _)))
     result
   }
 

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -144,7 +144,7 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
                                                                                      clearedModel: T
                                                                              )(implicit ac: AuthContext, hc: HeaderCarrier, format: Format[T]) = {
     if (previousBusinessActivities.contains(businessActivity) && !currentBusinessActivities.contains(businessActivity)) {
-      dataCacheConnector.save(key, clearedModel).map(Some(_))
+      businessMatchingService.clearSection(businessActivity)
     } else {
       Future.successful(None)
     }

--- a/app/controllers/businessmatching/RegisterServicesController.scala
+++ b/app/controllers/businessmatching/RegisterServicesController.scala
@@ -37,6 +37,7 @@ import models.estateagentbusiness.EstateAgentBusiness
 import models.hvd.Hvd
 import models.moneyservicebusiness.{MoneyServiceBusiness => MSBModel}
 import models.tcsp.Tcsp
+import play.api.libs.json.Format
 
 import scala.concurrent.Future
 
@@ -124,58 +125,24 @@ class RegisterServicesController @Inject()(val authConnector: AuthConnector,
                                                                                         previousBusinessActivities: Set[BusinessActivity],
                                                                                         currentBusinessActivities: Set[BusinessActivity]
                                                                                 )(implicit ac: AuthContext, hc: HeaderCarrier) = {
-      removeAspIfNotSelectedAndPreviouslySelected(previousBusinessActivities, currentBusinessActivities)
-      removeEabIfNotSelectedAndPreviouslySelected(previousBusinessActivities, currentBusinessActivities)
-      removeHvdIfNotSelectedAndPreviouslySelected(previousBusinessActivities, currentBusinessActivities)
-      removeMsbIfNotSelectedAndPreviouslySelected(previousBusinessActivities, currentBusinessActivities)
-      removeTcspIfNotSelectedAndPreviouslySelected(previousBusinessActivities, currentBusinessActivities)
+    removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[Asp](previousBusinessActivities, currentBusinessActivities, AccountancyServices, Asp.key, Asp())
+    removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[EstateAgentBusiness](previousBusinessActivities, currentBusinessActivities, EstateAgentBusinessService, EstateAgentBusiness.key, EstateAgentBusiness())
+    removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[Hvd](previousBusinessActivities, currentBusinessActivities, HighValueDealing, Hvd.key, Hvd())
+    removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[MSBModel](previousBusinessActivities, currentBusinessActivities, MoneyServiceBusiness, MSBModel.key, MSBModel())
+    removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[Tcsp](previousBusinessActivities, currentBusinessActivities, TrustAndCompanyServices, Tcsp.key, Tcsp())
   }
 
-  private def removeAspIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Set[BusinessActivity], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    val aspPreviouslySelected = previousBusinessActivities.contains(AccountancyServices)
-    val aspCurrentlySelected = currentBusinessActivities.contains(AccountancyServices)
-    if (aspPreviouslySelected && !aspCurrentlySelected) {
-      dataCacheConnector.save(Asp.key, Asp())
-    } else {
-      Future.successful(None)
-    }
-  }
-
-  private def removeEabIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Set[BusinessActivity], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    val eabPreviouslySelected = previousBusinessActivities.contains(EstateAgentBusinessService)
-    val eabCurrentlySelected = currentBusinessActivities.contains(EstateAgentBusinessService)
-    if (eabPreviouslySelected && !eabCurrentlySelected) {
-      dataCacheConnector.save(EstateAgentBusiness.key, EstateAgentBusiness())
-    } else {
-      Future.successful(None)
-    }
-  }
-
-  private def removeHvdIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Set[BusinessActivity], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    val hvdPreviouslySelected = previousBusinessActivities.contains(HighValueDealing)
-    val hvdCurrentlySelected = currentBusinessActivities.contains(HighValueDealing)
-    if (hvdPreviouslySelected && !hvdCurrentlySelected) {
-      dataCacheConnector.save(Hvd.key, Hvd())
-    } else {
-      Future.successful(None)
-    }
-  }
-
-  private def removeMsbIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Set[BusinessActivity], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    val msbPreviouslySelected = previousBusinessActivities.contains(MoneyServiceBusiness)
-    val msbCurrentlySelected = currentBusinessActivities.contains(MoneyServiceBusiness)
-    if (msbPreviouslySelected && !msbCurrentlySelected) {
-      dataCacheConnector.save(MSBModel.key, MSBModel())
-    } else {
-      Future.successful(None)
-    }
-  }
-
-  private def removeTcspIfNotSelectedAndPreviouslySelected(previousBusinessActivities: Set[BusinessActivity], currentBusinessActivities: Set[BusinessActivity])(implicit ac: AuthContext, hc: HeaderCarrier) = {
-    val tcspPreviouslySelected = previousBusinessActivities.contains(TrustAndCompanyServices)
-    val tcspCurrentlySelected = currentBusinessActivities.contains(TrustAndCompanyServices)
-    if (tcspPreviouslySelected && !tcspCurrentlySelected) {
-      dataCacheConnector.save(Tcsp.key, Tcsp())
+  private def removeBusinessActivitySectionIfNotSelectedAndPreviouslySelected[T](
+                                                                                     previousBusinessActivities: Set[BusinessActivity],
+                                                                                     currentBusinessActivities: Set[BusinessActivity],
+                                                                                     businessActivity: BusinessActivity,
+                                                                                     section: String,
+                                                                                     thing:T
+                                                                             )(implicit ac: AuthContext, hc: HeaderCarrier, format: Format[T]) = {
+    val previouslySelected = previousBusinessActivities.contains(businessActivity)
+    val currentlySelected = currentBusinessActivities.contains(businessActivity)
+    if (previouslySelected && !currentlySelected) {
+      dataCacheConnector.save[T](section, thing )
     } else {
       Future.successful(None)
     }

--- a/app/services/businessmatching/BusinessMatchingService.scala
+++ b/app/services/businessmatching/BusinessMatchingService.scala
@@ -91,7 +91,6 @@ class BusinessMatchingService @Inject()(
     case HighValueDealing => dataCacheConnector.save[Hvd](Hvd.key, None)
     case MoneyServiceBusiness => dataCacheConnector.save[Msb](Msb.key, None)
     case TrustAndCompanyServices => dataCacheConnector.save[Tcsp](Tcsp.key, None)
-    case _ => Future.successful(None)
   }
 
 }

--- a/app/services/businessmatching/BusinessMatchingService.scala
+++ b/app/services/businessmatching/BusinessMatchingService.scala
@@ -91,6 +91,7 @@ class BusinessMatchingService @Inject()(
     case HighValueDealing => dataCacheConnector.save[Hvd](Hvd.key, None)
     case MoneyServiceBusiness => dataCacheConnector.save[Msb](Msb.key, None)
     case TrustAndCompanyServices => dataCacheConnector.save[Tcsp](Tcsp.key, None)
+    case _ => Future.successful(None)
   }
 
 }

--- a/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
@@ -392,7 +392,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
       }
 
       "Remove supervision section data" when {
-        "jgr ASP deselected, TCSP not selected" in new Fixture {
+        "ASP deselected, TCSP not selected" in new Fixture {
           val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(BillPaymentServices, AccountancyServices))), preAppComplete = true)
           val newRequest = request.withFormUrlEncodedBody(
             "businessActivities" -> "02"

--- a/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
@@ -21,9 +21,14 @@ import cats.implicits._
 import connectors.DataCacheConnector
 import forms.{EmptyForm, Form2}
 import generators.ResponsiblePersonGenerator
+import models.asp.{Asp, PayrollServices, ServicesOfBusiness}
 import models.businessactivities.{AccountantForAMLSRegulations, BusinessActivities, TaxMatters, WhoIsYourAccountant}
 import models.businessmatching.{BusinessActivities => BMBusinessActivities, _}
+import models.estateagentbusiness.EstateAgentBusiness
+import models.hvd.Hvd
+import models.moneyservicebusiness.{MoneyServiceBusiness => MSBModel}
 import models.responsiblepeople.ResponsiblePerson
+import models.tcsp.Tcsp
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{eq => eqTo, _}
@@ -38,7 +43,7 @@ import services.StatusService
 import services.businessmatching.BusinessMatchingService
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
-import utils.{AuthorisedFixture, DependencyMocks, AmlsSpec}
+import utils.{AmlsSpec, AuthorisedFixture, DependencyMocks}
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -326,6 +331,78 @@ class RegisterServicesControllerSpec extends AmlsSpec
 
           }
 
+        }
+      }
+    }
+
+    "post" must {
+      "Remove existing section data " when {
+        "ASP is not selected, but was previously" in pending
+        "EAB is not selected, but was previously" in pending
+        "HVD is not selected, but was previously" in pending
+        "MSB is not selected, but was previously" in pending
+        "TCSP is not selected, but was previously" in pending
+      }
+
+      "Must not remove existing section data " when {
+        "ASP is selected and was previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(AccountancyServices))), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "01")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(0)).save(eqTo(Asp.key), any())(any(), any(), any())
+        }
+
+        "EAB is selected and was previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(EstateAgentBusinessService))), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "03")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(0)).save(eqTo(EstateAgentBusiness.key), any())(any(), any(), any())
+        }
+
+        "HVD is selected and was previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(HighValueDealing))), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "04")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(0)).save(eqTo(Hvd.key), any())(any(), any(), any())
+        }
+
+        "MSB is selected and was previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(MoneyServiceBusiness))), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "05")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(0)).save(eqTo(MSBModel.key), any())(any(), any(), any())
+        }
+
+        "TCSP is selected and was previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(TrustAndCompanyServices))), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "07")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(0)).save(eqTo(Tcsp.key), any())(any(), any(), any())
         }
       }
     }

--- a/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
@@ -21,7 +21,7 @@ import cats.implicits._
 import connectors.DataCacheConnector
 import forms.{EmptyForm, Form2}
 import generators.ResponsiblePersonGenerator
-import models.asp.{Asp, PayrollServices, ServicesOfBusiness}
+import models.asp.Asp
 import models.businessactivities.{AccountantForAMLSRegulations, BusinessActivities, TaxMatters, WhoIsYourAccountant}
 import models.businessmatching.{BusinessActivities => BMBusinessActivities, _}
 import models.estateagentbusiness.EstateAgentBusiness
@@ -45,8 +45,8 @@ import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import utils.{AmlsSpec, AuthorisedFixture, DependencyMocks}
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class RegisterServicesControllerSpec extends AmlsSpec
   with MockitoSugar
@@ -511,7 +511,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
 
         "TCSP is selected and was previously" in new Fixture {
           val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(TrustAndCompanyServices))), preAppComplete = true)
-          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "07")
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "06")
 
           when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
 

--- a/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
@@ -21,14 +21,10 @@ import cats.implicits._
 import connectors.DataCacheConnector
 import forms.{EmptyForm, Form2}
 import generators.ResponsiblePersonGenerator
-import models.asp.Asp
 import models.businessactivities.{AccountantForAMLSRegulations, BusinessActivities, TaxMatters, WhoIsYourAccountant}
 import models.businessmatching.{BusinessActivities => BMBusinessActivities, _}
-import models.estateagentbusiness.EstateAgentBusiness
-import models.hvd.Hvd
 import models.moneyservicebusiness.{MoneyServiceBusiness => MSBModel}
 import models.responsiblepeople.ResponsiblePerson
-import models.tcsp.Tcsp
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{eq => eqTo, _}
@@ -96,8 +92,13 @@ class RegisterServicesControllerSpec extends AmlsSpec
       controller.businessMatchingService.updateModel(any())(any(),any(),any())
     } thenReturn OptionT.some[Future, CacheMap](mockCacheMap)
 
+    when {
+      controller.businessMatchingService.clearSection(any())(any(),any())
+    } thenReturn Future.successful(mockCacheMap)
+
     val responsiblePerson = responsiblePersonGen.sample.get.copy(hasAlreadyPassedFitAndProper = None)
     val responsiblePersonChanged = responsiblePerson.copy(hasChanged = true, hasAccepted = true)
+
 
     val fitAndProperResponsiblePeople = Seq(
       responsiblePerson.copy(hasAlreadyPassedFitAndProper = Some(true)),
@@ -346,7 +347,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(0)).save(eqTo(Asp.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(0)).clearSection(eqTo(AccountancyServices))(any(), any())
         }
 
         "EAB is not selected, and was not previously" in new Fixture {
@@ -358,7 +359,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(0)).save(eqTo(EstateAgentBusiness.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(0)).clearSection(eqTo(EstateAgentBusinessService))(any(), any())
         }
 
         "HVD is not selected, and was not previously" in new Fixture {
@@ -370,7 +371,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(0)).save(eqTo(Hvd.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(0)).clearSection(eqTo(HighValueDealing))(any(), any())
         }
 
         "MSB is not selected, and was not previously" in new Fixture {
@@ -382,7 +383,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(0)).save(eqTo(MSBModel.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(0)).clearSection(eqTo(MoneyServiceBusiness))(any(), any())
         }
 
         "TCSP is not selected, and was not previously" in new Fixture {
@@ -394,7 +395,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(0)).save(eqTo(Tcsp.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(0)).clearSection(eqTo(TrustAndCompanyServices))(any(), any())
         }
       }
 
@@ -408,7 +409,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(1)).save(eqTo(Asp.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(1)).clearSection(eqTo(AccountancyServices))(any(), any())
         }
 
         "EAB is not selected, but was previously" in new Fixture {
@@ -420,7 +421,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(1)).save(eqTo(EstateAgentBusiness.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(1)).clearSection(eqTo(EstateAgentBusinessService))(any(), any())
         }
 
         "HVD is not selected, but was previously" in new Fixture {
@@ -432,7 +433,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(1)).save(eqTo(Hvd.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(1)).clearSection(eqTo(HighValueDealing))(any(), any())
         }
 
         "MSB is not selected, but was previously" in new Fixture {
@@ -444,7 +445,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(1)).save(eqTo(MSBModel.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(1)).clearSection(eqTo(MoneyServiceBusiness))(any(), any())
         }
 
         "TCSP is not selected, but was previously" in new Fixture {
@@ -456,7 +457,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(1)).save(eqTo(Tcsp.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(1)).clearSection(eqTo(TrustAndCompanyServices))(any(), any())
         }
       }
 
@@ -470,7 +471,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(0)).save(eqTo(Asp.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(0)).clearSection(eqTo(AccountancyServices))(any(), any())
         }
 
         "EAB is selected and was previously" in new Fixture {
@@ -482,7 +483,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(0)).save(eqTo(EstateAgentBusiness.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(0)).clearSection(eqTo(EstateAgentBusinessService))(any(), any())
         }
 
         "HVD is selected and was previously" in new Fixture {
@@ -494,7 +495,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(0)).save(eqTo(Hvd.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(0)).clearSection(eqTo(HighValueDealing))(any(), any())
         }
 
         "MSB is selected and was previously" in new Fixture {
@@ -506,7 +507,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(0)).save(eqTo(MSBModel.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(0)).clearSection(eqTo(MoneyServiceBusiness))(any(), any())
         }
 
         "TCSP is selected and was previously" in new Fixture {
@@ -518,7 +519,7 @@ class RegisterServicesControllerSpec extends AmlsSpec
           val result = controller.post()(newRequest)
 
           status(result) must be(SEE_OTHER)
-          verify(controller.dataCacheConnector, times(0)).save(eqTo(Tcsp.key), any())(any(), any(), any())
+          verify(controller.businessMatchingService, times(0)).clearSection(eqTo(TrustAndCompanyServices))(any(), any())
         }
       }
     }

--- a/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
@@ -336,8 +336,38 @@ class RegisterServicesControllerSpec extends AmlsSpec
     }
 
     "post" must {
+      "Do nothing to non-existing section data" when {
+        "ASP is not selected, and was not previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set())), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "02")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(0)).save(eqTo(Asp.key), any())(any(), any(), any())
+        }
+
+        "EAB is not selected, but was previously" in pending
+        "HVD is not selected, but was previously" in pending
+        "MSB is not selected, but was previously" in pending
+        "TCSP is not selected, but was previously" in pending
+      }
+
       "Remove existing section data " when {
-        "ASP is not selected, but was previously" in pending
+        "ASP is not selected, but was previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(AccountancyServices))), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "02")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(1)).save(eqTo(Asp.key), any())(any(), any(), any())
+        }
+
         "EAB is not selected, but was previously" in pending
         "HVD is not selected, but was previously" in pending
         "MSB is not selected, but was previously" in pending

--- a/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
@@ -100,7 +100,6 @@ class RegisterServicesControllerSpec extends AmlsSpec
     val responsiblePerson = responsiblePersonGen.sample.get.copy(hasAlreadyPassedFitAndProper = None)
     val responsiblePersonChanged = responsiblePerson.copy(hasChanged = true, hasAccepted = true)
 
-
     val fitAndProperResponsiblePeople = Seq(
       responsiblePerson.copy(hasAlreadyPassedFitAndProper = Some(true)),
       responsiblePerson.copy(hasAlreadyPassedFitAndProper = Some(false))

--- a/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
@@ -349,10 +349,53 @@ class RegisterServicesControllerSpec extends AmlsSpec
           verify(controller.dataCacheConnector, times(0)).save(eqTo(Asp.key), any())(any(), any(), any())
         }
 
-        "EAB is not selected, but was previously" in pending
-        "HVD is not selected, but was previously" in pending
-        "MSB is not selected, but was previously" in pending
-        "TCSP is not selected, but was previously" in pending
+        "EAB is not selected, and was not previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set())), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "02")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(0)).save(eqTo(EstateAgentBusiness.key), any())(any(), any(), any())
+        }
+
+        "HVD is not selected, and was not previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set())), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "02")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(0)).save(eqTo(Hvd.key), any())(any(), any(), any())
+        }
+
+        "MSB is not selected, and was not previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set())), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "02")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(0)).save(eqTo(MSBModel.key), any())(any(), any(), any())
+        }
+
+        "TCSP is not selected, and was not previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set())), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "02")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(0)).save(eqTo(Tcsp.key), any())(any(), any(), any())
+        }
       }
 
       "Remove existing section data " when {
@@ -368,10 +411,53 @@ class RegisterServicesControllerSpec extends AmlsSpec
           verify(controller.dataCacheConnector, times(1)).save(eqTo(Asp.key), any())(any(), any(), any())
         }
 
-        "EAB is not selected, but was previously" in pending
-        "HVD is not selected, but was previously" in pending
-        "MSB is not selected, but was previously" in pending
-        "TCSP is not selected, but was previously" in pending
+        "EAB is not selected, but was previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(EstateAgentBusinessService))), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "02")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(1)).save(eqTo(EstateAgentBusiness.key), any())(any(), any(), any())
+        }
+
+        "HVD is not selected, but was previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(HighValueDealing))), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "02")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(1)).save(eqTo(Hvd.key), any())(any(), any(), any())
+        }
+
+        "MSB is not selected, but was previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(MoneyServiceBusiness))), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "02")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(1)).save(eqTo(MSBModel.key), any())(any(), any(), any())
+        }
+
+        "TCSP is not selected, but was previously" in new Fixture {
+          val businessMatchingWithData = BusinessMatching(None, Some(BMBusinessActivities(businessActivities = Set(TrustAndCompanyServices))), preAppComplete = true)
+          val newRequest = request.withFormUrlEncodedBody("businessActivities" -> "02")
+
+          when(controller.businessMatchingService.getModel(any(), any(), any())).thenReturn(OptionT.some[Future, BusinessMatching](businessMatchingWithData))
+
+          val result = controller.post()(newRequest)
+
+          status(result) must be(SEE_OTHER)
+          verify(controller.dataCacheConnector, times(1)).save(eqTo(Tcsp.key), any())(any(), any(), any())
+        }
       }
 
       "Must not remove existing section data " when {


### PR DESCRIPTION
Amended the register services controller to remove the sections from mongo for any activities which were previously there, but have been removed. Also added logic to remove the supervision section if either ASP or TCSP had previously been there, but would no longer. 

## Related / Dependant PRs?

## How Has This Been Tested?

Unit and Manually Tested
Regression Acceptance Tests run

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [X] Build passing.
- [X] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [X] Requires acceptance test run.
- [X] Appropriate labels added.
