### PR TITLE
AMLS-4516 | Bug fix

### DIFF
--- a/test/controllers/hvd/ExpectToReceiveCashPaymentsControllerSpec.scala
+++ b/test/controllers/hvd/ExpectToReceiveCashPaymentsControllerSpec.scala
@@ -116,6 +116,17 @@ class ExpectToReceiveCashPaymentsControllerSpec extends AmlsSpec with MockitoSug
           status(result) must be(BAD_REQUEST)
 
         }
+        "check that error message -no option selected- exists in the request" in new Fixture {
+          val message = Messages("error.required.hvd.choose.option")
+
+          val result = controller.post(true)(request.withFormUrlEncodedBody())
+
+          val content = contentAsString(result)
+
+          status(result) must be(BAD_REQUEST)
+          Jsoup.parse(content).body().getElementsByClass("validation-summary-message").first().html() must include(message)
+          Jsoup.parse(content).body().getElementById("paymentMethods").html() must include(message)
+        }
       }
     }
 


### PR DESCRIPTION
When user is trying to submit page without selecting any of possible options there should be an error displayed above checkbox group (error-notification rendered). In this pull request there's a fix for this issue which was discovered on expect_to_receive page for High Value Dealers. Error notification need to be displayed in order to generate Google Analytics event for an error.

## Related / Dependant PRs?

none

## How Has This Been Tested?

- manual tests
- unit tests
- regression run
- need to be additionally tested in QA where the GA events can be tracked

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
