### PR TITLE
Amls 4471 | Bug Fix: Fees table (accesibility)

### DIFF
--- a/app/views/confirmation/breakdown.scala.html
+++ b/app/views/confirmation/breakdown.scala.html
@@ -22,21 +22,21 @@
     <summary class="summary">@Messages("confirmation.itemisedfeelink")</summary>
     <div class="details__inner">
         <ul class="list">
-            <table>
-                <caption>@summary</caption>
+            <span id="tblDesc">@summary</span>
+            <table aria-describedby="tblDesc">
                 <thead>
                     <tr>
-                        <th>@Messages("confirmation.item")</th>
-                        <th width="15%" class="numeric">@Messages("confirmation.quantity")</th>
-                        <th width="20%" class="numeric">@Messages("confirmation.feeperitem")</th>
-                        <th width="20%" class="numeric">@Messages("confirmation.totalfee")</th>
+                        <th scope="col">@Messages("confirmation.item")</th>
+                        <th scope="col" width="15%" class="numeric">@Messages("confirmation.quantity")</th>
+                        <th scope="col" width="20%" class="numeric">@Messages("confirmation.feeperitem")</th>
+                        <th scope="col" width="20%" class="numeric">@Messages("confirmation.totalfee")</th>
                     </tr>
                 </thead>
                 <tbody>
                 @breakdown.map {
                     case BreakdownRow(label, quantity, perItem, total) => {
                         <tr>
-                            <td>@Messages(label)</td>
+                            <td scope="row">@Messages(label)</td>
                             <td class="numeric">@quantity</td>
                             <td class="numeric">@perItem</td>
                             <td class="numeric">@total</td>

--- a/app/views/confirmation/confirmation_new.scala.html
+++ b/app/views/confirmation/confirmation_new.scala.html
@@ -47,14 +47,14 @@
         @detailsSummary(
             summary = Messages("confirmation.breakdown.details")
         ) {
-            <table>
-                <caption>@Messages("confirmation.breakdown")</caption>
+            <span id="tblDesc">@Messages("confirmation.breakdown")</span>
+            <table aria-describedby="tblDesc">
                 <thead>
                     <tr>
-                        <th>@Messages("confirmation.item")</th>
-                        <th width="15%" class="numeric">@Messages("confirmation.quantity")</th>
-                        <th width="20%" class="numeric">@Messages("confirmation.feeperitem")</th>
-                        <th width="20%" class="numeric">@Messages("confirmation.totalfee")</th>
+                        <th scope="col">@Messages("confirmation.item")</th>
+                        <th scope="col" width="15%" class="numeric">@Messages("confirmation.quantity")</th>
+                        <th scope="col" width="20%" class="numeric">@Messages("confirmation.feeperitem")</th>
+                        <th scope="col" width="20%" class="numeric">@Messages("confirmation.totalfee")</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -62,7 +62,7 @@
                 @rows.map {
                     case BreakdownRow(label, quantity, perItem, totalFees) => {
                         <tr>
-                            <td>@Messages(label)</td>
+                            <td scope="row">@Messages(label)</td>
                             <td class="numeric">@quantity</td>
                             <td class="numeric">@perItem</td>
                             <td class="numeric">@totalFees</td>


### PR DESCRIPTION
Bug fix: Table caption not read out when reading whole page. Changed caption to span with ariaDescribedBy. Added scopes for headers to be readout using other screen readers than VO ex. JAWS. VO is not supporting scopes.

## Related / Dependant PRs?

none

## How Has This Been Tested?

- manual tests
- unit tests run

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
