### PR TITLE
Amls 4347 v2

### DIFF
--- a/test/controllers/responsiblepeople/SoleProprietorOfAnotherBusinessControllerSpec.scala
+++ b/test/controllers/responsiblepeople/SoleProprietorOfAnotherBusinessControllerSpec.scala
@@ -19,16 +19,16 @@ package controllers.responsiblepeople
 import connectors.DataCacheConnector
 import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople.{PersonName, ResponsiblePerson, SoleProprietorOfAnotherBusiness, VATRegisteredNo}
+import models.status.{NotCompleted, SubmissionStatus}
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
 import org.mockito.Matchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
-import play.api.i18n.Messages
 import play.api.test.Helpers._
+import services.StatusService
 import uk.gov.hmrc.http.cache.client.CacheMap
-import utils.{AuthorisedFixture, AmlsSpec}
+import utils.{AmlsSpec, AuthorisedFixture}
 
 import scala.concurrent.Future
 
@@ -40,8 +40,12 @@ class SoleProprietorOfAnotherBusinessControllerSpec extends AmlsSpec with Mockit
 
     lazy val mockDataCacheConnector = mock[DataCacheConnector]
 
-    val controller = new SoleProprietorOfAnotherBusinessController(dataCacheConnector = mockDataCacheConnector, authConnector = self.authConnector) {
-    }
+    val submissionStatus: SubmissionStatus = NotCompleted
+
+    val controller = new SoleProprietorOfAnotherBusinessController(
+      dataCacheConnector = mockDataCacheConnector,
+      authConnector = self.authConnector,
+      statusService = mock[StatusService])
   }
 
   val emptyCache = CacheMap("", Map.empty)
