### PR TITLE
AMLS-4796 | Supervision bug fix

### DIFF
--- a/app/controllers/supervision/SummaryController.scala
+++ b/app/controllers/supervision/SummaryController.scala
@@ -24,6 +24,7 @@ import forms.EmptyForm
 import javax.inject.Inject
 import models.supervision.Supervision
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
+import utils.ControllerHelper
 import views.html.supervision.summary
 
 class SummaryController  @Inject() (val dataCacheConnector: DataCacheConnector,
@@ -33,7 +34,8 @@ class SummaryController  @Inject() (val dataCacheConnector: DataCacheConnector,
   def get() = Authorised.async {
     implicit authContext => implicit request =>
       dataCacheConnector.fetch[Supervision](Supervision.key) map {
-        case Some(data) => Ok(summary(EmptyForm, data))
+        case Some(data@Supervision(Some(anotherBody), Some(_), _, Some(_), _, _)) if ControllerHelper.isAbComplete(anotherBody) =>
+          Ok(summary(EmptyForm, data))
         case _ =>
           Redirect(controllers.routes.RegistrationProgressController.get())
       }

--- a/app/utils/ControllerHelper.scala
+++ b/app/utils/ControllerHelper.scala
@@ -25,7 +25,7 @@ import models.renewal.CustomersOutsideUK
 import models.responsiblepeople.ResponsiblePerson.filter
 import models.responsiblepeople.{NonUKResidence, ResponsiblePerson}
 import models.status._
-import models.supervision.{AnotherBodyNo, AnotherBodyYes, Supervision}
+import models.supervision.{AnotherBody, AnotherBodyNo, AnotherBodyYes, Supervision}
 import play.api.Play.current
 import play.api.i18n.Messages
 import play.api.i18n.Messages.Implicits._
@@ -192,6 +192,12 @@ object ControllerHelper {
 
   def supervisionComplete(cache: CacheMap) = cache.getEntry[Supervision](Supervision.key) match {
     case Some(supervision) => supervision.isComplete
+    case _ => false
+  }
+
+  def isAbComplete(anotherBody: AnotherBody): Boolean = anotherBody match {
+    case AnotherBodyYes(_, Some(_), Some(_), Some(_)) => true
+    case AnotherBodyNo => true
     case _ => false
   }
 }

--- a/app/views/supervision/summary.scala.html
+++ b/app/views/supervision/summary.scala.html
@@ -43,7 +43,7 @@
             }
         }
 
-        case AnotherBodyYes(supervisorName, startDate, endDate, endingReasons) => {
+        case AnotherBodyYes(supervisorName, Some(sDate), Some(eDate), Some(reasons)) => {
             @checkYourAnswers(
                 question = Messages("supervision.another_body.title"),
                 editLinkTag = "supervisionanotherbody-edit-name",
@@ -57,7 +57,7 @@
                 editLinkTag = "supervisionanotherbody-edit-start-date",
                 editUrl = controllers.supervision.routes.SupervisionStartController.get(true).toString
             ) {
-                    <p>@DateHelper.formatDate(startDate.get.startDate)</p>
+                <p>@DateHelper.formatDate(sDate.startDate)</p>
             }
 
             @checkYourAnswers(
@@ -65,7 +65,7 @@
                 editLinkTag = "supervisionanotherbody-edit-end-date",
                 editUrl = controllers.supervision.routes.SupervisionEndController.get(true).toString
             ) {
-                <p>@DateHelper.formatDate(endDate.get.endDate)</p>
+                <p>@DateHelper.formatDate(eDate.endDate)</p>
             }
 
             @checkYourAnswers(
@@ -73,10 +73,9 @@
                 editLinkTag = "supervisionanotherbody-edit-ending-reason",
                 editUrl = controllers.supervision.routes.SupervisionEndReasonsController.get(true).toString
             ) {
-                <p>@endingReasons.get.endingReason</p>
+                <p>@reasons.endingReason</p>
             }
         }
-
     }
 
     @checkYourAnswers(

--- a/release_notes/AMLS-4796.txt
+++ b/release_notes/AMLS-4796.txt
@@ -1,0 +1,1 @@
+ + [AMLS-4796](https://jira.tools.tax.service.gov.uk/browse/AMLS-4796) - 'Bug fix: supervision section summary page breaks when user is navigating back through the section'

--- a/test/controllers/supervision/SummaryControllerSpec.scala
+++ b/test/controllers/supervision/SummaryControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers.supervision
 
 import models.asp.Asp
-import models.supervision.Supervision
+import models.supervision.{Supervision, SupervisionValues}
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 
 class SummaryControllerSpec extends AmlsSpec with MockitoSugar {
 
-  trait Fixture extends AuthorisedFixture  with DependencyMocks{
+  trait Fixture extends AuthorisedFixture  with DependencyMocks with SupervisionValues {
     self => val request = addToken(authRequest)
 
     val controller = new SummaryController(mockCacheConnector, authConnector = self.authConnector)
@@ -39,20 +39,24 @@ class SummaryControllerSpec extends AmlsSpec with MockitoSugar {
   }
 
   "Get" must {
-
-    "load the summary page when section data is available" in new Fixture {
-
-
+    "load the summary page when section data is available and section is complete" in new Fixture {
 
       when(controller.dataCacheConnector.fetch[Supervision](any())
-        (any(), any(), any())).thenReturn(Future.successful(Some(model)))
+        (any(), any(), any())).thenReturn(Future.successful(Some(completeModel)))
 
       val result = controller.get()(request)
       status(result) must be(OK)
     }
 
-    "redirect to the main summary page when section data is unavailable" in new Fixture {
+    "redirect to the main summary page when section data is available but incomplete" in new Fixture {
+      when(controller.dataCacheConnector.fetch[Supervision](any())
+        (any(), any(), any())).thenReturn(Future.successful(Some(model)))
 
+      val result = controller.get()(request)
+      status(result) must be(SEE_OTHER)
+    }
+
+    "redirect to the main summary page when section data is unavailable" in new Fixture {
       when(controller.dataCacheConnector.fetch[Asp](any())
         (any(), any(), any())).thenReturn(Future.successful(None))
 

--- a/test/utils/ControllerHelperSpec.scala
+++ b/test/utils/ControllerHelperSpec.scala
@@ -169,5 +169,24 @@ class ControllerHelperSpec extends AmlsSpec with ResponsiblePeopleValues with De
         ControllerHelper.supervisionComplete(mockCacheMap) mustBe false
       }
     }
+
+    "isAbComplete" must {
+
+      val start = Some(SupervisionStart(new LocalDate(1990, 2, 24)))  //scalastyle:off magic.number
+      val end = Some(SupervisionEnd(new LocalDate(1998, 2, 24)))//scalastyle:off magic.number
+      val reason = Some(SupervisionEndReasons("Reason"))
+
+      "return true if another body is AnotherBodyNo" in {
+        ControllerHelper.isAbComplete(AnotherBodyNo) mustBe true
+      }
+
+      "return true if another body is complete AnotherBodyYes" in {
+        ControllerHelper.isAbComplete(AnotherBodyYes("Supervisor", start, end, reason)) mustBe true
+      }
+
+      "return false if another body is incomplete AnotherBodyYes" in {
+        ControllerHelper.isAbComplete(AnotherBodyYes("Supervisor", None, end, reason)) mustBe false
+      }
+    }
   }
 }


### PR DESCRIPTION
Steps to recreate in the ticket with the same number.

User navigating through the flow, then clicking back could get to the state when the supervision section is incomplete and clicking back to the summary page caused the error because of missing data.

To avoid this change has been implemented to display summary page only when Supervision section is  complete. In other cases user is being redirected to progress page. 

If as result of clicking back supervision section will get to incomplete state user will see that on progress page.

## Related / Dependant PRs?

- none

## How Has This Been Tested?

- unit tests
- manual tests
- regression run (supervision elements)

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
