### PR TITLE
AMLS-3754-v2 | AMLS4394 approval question show on CYA page based on B…

### DIFF
--- a/app/models/businessmatching/BusinessMatching.scala
+++ b/app/models/businessmatching/BusinessMatching.scala
@@ -20,6 +20,7 @@ import models.businesscustomer.ReviewDetails
 import models.businessmatching.BusinessType.{LPrLLP, LimitedCompany, UnincorporatedBody}
 import models.registrationprogress.{Completed, NotStarted, Section, Started}
 import uk.gov.hmrc.http.cache.client.CacheMap
+import utils.ControllerHelper
 
 case class BusinessMatching(
                              reviewDetails: Option[ReviewDetails] = None,
@@ -33,6 +34,22 @@ case class BusinessMatching(
                              preAppComplete: Boolean = false
 
                            ) {
+
+  def msbOrTcsp: Boolean = {
+    msb || tcsp
+  }
+
+  def msb: Boolean = {
+    activities.foldLeft(false) { (x, y) =>
+      y.businessActivities.contains(MoneyServiceBusiness)
+    }
+  }
+
+  def tcsp: Boolean = {
+    activities.foldLeft(false) { (x, y) =>
+      y.businessActivities.contains(TrustAndCompanyServices)
+    }
+  }
 
   def activities(p: BusinessActivities): BusinessMatching =
     this.copy(activities = Some(p), hasChanged = hasChanged || !this.activities.contains(p), hasAccepted = hasAccepted && this.activities.contains(p))

--- a/app/views/responsiblepeople/detailed_answers.scala.html
+++ b/app/views/responsiblepeople/detailed_answers.scala.html
@@ -22,7 +22,13 @@
 @import forms.EmptyForm
 @import config.ApplicationConfig
 
-@(model: Option[ResponsiblePerson], idx: Int, showHide: Boolean = false, rpName: String = "", flow: Option[String] = None)(implicit request: Request[_],m:Messages, lang: Lang)
+@(model: Option[ResponsiblePerson],
+    idx: Int,
+    showHide: Boolean = false,
+    rpName: String = "",
+    flow: Option[String] = None,
+    showApprovalSection: Boolean = false
+)(implicit request: Request[_],m:Messages, lang: Lang)
 
 @detailedAnswers[T](
     question: String = "",
@@ -430,19 +436,20 @@
             }
         }
 
-        @person.approvalFlags.hasAlreadyPaidApprovalCheck.map { fp =>
-            @detailedAnswers(
-                question = Messages("responsiblepeople.detailed_answers.already_paid_approval_check", personName),
-                editUrl = controllers.responsiblepeople.routes.ApprovalCheckController.get(idx, true, flow).toString(),
-                dataItem = person.approvalFlags.hasAlreadyPaidApprovalCheck
-            ) { fp2 =>
-                <p>@fp match {
-                    case true => {@Messages("lbl.yes")}
-                    case false => {@Messages("lbl.no")}
-                }</p>
+        @if(showApprovalSection) {
+            @person.approvalFlags.hasAlreadyPaidApprovalCheck.map { fp =>
+                @detailedAnswers(
+                    question = Messages("responsiblepeople.detailed_answers.already_paid_approval_check", personName),
+                    editUrl = controllers.responsiblepeople.routes.ApprovalCheckController.get(idx, true, flow).toString(),
+                    dataItem = person.approvalFlags.hasAlreadyPaidApprovalCheck
+                ) { fp2 =>
+                    <p>@fp match {
+                        case true => {@Messages("lbl.yes")}
+                        case false => {@Messages("lbl.no")}
+                    }</p>
+                }
             }
         }
-
     }
 
     @form(EmptyForm, controllers.responsiblepeople.routes.DetailedAnswersController.post(idx, flow)) {

--- a/test/views/responsiblepeople/detailed_answersSpec.scala
+++ b/test/views/responsiblepeople/detailed_answersSpec.scala
@@ -282,28 +282,50 @@ class detailed_answersSpec extends AmlsSpec
 
       }
 
-        "approval check was paid" in new ViewFixture {
-          val responsiblePeopleModelWithApprovalCheck = responsiblePeopleModel.copy(
-            approvalFlags = ApprovalFlags(hasAlreadyPassedFitAndProper = Some(true), hasAlreadyPaidApprovalCheck = Some(true))
-          )
+      "approval check was paid" in new ViewFixture {
+        val responsiblePeopleModelWithApprovalCheck = responsiblePeopleModel.copy(
+          approvalFlags = ApprovalFlags(hasAlreadyPassedFitAndProper = Some(true), hasAlreadyPaidApprovalCheck = Some(true))
+        )
 
-          override val sectionChecks = Table[String, Element => Boolean](
-            ("title key", "check"),
-            (Messages("responsiblepeople.detailed_answers.already_paid_approval_check", personName.fullName), checkElementTextIncludes(_, "Yes"))
-          )
+        override val sectionChecks = Table[String, Element => Boolean](
+          ("title key", "check"),
+          (Messages("responsiblepeople.detailed_answers.already_paid_approval_check", personName.fullName), checkElementTextIncludes(_, "Yes"))
+        )
 
-          def view = {
-            views.html.responsiblepeople.detailed_answers(Some(responsiblePeopleModelWithApprovalCheck), 1, true, personName.fullName)
+        def view = {
+          views.html.responsiblepeople.detailed_answers(Some(responsiblePeopleModelWithApprovalCheck), 1, true, personName.fullName, showApprovalSection = true)
+        }
+
+        forAll(sectionChecks) { (key, check) => {
+          val headers = doc.select("section.check-your-answers h2")
+          val header = headers.toList.find(e => e.text() == key)
+
+          header must not be None
+          val section = header.get.parents().select("section").first()
+          check(section) must be(true)
           }
+        }
+      }
 
-          forAll(sectionChecks) { (key, check) => {
-            val headers = doc.select("section.check-your-answers h2")
-            val header = headers.toList.find(e => e.text() == key)
+      "approval check question is not shown if show flag" in new ViewFixture {
+        val responsiblePeopleModelWithApprovalCheck = responsiblePeopleModel.copy(
+          approvalFlags = ApprovalFlags(hasAlreadyPassedFitAndProper = Some(true), hasAlreadyPaidApprovalCheck = Some(true))
+        )
 
-            header must not be None
-            val section = header.get.parents().select("section").first()
-            check(section) must be(true)
+        override val sectionChecks = Table[String, Element => Boolean](
+          ("title key", "check"),
+          (Messages("responsiblepeople.detailed_answers.already_paid_approval_check", personName.fullName), checkElementTextIncludes(_, "Yes"))
+        )
 
+        def view = {
+          views.html.responsiblepeople.detailed_answers(Some(responsiblePeopleModelWithApprovalCheck), 1, true, personName.fullName, showApprovalSection = false)
+        }
+
+        forAll(sectionChecks) { (key, check) => {
+          val headers = doc.select("section.check-your-answers h2")
+          val header = headers.toList.find(e => e.text() == key)
+
+          header must be(None)
           }
         }
       }


### PR DESCRIPTION
this is to make the code show the "passed Approval" question on the CYA base on:
MSB\TCSP, F&P=Yes|No -> dont show
others, F&P=Yes -> dont show
others, F&P=NO -> show


## Related / Dependant PRs?

<!--- List any related issues here -->

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
