### PR TITLE
AMLS-4772 | Bug fix: empty responsible people when trying to change nominated officer

### DIFF
--- a/app/controllers/changeofficer/NewOfficerController.scala
+++ b/app/controllers/changeofficer/NewOfficerController.scala
@@ -98,7 +98,7 @@ class NewOfficerController @Inject()(val authConnector: AuthConnector,
   }
 
   private def updateNominatedOfficers(oldOfficer: (ResponsiblePerson, Int), roles: RoleInBusiness, responsiblePeople: Seq[ResponsiblePerson], index: Int) = {
-    removeNominatedOfficers(responsiblePeople)
+    removeNominatedOfficers(ResponsiblePerson.filter(responsiblePeople))
       .patch(oldOfficer._2 - 1, Seq(updateRoles(oldOfficer._1, roles)), 1)
       .patch(index, Seq(addNominatedOfficer(responsiblePeople(index))), 1)
       .map(_.copy(hasAccepted = true))

--- a/release_notes/AMLS-4772.txt
+++ b/release_notes/AMLS-4772.txt
@@ -1,0 +1,1 @@
+ + [AMLS-4772](https://jira.tools.tax.service.gov.uk/browse/AMLS-4772) - 'Bug fix: empty responsible people when trying to change nominated officer'

--- a/test/controllers/changeofficer/NewOfficerControllerSpec.scala
+++ b/test/controllers/changeofficer/NewOfficerControllerSpec.scala
@@ -348,7 +348,7 @@ class NewOfficerControllerSpec extends AmlsSpec with ResponsiblePersonGenerator 
 
         val updateNominatedOfficers = PrivateMethod[Seq[ResponsiblePerson]]('updateNominatedOfficers)
 
-        val result = controller invokePrivate updateNominatedOfficers((oldOfficer, 1), RoleInBusiness(Set()), responsiblePeople, 0)
+        val result = controller invokePrivate updateNominatedOfficers((oldOfficer, 1), RoleInBusiness(Set()), responsiblePeople :+ emptyPerson, 0)
 
         result must equal(Seq(
           newOfficer.copy(
@@ -362,6 +362,8 @@ class NewOfficerControllerSpec extends AmlsSpec with ResponsiblePersonGenerator 
             hasAccepted = true
           )
         ))
+
+        result.seq.length must equal(2)
       }
     }
 


### PR DESCRIPTION
As above. Full description of issue in the ticket. 
Fixed it by filtering rp's before updating nominated officer entry.

## Related / Dependant PRs?

none

## How Has This Been Tested?

manually and unit tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
