### PR TITLE
Amls 4728 - Updated YTP "continue" button content

### DIFF
--- a/app/views/tradingpremises/your_trading_premises.scala.html
+++ b/app/views/tradingpremises/your_trading_premises.scala.html
@@ -87,7 +87,7 @@
         </ul>
     }
 
-    @if(incompleteTp.nonEmpty) {
+    @if(incompleteTp.nonEmpty || (completeTp.isEmpty & incompleteTp.isEmpty)) {
         @form(f, controllers.routes.RegistrationProgressController.get()) {
             @submit(false, Some(Messages("button.returntoapplicationprogress")), returnLink = false)
         }

--- a/app/views/tradingpremises/your_trading_premises.scala.html
+++ b/app/views/tradingpremises/your_trading_premises.scala.html
@@ -87,7 +87,15 @@
         </ul>
     }
 
-    @form(f, controllers.routes.RegistrationProgressController.get()) {
-        @submit(false, Some(Messages("button.checkyouranswers.acceptandcomplete")), returnLink = false)
+    @if(incompleteTp.nonEmpty) {
+        @form(f, controllers.routes.RegistrationProgressController.get()) {
+            @submit(false, Some(Messages("button.returntoapplicationprogress")), returnLink = false)
+        }
+    } else {
+        @form(f, controllers.routes.RegistrationProgressController.get()) {
+            @submit(false, Some(Messages("button.checkyouranswers.acceptandcomplete")), returnLink = false)
+            }
+        }
     }
-}
+
+

--- a/release_notes/AMLS-4728.txt
+++ b/release_notes/AMLS-4728.txt
@@ -1,0 +1,1 @@
+ + [AMLS-4728](https://jira.tools.tax.service.gov.uk/browse/AMLS-4728) - 'Changed TP button content if incomplete tp is there'

--- a/test/views/tradingpremises/your_trading_premisesSpec.scala
+++ b/test/views/tradingpremises/your_trading_premisesSpec.scala
@@ -22,6 +22,7 @@ import models.status.NotCompleted
 import models.tradingpremises.{Address, TradingPremises, YourTradingPremises}
 import org.scalatest.MustMatchers
 import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
 import utils.AmlsSpec
 import views.Fixture
 
@@ -114,6 +115,26 @@ class your_trading_premisesSpec extends AmlsSpec with MustMatchers with TradingP
       doc.getElementById("detail-edit-3").attr("href") must be(controllers.tradingpremises.routes.YourTradingPremisesController.getIndividual(4, true).url)
       doc.getElementById("detail-remove-3").attr("href") must be(controllers.tradingpremises.routes.RemoveTradingPremisesController.get(4).url)
 
+    }
+
+    "show the correct continuation button when there are both types of lists" in new ViewFixture {
+      def  view = views.html.tradingpremises.your_trading_premises(EmptyForm, false, NotCompleted, completeTpSeq, incompleteTpSeq)
+      html must include(Messages("button.returntoapplicationprogress"))
+    }
+
+    "show the correct continuation button when there are only incomplete tps" in new ViewFixture {
+      def  view = views.html.tradingpremises.your_trading_premises(EmptyForm, false, NotCompleted, Seq.empty[(TradingPremises, Int)], incompleteTpSeq)
+      html must include(Messages("button.returntoapplicationprogress"))
+    }
+
+    "show the correct continuation button when there are only complete TP's" in new ViewFixture {
+      def  view = views.html.tradingpremises.your_trading_premises(EmptyForm, false, NotCompleted, completeTpSeq, Seq.empty[(TradingPremises, Int)])
+      html must include(Messages("button.checkyouranswers.acceptandcomplete"))
+    }
+
+    "show the correct continuation button when there are no TPs" in new ViewFixture {
+      def view = views.html.tradingpremises.your_trading_premises(EmptyForm, false, NotCompleted, Seq.empty[(TradingPremises, Int)], Seq.empty[(TradingPremises, Int)])
+      html must include (Messages("button.returntoapplicationprogress"))
     }
   }
 }


### PR DESCRIPTION
If there is an incomplete trading premises in the list of Your trading premises. The button now reads "Return to application progress" 

If all trading premises are complete the button reads "Accept and complete section"

## Related / Dependant PRs?

<!--- List any related issues here -->

## How Has This Been Tested?

Manually
May need acceptance test check/run - Left checkbox blank

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
