### PR TITLE
AMLS-4558-failed-future-fix | added the page redirection when the cal…

### DIFF
--- a/app/controllers/LandingController.scala
+++ b/app/controllers/LandingController.scala
@@ -143,7 +143,7 @@ class LandingController @Inject()(val landingService: LandingService,
             val hasIncompleteRps: Option[Boolean] = for {
               rps <- cache.map(_.getEntry[Seq[ResponsiblePerson]](ResponsiblePerson.key))
             } yield ControllerHelper.hasIncompleteResponsiblePerson(rps)
-            Logger.debug(s"[AMLSLandingController][hasIncompleteResponsiblePeople]: Rps.isComplete = ${hasIncompleteRps.contains(true)}")
+            Logger.debug(s"[AMLSLandingController][hasIncompleteResponsiblePeople]: hasInCompleteResponsbilePeople = ${hasIncompleteRps.contains(true)}")
             hasIncompleteRps.contains(true)
         }
     }
@@ -221,11 +221,14 @@ class LandingController @Inject()(val landingService: LandingService,
               Logger.debug("[AMLSLandingController][refreshAndRedirect]: redirect is successful()")
               r
             case Failure(ex) =>
-              Logger.debug(s"[AMLSLandingController][refreshAndRedirect]: op failed with ${ex.getMessage} - redirecting to StatusController")
-              Future.successful(Redirect(controllers.routes.StatusController.get()))
-            case _ =>
-              Logger.debug(s"[AMLSLandingController][refreshAndRedirect]: refresh cache returned _ and redirecting to StatusController")
-              Future.successful(Redirect(controllers.routes.StatusController.get()))
+              hasIncompleteResponsiblePeople() map {
+                case true =>
+                  Logger.debug(s"[AMLSLandingController][refreshAndRedirect]: got a future.Failure with incomplete RPs, redirecting to LoginEvent")
+                  Redirect(controllers.routes.LoginEventController.get())
+                case false =>
+                  Logger.debug(s"[AMLSLandingController][refreshAndRedirect]: got a future.Failure with complete RPs, redirecting to StatusController")
+                  Redirect(controllers.routes.StatusController.get())
+              }
           }
         }
     }

--- a/app/controllers/LandingController.scala
+++ b/app/controllers/LandingController.scala
@@ -221,6 +221,7 @@ class LandingController @Inject()(val landingService: LandingService,
               Logger.debug("[AMLSLandingController][refreshAndRedirect]: redirect is successful()")
               r
             case Failure(ex) =>
+              Logger.debug(s"[AMLSLandingController][refreshAndRedirect]: op failed with ${ex.getMessage} - redirecting to StatusController")
               hasIncompleteResponsiblePeople() map {
                 case true =>
                   Logger.debug(s"[AMLSLandingController][refreshAndRedirect]: got a future.Failure with incomplete RPs, redirecting to LoginEvent")


### PR DESCRIPTION
when the call to getEntry[SubscriptionResponse] fail we still check which page should we go to


[Your pull request description here]

## Related / Dependant PRs?

<!--- List any related issues here -->

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [ ] Appropriate labels added.
