### PR TITLE
AMLS-4821 | Fix - Country lookup field

### DIFF
--- a/app/views/include/forms2/country_autocomplete.scala.html
+++ b/app/views/include/forms2/country_autocomplete.scala.html
@@ -39,7 +39,7 @@
         }
 
         <select name="@field.name" id="@field.id" class="@classes.mkString(" ")" data-gov-autocomplete="true">
-            <option value=""></option>
+            <option>@field.value</option>
             @data.map { kvp =>
                 <option value="@kvp.value" @if(field.value.contains(kvp.value)) {selected}>@kvp.name</option>
             }

--- a/release_notes/AMLS-4821.txt
+++ b/release_notes/AMLS-4821.txt
@@ -1,0 +1,1 @@
+ + [AMLS-4821](https://jira.tools.tax.service.gov.uk/browse/AMLS-4821) - 'Fix - Country lookup field should retain invalid entry when showing validation error messages'

--- a/test/views/include/country_autocompleteSpec.scala
+++ b/test/views/include/country_autocompleteSpec.scala
@@ -16,8 +16,8 @@
 
 package views.include
 
-import forms.ValidField
-import jto.validation.Path
+import forms.{InvalidField, ValidField}
+import jto.validation.{Path, ValidationError}
 import models.autocomplete.NameValuePair
 import org.jsoup.Jsoup
 import org.scalatestplus.play.PlaySpec
@@ -47,6 +47,17 @@ class country_autocompleteSpec extends PlaySpec with AmlsSpec {
       }
 
       html.select(s"[selected]").attr("value") mustBe "country:2"
+    }
+
+    "retain invalid entry" in new Fixture {
+      val result = country_autocomplete(
+        InvalidField(Path \ "country", Seq("invalid entry"), Seq(ValidationError("validation error"))),
+        data = listData
+      ).toString
+
+      val html = Jsoup.parse(result)
+
+      html.getElementsByTag("option").eq(0).text() mustBe "invalid entry"
     }
   }
 


### PR DESCRIPTION
Country lookup field should retain invalid entry when showing validation error messages. In this PR there is small change to country_autocomplete component which allows to do that.

## Related / Dependant PRs?

- none

## How Has This Been Tested?

- manually
- unit tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