@@ -50,52 +54,174 @@ class SoleProprietorOfAnotherBusinessControllerSpec extends AmlsSpec with Mockit
   val soleProprietorOfAnotherBusiness = Some(SoleProprietorOfAnotherBusiness(true))
 
   "SoleProprietorOfAnotherBusinessController" when {
+    "get is called" when {
+      "application status is PostSubmission" when {
+        "adding a new Responsible Person" must {
+          "display empty Sole Proprietor view" in new Fixture {
 
-    "get is called" must {
-      "display page" in new Fixture {
+            when(mockDataCacheConnector.fetch[Seq[ResponsiblePerson]](any())(any(), any(), any()))
+              .thenReturn(Future.successful(Some(Seq(ResponsiblePerson(personName, lineId = None)))))
 
-        when(mockDataCacheConnector.fetch[Seq[ResponsiblePerson]](any())(any(), any(), any()))
-          .thenReturn(Future.successful(Some(Seq(ResponsiblePerson(personName)))))
+            when(controller.statusService.isPreSubmission(any(), any(), any()))
+              .thenReturn(Future.successful(false))
 
-        val result = controller.get(1)(request)
+            val result = controller.get(1)(request)
 
-        status(result) must be(OK)
+            status(result) must be(OK)
 
-        val document = Jsoup.parse(contentAsString(result))
-        document.getElementById("soleProprietorOfAnotherBusiness-true").hasAttr("checked") must be(false)
-        document.getElementById("soleProprietorOfAnotherBusiness-false").hasAttr("checked") must be(false)
-      }
+            val document = Jsoup.parse(contentAsString(result))
+            document.getElementById("soleProprietorOfAnotherBusiness-true").hasAttr("checked") must be(false)
+            document.getElementById("soleProprietorOfAnotherBusiness-false").hasAttr("checked") must be(false)
+          }
+        }
 
-      "display page and prepopulate data from save4later" in new Fixture {
+        "updating existing Responsible Person if there is some VAT data" must {
+          "redirect to VATRegisteredController" in new Fixture {
 
-        when(mockDataCacheConnector.fetch[Seq[ResponsiblePerson]](any())(any(), any(), any()))
-          .thenReturn(Future.successful(Some(Seq(ResponsiblePerson(personName, soleProprietorOfAnotherBusiness = soleProprietorOfAnotherBusiness)))))
+            val mockCacheMap = mock[CacheMap]
 
-        val result = controller.get(1)(request)
-        status(result) must be(OK)
+            when(mockDataCacheConnector.fetch[Seq[ResponsiblePerson]](any())(any(), any(), any()))
+              .thenReturn(Future.successful(Some(Seq(ResponsiblePerson(personName = personName, vatRegistered = Some(VATRegisteredNo), lineId = Some(44444))))))
 
-        val document = Jsoup.parse(contentAsString(result))
-        document.getElementById("soleProprietorOfAnotherBusiness-true").hasAttr("checked") must be(true)
-        document.getElementById("soleProprietorOfAnotherBusiness-false").hasAttr("checked") must be(false)
+            when(mockDataCacheConnector.save[Seq[ResponsiblePerson]](any(), any())(any(), any(), any()))
+              .thenReturn(Future.successful(mockCacheMap))
 
-      }
+            when(controller.statusService.isPreSubmission(any(), any(), any()))
+              .thenReturn(Future.successful(false))
 
-      "display page Not Found" when {
-        "neither soleProprietorOfAnotherBusiness nor name is set" in new Fixture {
+            val result = controller.get(1)(request)
+
+            status(result) must be(SEE_OTHER)
+
+            redirectLocation(result) must be(Some(controllers.responsiblepeople.routes.VATRegisteredController.get(1).url))
+          }
+        }
+
+        "updating existing Responsible Person if there is no any VAT data" must {
+          "redirect to SelfAssessmentController" in new Fixture {
+
+            val mockCacheMap = mock[CacheMap]
+
+            when(mockDataCacheConnector.fetch[Seq[ResponsiblePerson]](any())(any(), any(), any()))
+              .thenReturn(Future.successful(Some(Seq(ResponsiblePerson(personName, soleProprietorOfAnotherBusiness = None, vatRegistered = None, lineId = Some(4444))))))
+
+            when(mockDataCacheConnector.save[Seq[ResponsiblePerson]](any(), any())(any(), any(), any()))
+              .thenReturn(Future.successful(mockCacheMap))
+
+            when(controller.statusService.isPreSubmission(any(), any(), any()))
+              .thenReturn(Future.successful(false))
+
+            val result = controller.get(1)(request)
+
+            status(result) must be(SEE_OTHER)
+
+            redirectLocation(result) must be(Some(controllers.responsiblepeople.routes.RegisteredForSelfAssessmentController.get(1).url))
+          }
+        }
+
+        "display page and prepopulate data from save4later" in new Fixture {
 
           when(mockDataCacheConnector.fetch[Seq[ResponsiblePerson]](any())(any(), any(), any()))
-            .thenReturn(Future.successful(Some(Seq(ResponsiblePerson()))))
+            .thenReturn(Future.successful(Some(Seq(ResponsiblePerson(personName, soleProprietorOfAnotherBusiness = soleProprietorOfAnotherBusiness)))))
+          when(controller.dataCacheConnector.save[Seq[ResponsiblePerson]](any(), any())(any(), any(), any()))
+            .thenReturn(Future.successful(emptyCache))
+          when(controller.statusService.isPreSubmission(any(), any(), any()))
+            .thenReturn(Future.successful(false))
 
           val result = controller.get(1)(request)
-          status(result) must be(NOT_FOUND)
+          status(result) must be(OK)
 
+          val document = Jsoup.parse(contentAsString(result))
+          document.getElementById("soleProprietorOfAnotherBusiness-true").hasAttr("checked") must be(true)
+          document.getElementById("soleProprietorOfAnotherBusiness-false").hasAttr("checked") must be(false)
+        }
+
+        "display page Not Found" when {
+          "neither soleProprietorOfAnotherBusiness nor name is set" in new Fixture {
+
+            when(mockDataCacheConnector.fetch[Seq[ResponsiblePerson]](any())(any(), any(), any()))
+              .thenReturn(Future.successful(Some(Seq(ResponsiblePerson()))))
+            when(controller.statusService.isPreSubmission(any(), any(), any()))
+              .thenReturn(Future.successful(false))
+
+            val result = controller.get(1)(request)
+            status(result) must be(NOT_FOUND)
+          }
         }
       }
 
+      "application status is PreSubmission" when {
+        "adding a new Responsible Person" must {
+          "display the Sole Proprietor view" in new Fixture {
+
+            when(mockDataCacheConnector.fetch[Seq[ResponsiblePerson]](any())(any(), any(), any()))
+              .thenReturn(Future.successful(Some(Seq(ResponsiblePerson(personName, lineId = None)))))
+
+            when(controller.statusService.isPreSubmission(any(), any(), any()))
+              .thenReturn(Future.successful(true))
+
+            val result = controller.get(1)(request)
+
+            status(result) must be(OK)
+
+            val document = Jsoup.parse(contentAsString(result))
+            document.getElementById("soleProprietorOfAnotherBusiness-true").hasAttr("checked") must be(false)
+            document.getElementById("soleProprietorOfAnotherBusiness-false").hasAttr("checked") must be(false)
+          }
+        }
+
+        "adding a new Responsible Person" must {
+          "display page" in new Fixture {
+
+            when(mockDataCacheConnector.fetch[Seq[ResponsiblePerson]](any())(any(), any(), any()))
+              .thenReturn(Future.successful(Some(Seq(ResponsiblePerson(personName)))))
+
+            when(controller.statusService.isPreSubmission(any(), any(), any()))
+              .thenReturn(Future.successful(true))
+
+            val result = controller.get(1)(request)
+
+            status(result) must be(OK)
+
+            val document = Jsoup.parse(contentAsString(result))
+            document.getElementById("soleProprietorOfAnotherBusiness-true").hasAttr("checked") must be(false)
+            document.getElementById("soleProprietorOfAnotherBusiness-false").hasAttr("checked") must be(false)
+          }
+        }
+
+        "display page and prepopulate data from save4later" in new Fixture {
+
+          when(mockDataCacheConnector.fetch[Seq[ResponsiblePerson]](any())(any(), any(), any()))
+            .thenReturn(Future.successful(Some(Seq(ResponsiblePerson(personName, soleProprietorOfAnotherBusiness = soleProprietorOfAnotherBusiness)))))
+          when(controller.dataCacheConnector.save[Seq[ResponsiblePerson]](any(), any())(any(), any(), any()))
+            .thenReturn(Future.successful(emptyCache))
+          when(controller.statusService.isPreSubmission(any(), any(), any()))
+            .thenReturn(Future.successful(true))
+
+          val result = controller.get(1)(request)
+          status(result) must be(OK)
+
+          val document = Jsoup.parse(contentAsString(result))
+          document.getElementById("soleProprietorOfAnotherBusiness-true").hasAttr("checked") must be(true)
+          document.getElementById("soleProprietorOfAnotherBusiness-false").hasAttr("checked") must be(false)
+        }
+
+        "display page Not Found" when {
+          "neither soleProprietorOfAnotherBusiness nor name is set" in new Fixture {
+
+            when(mockDataCacheConnector.fetch[Seq[ResponsiblePerson]](any())(any(), any(), any()))
+              .thenReturn(Future.successful(Some(Seq(ResponsiblePerson()))))
+            when(controller.statusService.isPreSubmission(any(), any(), any()))
+              .thenReturn(Future.successful(true))
+
+            val result = controller.get(1)(request)
+            status(result) must be(NOT_FOUND)
+          }
+        }
+      }
     }
 
     "post is called" when {
-
       "soleProprietorOfAnotherBusiness is set to true" must {
         "go to VATRegisteredController" in new Fixture {
 
@@ -125,10 +251,8 @@ class SoleProprietorOfAnotherBusinessControllerSpec extends AmlsSpec with Mockit
       }
 
       "soleProprietorOfAnotherBusiness is set to false" when {
-
         "edit is true" must {
           "go to DetailedAnswersController" in new Fixture {
-
             val mockCacheMap = mock[CacheMap]
             val newRequest = request.withFormUrlEncodedBody(
               "soleProprietorOfAnotherBusiness" -> "false",
@@ -148,7 +272,6 @@ class SoleProprietorOfAnotherBusinessControllerSpec extends AmlsSpec with Mockit
 
         "edit is false" must {
           "go to RegisteredForSelfAssessmentController" in new Fixture {
-
             val mockCacheMap = mock[CacheMap]
             val newRequest = request.withFormUrlEncodedBody(
               "soleProprietorOfAnotherBusiness" -> "false",
@@ -174,7 +297,6 @@ class SoleProprietorOfAnotherBusinessControllerSpec extends AmlsSpec with Mockit
 
       "respond with BAD_REQUEST" when {
         "given an invalid form" in new Fixture {
-
           val newRequest = request.withFormUrlEncodedBody(
             "soleProprietorOfAnotherBusiness" -> "",
             "personName" -> "Person Name")
@@ -190,7 +312,6 @@ class SoleProprietorOfAnotherBusinessControllerSpec extends AmlsSpec with Mockit
 
       "respond with NOT_FOUND" when {
         "ResponsiblePeople model cannot be found with given index" in new Fixture {
-
           val newRequest = request.withFormUrlEncodedBody(
             "soleProprietorOfAnotherBusiness" -> "true",
             "personName" -> "Person Name")
@@ -204,6 +325,5 @@ class SoleProprietorOfAnotherBusinessControllerSpec extends AmlsSpec with Mockit
         }
       }
     }
-
   }
 }

--- a/test/services/ConfirmationServiceSpec.scala
+++ b/test/services/ConfirmationServiceSpec.scala
@@ -742,13 +742,13 @@ class ConfirmationServiceSpec extends PlaySpec
             etmpFormBundleNumber = "",
             amlsRefNo = amlsRegistrationNumber,
             Some(SubscriptionFees(
-            registrationFee = 100,
-            fpFee = Some(125.0),
-            fpFeeRate = Some(130.0),
-            premiseFee = 0,
-            premiseFeeRate = Some(125.0),
-            totalFees = 0,
-            paymentReference = ""
+              registrationFee = 100,
+              fpFee = Some(125.0),
+              fpFeeRate = Some(130.0),
+              premiseFee = 0,
+              premiseFeeRate = Some(125.0),
+              totalFees = 0,
+              paymentReference = ""
             ))
           )
 
@@ -896,9 +896,9 @@ class ConfirmationServiceSpec extends PlaySpec
               cache.getEntry[Seq[TradingPremises]](eqTo(TradingPremises.key))(any())
             } thenReturn Some(Seq(TradingPremises()))
 
-          when {
-            cache.getEntry[Seq[ResponsiblePerson]](eqTo(ResponsiblePerson.key))(any())
-          } thenReturn Some(Seq(ResponsiblePerson()))
+            when {
+              cache.getEntry[Seq[ResponsiblePerson]](eqTo(ResponsiblePerson.key))(any())
+            } thenReturn Some(Seq(ResponsiblePerson()))
 
             val result = TestConfirmationService.getBreakdownRows(
               SubmissionReady,
@@ -920,9 +920,9 @@ class ConfirmationServiceSpec extends PlaySpec
               cache.getEntry[AmendVariationRenewalResponse](AmendVariationRenewalResponse.key)
             } thenReturn Some(amendmentResponse.copy(difference = Some(100)))
 
-          when {
-            cache.getEntry[Seq[ResponsiblePerson]](eqTo(ResponsiblePerson.key))(any())
-          } thenReturn Some(Seq(ResponsiblePerson()))
+            when {
+              cache.getEntry[Seq[ResponsiblePerson]](eqTo(ResponsiblePerson.key))(any())
+            } thenReturn Some(Seq(ResponsiblePerson()))
 
             val result = TestConfirmationService.getBreakdownRows(
               SubmissionReadyForReview,
@@ -1115,7 +1115,7 @@ class ConfirmationServiceSpecWithPhase2Changes extends PlaySpec
         val rows = Seq(
           BreakdownRow("confirmation.submission", 1, 100, 100)
         ) ++ Seq(
-          BreakdownRow("confirmation.responsiblepeople",0, 100, 0)
+          BreakdownRow("confirmation.responsiblepeople", 0, 100, 0)
         ) ++ Seq(
           BreakdownRow("confirmation.tradingpremises", 1, 115, 0)
         )
@@ -1198,7 +1198,6 @@ class ConfirmationServiceSpecWithPhase2Changes extends PlaySpec
               unpaidRow.total.value mustBe 0
           }
         }
-
       }
 
       "not include deleted premises in the amendment confirmation table" in new Fixture {
@@ -1226,7 +1225,6 @@ class ConfirmationServiceSpecWithPhase2Changes extends PlaySpec
               rows.filter(_.label == "confirmation.tradingpremises").head.quantity mustBe 1
           }
         }
-
       }
 
       "not include responsible people in breakdown" when {
@@ -1255,7 +1253,6 @@ class ConfirmationServiceSpecWithPhase2Changes extends PlaySpec
           whenReady(TestConfirmationService.getAmendment)(_ foreach {
             case rows => rows.filter(_.label == "confirmation.responsiblepeople").head.quantity mustBe 1
           })
-
         }
       }
 
@@ -1287,7 +1284,6 @@ class ConfirmationServiceSpecWithPhase2Changes extends PlaySpec
               rows.count(_.label.equals("confirmation.responsiblepeople.fp.passed")) must be(0)
             }
           }
-
         }
 
         "the business type is TCSP and there is not a Responsible Persons fee to pay from am amendment" in new Fixture {
@@ -1316,7 +1312,6 @@ class ConfirmationServiceSpecWithPhase2Changes extends PlaySpec
               rows.count(_.label.equals("confirmation.responsiblepeople.fp.passed")) must be(0)
             }
           }
-
         }
       }
 
