### PR TITLE
AMLS-4628 | Added visually hidden label for form on "name change" page

### DIFF
--- a/app/views/responsiblepeople/legal_name_change_date.scala.html
+++ b/app/views/responsiblepeople/legal_name_change_date.scala.html
@@ -35,7 +35,10 @@
         @date(
             f = f,
             p = "date",
+            labelText = "responsiblepeople.legalnamechangedate.title",
+            legendHidden = true,
             example = true
+
         )
 
 

--- a/release_notes/AMLS-4628.txt
+++ b/release_notes/AMLS-4628.txt
@@ -1,0 +1,1 @@
+ + [AMLS-4628](https://jira.tools.tax.service.gov.uk/browse/AMLS-4628) - 'Added visually hidden label to "When did X's name change?" form'


### PR DESCRIPTION
Simple change - added visually hidden label to date field in legal_name_change_date.scala.html, as per other date fields on site, so label is now read out by VO.

## Related / Dependant PRs?

## How Has This Been Tested?

Passed spec tests, tested using MacOS VO

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [X] Build passing.
- [X] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [X] Appropriate labels added.
- [X] RELEASE NOTES ADDED.