### PR TITLE
AMLS-4603 | Bug fix

### DIFF
--- a/app/controllers/supervision/ProfessionalBodyMemberController.scala
+++ b/app/controllers/supervision/ProfessionalBodyMemberController.scala
@@ -66,8 +66,7 @@ class ProfessionalBodyMemberController @Inject()(
 
   def redirectTo(data: ProfessionalBodyMember, supervision: Supervision, edit: Boolean) =
     (data, edit) match {
-      case (ProfessionalBodyMemberYes, _) if !supervision.professionalBodyMember.contains(ProfessionalBodyMemberYes) =>
-        Redirect(routes.WhichProfessionalBodyController.get(edit))
+      case (ProfessionalBodyMemberYes, _) if !supervision.isComplete => Redirect(routes.WhichProfessionalBodyController.get(edit))
       case (ProfessionalBodyMemberNo, false) => Redirect(routes.PenalisedByProfessionalController.get())
       case _ => Redirect(routes.SummaryController.get())
     }

--- a/release_notes/AMLS-4603.txt
+++ b/release_notes/AMLS-4603.txt
@@ -1,0 +1,1 @@
+ + [AMLS-4603](https://jira.tools.tax.service.gov.uk/browse/AMLS-4603) - 'Bug fix: Flow does not break on Which professional body are you member of? anymore'

--- a/test/controllers/supervision/ProfessionalBodyMemberControllerSpec.scala
+++ b/test/controllers/supervision/ProfessionalBodyMemberControllerSpec.scala
@@ -113,15 +113,25 @@ class ProfessionalBodyMemberControllerSpec extends AmlsSpec with MockitoSugar {
       "redirect to SummaryController" when {
         "edit is true" when {
           "isMember is true" when {
-            "ProfessionalBodyMemberYes is already defined" in new Fixture {
+            "ProfessionalBodyMemberYes is already defined and professional bodies provided" in new Fixture {
 
               val newRequest = request.withFormUrlEncodedBody(
                 "isAMember" -> "true"
               )
 
-              mockCacheFetch[Supervision](Some(Supervision(
-                professionalBodyMember = Some(ProfessionalBodyMemberYes)
+              val cache = mockCacheFetch[Supervision](Some(Supervision(
+                anotherBody = Some(AnotherBodyNo),
+                professionalBodyMember = Some(ProfessionalBodyMemberYes),
+                professionalBodies = Some(ProfessionalBodies(Set(AccountingTechnicians))),
+                professionalBody = Some(ProfessionalBodyNo),
+                hasChanged = true,
+                hasAccepted = true
               )))
+
+              val complete = mock[Supervision]
+
+              when(complete.isComplete) thenReturn true
+              when(mockCacheMap.getEntry[Supervision]("supervision")) thenReturn Some(complete)
 
               val result = controller.post(true)(newRequest)
               status(result) must be(SEE_OTHER)


### PR DESCRIPTION
Flow break when going back on question: Which professional body are you a member of? was fixed by changing redirection conditions in ProfessionalBodyMemberController.

## Related / Dependant PRs?

- none

## How Has This Been Tested?

- manually
- regression sections involving supervision

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