@@ -1527,7 +1522,6 @@ class ConfirmationServiceSpecWithPhase2Changes extends PlaySpec
               rows.count(_.label.equals("confirmation.responsiblepeople.fp.passed")) must be(1)
             }
           }
-
         }
 
         "the business type is TCSP and there is not a Responsible Persons fee to pay from an variation" in new Fixture {
@@ -1562,7 +1556,6 @@ class ConfirmationServiceSpecWithPhase2Changes extends PlaySpec
               rows.count(_.label.equals("confirmation.responsiblepeople.fp.passed")) must be(1)
             }
           }
-
         }
 
         "each of the categorised fees are in the response" in new Fixture {
@@ -1768,7 +1761,7 @@ class ConfirmationServiceSpecWithPhase2Changes extends PlaySpec
 
             val submissionData = Seq(
               BreakdownRow("confirmation.submission", 0, 0, 0),
-              BreakdownRow("confirmation.responsiblepeople",0, 100, 0),
+              BreakdownRow("confirmation.responsiblepeople",0,100,0),
               BreakdownRow("confirmation.tradingpremises", 1, 115, 0)
             )
 
@@ -1797,7 +1790,7 @@ class ConfirmationServiceSpecWithPhase2Changes extends PlaySpec
 
             val submissionData = Seq(
               BreakdownRow("confirmation.submission", 1, 100, 100),
-              BreakdownRow("confirmation.responsiblepeople",0, 100, 0),
+              BreakdownRow("confirmation.responsiblepeople",0,100,0),
               BreakdownRow("confirmation.tradingpremises", 1, 115, 0)
             )
 
@@ -1857,8 +1850,6 @@ class ConfirmationServiceSpecWithPhase2Changes extends PlaySpec
 
         }
       }
-
     }
-
   }
 }


### PR DESCRIPTION
Changes to sole proprietor question:

- changed flow to not display sole proprietor question when people will update date of birth or fit and proper data but to redirect them appropriately to VAT or SA page
- removed two not valid tests when the toggle is true

## Related / Dependant PRs?

Was depending on AMLS-4355 but 4355 is already merged to master

## How Has This Been Tested?

Unit tests, manual tests

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
