### PR TITLE
Amls 4917 - Error removing BPS or TDI

### DIFF
--- a/app/controllers/businessmatching/updateservice/RemoveBusinessTypeHelper.scala
+++ b/app/controllers/businessmatching/updateservice/RemoveBusinessTypeHelper.scala
@@ -72,6 +72,8 @@ class RemoveBusinessTypeHelper @Inject()(val authConnector: AuthConnector,
           dataCacheConnector.removeByKey[Asp](Asp.key)
         case EstateAgentBusinessService =>
           dataCacheConnector.removeByKey[EstateAgentBusiness](EstateAgentBusiness.key)
+        case _ =>
+          dataCacheConnector.fetchAllWithDefault
       }
     }
 

--- a/test/controllers/businessmatching/updateservice/RemoveBusinessTypeHelperSpec.scala
+++ b/test/controllers/businessmatching/updateservice/RemoveBusinessTypeHelperSpec.scala
@@ -16,7 +16,6 @@
 
 package controllers.businessmatching.updateservice
 
-import connectors.KeystoreConnector
 import models.asp.Asp
 import models.businessmatching.updateservice.ServiceChangeRegister
 import models.businessmatching.{BusinessActivities => BMBusinessActivities, _}
@@ -32,7 +31,6 @@ import org.mockito.Mockito.{never, verify}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 import play.api.Application
-import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers._
 import utils._
@@ -765,6 +763,15 @@ class RemoveBusinessTypeHelperSpec extends AmlsSpec with FutureAssertions with M
         verify(mockCacheConnector, never).save[MoneyServiceBusinessSection](eqTo(MoneyServiceBusinessSection.key), any())(any(), any(), any())
         verify(mockCacheConnector, never).save[Asp](eqTo(Asp.key), any())(any(), any(), any())
         verify(mockCacheConnector, never).save[Hvd](eqTo(Hvd.key), any())(any(), any(), any())
+      }
+    }
+    "not raise an exception" when {
+      "removing BPS" in new Fixture {
+        val result = await(helper.removeSectionData(RemoveBusinessTypeFlowModel(Some(Set(BillPaymentServices)))).value)
+      }
+
+      "removing TDI" in new Fixture {
+        val result = await(helper.removeSectionData(RemoveBusinessTypeFlowModel(Some(Set(TelephonePaymentService)))).value)
       }
     }
   }

--- a/test/controllers/businessmatching/updateservice/RemoveBusinessTypeHelperSpec.scala
+++ b/test/controllers/businessmatching/updateservice/RemoveBusinessTypeHelperSpec.scala
@@ -27,15 +27,17 @@ import models.responsiblepeople.{ApprovalFlags, ResponsiblePerson}
 import models.tcsp.Tcsp
 import models.tradingpremises.{CurrencyExchange, TradingPremises, TradingPremisesMsbServices, WhatDoesYourBusinessDo}
 import org.mockito.Matchers.{any, eq => eqTo}
-import org.mockito.Mockito.{never, verify}
+import org.mockito.Mockito.{never, verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers._
+import uk.gov.hmrc.http.cache.client.CacheMap
 import utils._
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class RemoveBusinessTypeHelperSpec extends AmlsSpec with FutureAssertions with MockitoSugar with ScalaFutures {
 
@@ -44,6 +46,8 @@ class RemoveBusinessTypeHelperSpec extends AmlsSpec with FutureAssertions with M
     .build()
 
   val MSBOnlyModel = RemoveBusinessTypeFlowModel(activitiesToRemove = Some(Set(MoneyServiceBusiness)))
+
+  val cacheMap = CacheMap("", Map.empty)
 
   trait Fixture extends AuthorisedFixture with DependencyMocks {
     self =>
@@ -767,10 +771,18 @@ class RemoveBusinessTypeHelperSpec extends AmlsSpec with FutureAssertions with M
     }
     "not raise an exception" when {
       "removing BPS" in new Fixture {
+        when {
+          mockCacheConnector.fetchAllWithDefault
+        } thenReturn Future.successful(cacheMap)
+
         val result = await(helper.removeSectionData(RemoveBusinessTypeFlowModel(Some(Set(BillPaymentServices)))).value)
       }
 
       "removing TDI" in new Fixture {
+        when {
+          mockCacheConnector.fetchAllWithDefault
+        } thenReturn Future.successful(cacheMap)
+
         val result = await(helper.removeSectionData(RemoveBusinessTypeFlowModel(Some(Set(TelephonePaymentService)))).value)
       }
     }


### PR DESCRIPTION
On removing BPS or TDI an exception is thrown and logged in Kibana. While the flow still completes; this is a bad experience for the end user. This PR adds a generic catch all where a given sector does not exist in the cache for removal. 

## Related / Dependant PRs?

N/A

## How Has This Been Tested?

Local + Unit + Regression. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
