### PR TITLE
Amls 4757

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -400,7 +400,9 @@ button.continuetopayment = Continue to payment
 button.returntosummary = Return to Summary
 button.confirmandsubmit = Confirm and submit
 button.confirmandcontinue = Confirm and continue
-button.returntoapplicationprogress = Return to application progress
+
+button.returntoapplicationprogress = Return to about your business
+
 button.payfee = Pay registration fee
 button.amendment.payfee = Pay amendment fee
 button.logout = Log out
@@ -496,8 +498,8 @@ lbl.hint.crn = It’s 8 characters and can be just numbers, or a mix of numbers 
 
 lbl.hint.vat = It's 9 numbers with no letters, punctuation or other characters.
 
-link.return.registration.progress = Return to application progress
-link.return.renewal.progress = Return to renewal progress
+link.return.registration.progress = Return to about your business
+link.return.renewal.progress = Return to about your business
 link.renewal.progress.change.answers = Change your answers
 link.print = Print
 

--- a/release_notes/AMLS-4757.txt
+++ b/release_notes/AMLS-4757.txt
@@ -1,0 +1,1 @@
+ + [AMLS-4757](https://jira.tools.tax.service.gov.uk/browse/AMLS-4757) - 'Change Return to application progress link and button to Return to about your business'


### PR DESCRIPTION
Replace 'Return to application progress' link to 'Return to about your business'

The following pages also have a green Return to application progress link given there is incomplete data. We need to update this link to say Return to about your business on the following pages

- Your trading premises
- Your bank accounts
- Your responsible people
- 

The renewal journey has a Return to renewal progress link, this needs changed to say 'Return to about your business'

## Related / Dependant PRs?

https://github.com/hmrc/amls-acceptance-test/pull/152

## How Has This Been Tested?

Unit + local + regression. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
