### PR TITLE
AMLS-3717 | New Officer Controller validation

### DIFF
--- a/app/controllers/changeofficer/NewOfficerController.scala
+++ b/app/controllers/changeofficer/NewOfficerController.scala
@@ -16,22 +16,21 @@
 
 package controllers.changeofficer
 
-import javax.inject.Inject
-
 import cats.data.OptionT
+import cats.implicits._
 import connectors.DataCacheConnector
 import controllers.BaseController
-import forms.{EmptyForm, Form2, InvalidForm, ValidForm}
+import forms.{Form2, InvalidForm, ValidForm}
+import javax.inject.Inject
 import models.changeofficer.{ChangeOfficer, NewOfficer, RoleInBusiness}
 import models.responsiblepeople.ResponsiblePerson
 import models.responsiblepeople.ResponsiblePerson.flowChangeOfficer
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
+import utils.StatusConstants
 
 import scala.concurrent.Future
-import cats.implicits._
-import utils.StatusConstants
-import uk.gov.hmrc.http.HeaderCarrier
 
 class NewOfficerController @Inject()(val authConnector: AuthConnector, cacheConnector: DataCacheConnector) extends BaseController {
 
@@ -80,6 +79,6 @@ class NewOfficerController @Inject()(val authConnector: AuthConnector, cacheConn
       people <- OptionT(cacheConnector.fetch[Seq[ResponsiblePerson]](ResponsiblePerson.key))
       changeOfficer <- OptionT(cacheConnector.fetch[ChangeOfficer](ChangeOfficer.key)) orElse OptionT.pure(ChangeOfficer(RoleInBusiness(Set.empty)))
       selectedOfficer <- OptionT.fromOption[Future](changeOfficer.newOfficer) orElse OptionT.some(NewOfficer(""))
-    } yield (selectedOfficer, people.filter(p => p.personName.isDefined & !p.status.contains(StatusConstants.Deleted)))
+    } yield (selectedOfficer, people.filter(p => p.personName.isDefined & p.isComplete & !p.status.contains(StatusConstants.Deleted)))
   }
 }

--- a/release_notes/AMLS-3717.txt
+++ b/release_notes/AMLS-3717.txt
@@ -1,0 +1,1 @@
+ + [AMLS-3717](https://jira.tools.tax.service.gov.uk/browse/AMLS-3717) - 'NewOfficerController now only displays complete employees for selection as Nominated Officer'

--- a/test/generators/ResponsiblePersonGenerator.scala
+++ b/test/generators/ResponsiblePersonGenerator.scala
@@ -16,12 +16,11 @@
 
 package generators
 
-import config.ApplicationConfig
-import models.responsiblepeople._
-import org.scalacheck.Gen
 import models.FormTypes
 import models.responsiblepeople.TimeAtAddress.ThreeYearsPlus
+import models.responsiblepeople._
 import org.joda.time.LocalDate
+import org.scalacheck.Gen
 
 // scalastyle:off magic.number
 trait ResponsiblePersonGenerator extends BaseGenerator {
@@ -82,6 +81,39 @@ trait ResponsiblePersonGenerator extends BaseGenerator {
     None,
     Some(SoleProprietorOfAnotherBusiness(false))
   )
+
+  val completeResponsiblePersonGen: Gen[ResponsiblePerson] = for {
+    personName <- personNameGen
+    positions <- positionsGen
+    phoneNumber <- numSequence(10)
+    email <- emailGen
+    address <- personAddressGen
+  } yield new ResponsiblePerson(
+    Some(personName),
+    Some(PreviousName(hasPreviousName = Some(false), None, None, None)),
+    None,
+    Some(KnownBy(Some(false), None)),
+    Some(PersonResidenceType(NonUKResidence, None, None)),
+    None,
+    None,
+    None,
+    Some(ContactDetails(phoneNumber, email)),
+    Some(ResponsiblePersonAddressHistory(Some(ResponsiblePersonCurrentAddress(address, Some(ThreeYearsPlus), None)))),
+    Some(positions),
+    Some(SaRegisteredNo),
+    None,
+    Some(ExperienceTrainingNo),
+    Some(TrainingNo),
+    approvalFlags = ApprovalFlags(hasAlreadyPassedFitAndProper = None),
+    hasChanged = false,
+    hasAccepted = true,
+    None,
+    None,
+    None,
+    Some(SoleProprietorOfAnotherBusiness(false))
+  ) {
+    override def isComplete: Boolean = true
+  }
 
   def responsiblePersonWithPositionsGen(positions: Option[Set[PositionWithinBusiness]]): Gen[ResponsiblePerson] = for {
     person <- responsiblePersonGen

--- a/test/models/responsiblepeople/ResponsiblePersonSpec.scala
+++ b/test/models/responsiblepeople/ResponsiblePersonSpec.scala
@@ -16,10 +16,7 @@
 
 package models.responsiblepeople
 
-import controllers.responsiblepeople.NinoUtil
-import models.Country
 import models.registrationprogress.{Completed, NotStarted, Started}
-import models.responsiblepeople.TimeAtAddress.{OneToThreeYears, SixToElevenMonths, ZeroToFiveMonths}
 import org.joda.time.LocalDate
 import org.mockito.Matchers.{any, eq => meq}
 import org.mockito.Mockito._


### PR DESCRIPTION
Updated NewOfficerController to only display complete responsible people. Updates to spec required, and updates to ResponsiblePersonGenerator in order to test with complete / incomplete people.

## Related / Dependant PRs?

NA

## How Has This Been Tested?

Passes spec tests and regression tests

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [X] Build passing.
- [X] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ dd] Requires acceptance test run.
- [X] Appropriate labels added.
- [X] RELEASE NOTES ADDED.