### PR TITLE
AMLS-4675 | Buf fix for notifications with <no subject> and no content. Missing content was defaulted to 'no content' text when no message details are available.

### DIFF
--- a/app/services/NotificationService.scala
+++ b/app/services/NotificationService.scala
@@ -60,7 +60,10 @@ class NotificationService @Inject()(val amlsNotificationConnector: AmlsNotificat
 
       case _ => (for {
         details <- OptionT(amlsNotificationConnector.getMessageDetailsByAmlsRegNo(amlsRegNo, id))
-        messageText <- OptionT.fromOption[Future](details.messageText)
+        messageText <- OptionT.fromOption[Future](details.messageText match {
+          case t@Some(_) => t
+          case _ => Some("notifications.content.NoContent")
+        })
       } yield details.copy(messageText = Some(CustomAttributeProvider.commonMark(NotificationDetails.processGenericMessage(messageText))))).value
     }
   }

--- a/conf/messages
+++ b/conf/messages
@@ -2016,6 +2016,8 @@ notifications.subject.DeRegistrationEffectiveDateChange = Your de-registration d
 
 notifications.subject.NoSubject = <no subject>
 
+notifications.content.NoContent = <![CDATA[<P>No content</P>]]>
+
 notifications.previousReg = Messages from your previous registrations
 
 notifications.header = Your messages


### PR DESCRIPTION
AMLS-4675 | Buf fix for notifications with <no subject> and no content. Missing content was defaulted to 'no content' text when no message details are available.

## Related / Dependant PRs?

- none

## How Has This Been Tested?

- unit tests run

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
