### PR TITLE
Amls 4838 - Bug fix: Validation error messages not linked to group on MSB 'Where do you send the largest amounts of money' page

### DIFF
--- a/app/models/moneyservicebusiness/SendTheLargestAmountsOfMoney.scala
+++ b/app/models/moneyservicebusiness/SendTheLargestAmountsOfMoney.scala
@@ -73,6 +73,7 @@ private sealed trait SendTheLargestAmountsOfMoney0 {
       case (a, Some(b), Some(c)) => SendTheLargestAmountsOfMoney(Seq(a, b, c))
       case (a, Some(b), None) => SendTheLargestAmountsOfMoney(Seq(a, b))
       case (a, None, None) => SendTheLargestAmountsOfMoney(Seq(a))
+      case (_, _, _) => SendTheLargestAmountsOfMoney(Seq())
       }
     }
 
@@ -87,6 +88,7 @@ private sealed trait SendTheLargestAmountsOfMoney0 {
       case Seq(a, b, c) => Json.obj("country_1" -> a, "country_2" -> b, "country_3" -> c)
       case Seq(a, b) => Json.obj("country_1" -> a, "country_2" -> b)
       case Seq(a) => Json.obj("country_1" -> a)
+      case _ => Json.obj()
     }
   }
 }

--- a/app/models/moneyservicebusiness/SendTheLargestAmountsOfMoney.scala
+++ b/app/models/moneyservicebusiness/SendTheLargestAmountsOfMoney.scala
@@ -16,46 +16,87 @@
 
 package models.moneyservicebusiness
 
-import models.Country
-import models.FormTypes._
 import jto.validation.forms.UrlFormEncoded
-import jto.validation.{From, Rule, Success, Write}
-import jto.validation._
+import jto.validation.{From, Path, Rule, RuleLike, To, Write, WriteLike}
+import models.Country
 import play.api.libs.json.{Json, Reads, Writes}
+import utils.TraversableValidators
 
-case class SendTheLargestAmountsOfMoney (
-                       country_1: Country,
-                       country_2: Option[Country] = None,
-                       country_3: Option[Country] = None
-                     ) {
+case class SendTheLargestAmountsOfMoney (countries: Seq[Country])
 
-  def countryList = {
-    this.productIterator.collect {
-      case Some(Country(name, code)) => Country(name, code)
-      case x: Country => x
+private sealed trait SendTheLargestAmountsOfMoney0 {
+
+  private implicit def rule[A]
+  (implicit
+   a: Path => RuleLike[A, Seq[String]],
+   cR: Rule[Seq[String], Seq[Country]]
+  ): Rule[A, SendTheLargestAmountsOfMoney] =
+    From[A] { __ =>
+
+      import TraversableValidators._
+      import utils.MappingUtils.Implicits.RichRule
+
+      implicit val emptyToNone: String => Option[String] = {
+        case "" => None
+        case s => Some(s)
+      }
+
+      val seqR = {
+        (seqToOptionSeq[String] andThen flattenR[String] andThen cR)
+          .andThen(minLengthR[Seq[Country]](1) withMessage "error.invalid.country")
+          .andThen(maxLengthR[Seq[Country]](3))
+      }
+
+      (__ \ "largestAmountsOfMoney").read(seqR) map SendTheLargestAmountsOfMoney.apply
     }
+
+  private implicit def write[A]
+  (implicit
+   a: Path => WriteLike[Seq[Country], A]
+  ): Write[SendTheLargestAmountsOfMoney, A] =
+    To[A] { __ =>
+      import play.api.libs.functional.syntax.unlift
+      (__ \ "largestAmountsOfMoney").write[Seq[Country]] contramap unlift(SendTheLargestAmountsOfMoney.unapply)
+    }
+
+  val formR: Rule[UrlFormEncoded, SendTheLargestAmountsOfMoney] = {
+    import jto.validation.forms.Rules._
+    implicitly
   }
 
+  val jsonR: Reads[SendTheLargestAmountsOfMoney] = {
+    import play.api.libs.functional.syntax._
+    import play.api.libs.json._
+    ((__ \ "country_1").read[Country] and
+    (__ \ "country_2").readNullable[Country] and
+    (__ \ "country_3").readNullable[Country]).tupled map {
+      case (a, Some(b), Some(c)) => SendTheLargestAmountsOfMoney(Seq(a, b, c))
+      case (a, Some(b), None) => SendTheLargestAmountsOfMoney(Seq(a, b))
+      case (a, None, None) => SendTheLargestAmountsOfMoney(Seq(a))
+      }
+    }
+
+  val formW: Write[SendTheLargestAmountsOfMoney, UrlFormEncoded] = {
+    import jto.validation.forms.Writes._
+    import utils.MappingUtils.spm
+    implicitly
+  }
+
+  val jsonW = Writes[SendTheLargestAmountsOfMoney] { lom =>
+    lom.countries match {
+      case Seq(a, b, c) => Json.obj("country_1" -> a, "country_2" -> b, "country_3" -> c)
+      case Seq(a, b) => Json.obj("country_1" -> a, "country_2" -> b)
+      case Seq(a) => Json.obj("country_1" -> a)
+    }
+  }
 }
 
 object SendTheLargestAmountsOfMoney {
 
-  implicit val format = Json.format[SendTheLargestAmountsOfMoney]
+  private object Cache extends SendTheLargestAmountsOfMoney0
 
-  implicit val formRule: Rule[UrlFormEncoded, SendTheLargestAmountsOfMoney] = From[UrlFormEncoded] { __ =>
-    import utils.MappingUtils.Implicits._
-    import jto.validation.forms.Rules._
-        ((__ \ "country_1").read[Country].withMessage("error.required.country.name") ~
-          (__ \ "country_2").read[Option[Country]] ~
-          (__ \ "country_3").read[Option[Country]]
-          )(SendTheLargestAmountsOfMoney.apply _)
-    }
-
-  implicit val formWrites: Write[SendTheLargestAmountsOfMoney, UrlFormEncoded] = Write {countries =>
-      Map(
-        "country_1" -> Seq(countries.country_1.code),
-        "country_2" -> (countries.country_2.toSeq map { _.code }),
-        "country_3" -> (countries.country_3.toSeq map { _.code })
-      )
-    }
+  implicit val formR: Rule[UrlFormEncoded, SendTheLargestAmountsOfMoney] = Cache.formR
+  implicit val formW: Write[SendTheLargestAmountsOfMoney, UrlFormEncoded] = Cache.formW
+  implicit val jsonR: Reads[SendTheLargestAmountsOfMoney] = Cache.jsonR
+  implicit val jsonW: Writes[SendTheLargestAmountsOfMoney] = Cache.jsonW
 }

--- a/app/models/renewal/SendTheLargestAmountsOfMoney.scala
+++ b/app/models/renewal/SendTheLargestAmountsOfMoney.scala
@@ -58,6 +58,6 @@ object SendTheLargestAmountsOfMoney {
     }
 
   implicit def convert(model: SendTheLargestAmountsOfMoney): models.moneyservicebusiness.SendTheLargestAmountsOfMoney = {
-    models.moneyservicebusiness.SendTheLargestAmountsOfMoney(model.country_1,model.country_2,model.country_3)
+    models.moneyservicebusiness.SendTheLargestAmountsOfMoney(model.countryList.toSeq)
   }
 }

--- a/app/services/LandingService.scala
+++ b/app/services/LandingService.scala
@@ -36,7 +36,7 @@ import models.status.RenewalSubmitted
 import models.supervision.Supervision
 import models.tcsp.Tcsp
 import models.tradingpremises.TradingPremises
-import models.{AmendVariationRenewalResponse, SubscriptionResponse, ViewResponse}
+import models._
 import play.api.mvc.Request
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.cache.client.CacheMap
@@ -283,7 +283,11 @@ class LandingService @Inject() (
             (_.transactionsInNext12Months.map(t => TransactionsInLast12Months(t.txnAmount))),
 
           sendTheLargestAmountsOfMoney = viewResponse.msbSection.fold[Option[SendTheLargestAmountsOfMoney]](None)
-            (_.sendTheLargestAmountsOfMoney.map(s => SendTheLargestAmountsOfMoney(s.country_1, s.country_2, s.country_3))),
+            (_.sendTheLargestAmountsOfMoney.map (s => s.countries match {
+              case Seq(a, b, c) => SendTheLargestAmountsOfMoney(a, Some(b), Some(c))
+              case Seq(a, b) => SendTheLargestAmountsOfMoney(a, Some(b))
+              case Seq(a) => SendTheLargestAmountsOfMoney(a)
+            })),
 
           mostTransactions = viewResponse.msbSection.fold[Option[MostTransactions]](None)
             (_.mostTransactions.map(m => MostTransactions(m.countries))),

--- a/app/views/msb/send_largest_amounts_of_money.scala.html
+++ b/app/views/msb/send_largest_amounts_of_money.scala.html
@@ -40,8 +40,7 @@
             legend = "msb.send.the.largest.amounts.of.money.title",
             f = f("largestAmountsOfMoney-fieldset"),
             legendHidden = true,
-            panel = false,
-            classes = Seq("inline")
+            panel = false
         ) {
             @errorGroup(
                 field = f("largestAmountsOfMoney")

--- a/app/views/msb/send_largest_amounts_of_money.scala.html
+++ b/app/views/msb/send_largest_amounts_of_money.scala.html
@@ -38,18 +38,24 @@
 
         @fieldset(
             legend = "msb.send.the.largest.amounts.of.money.title",
-            f = f("countries"),
+            f = f("largestAmountsOfMoney-fieldset"),
             legendHidden = true,
-            panel = false
+            panel = false,
+            classes = Seq("inline")
         ) {
-            @for(i <- 1 until 4) {
-                @defining(
-                    f(s"country_$i")
-                ) { field => @country_autocomplete(
-                    field = field,
-                    labelText = s"lbl.country.line$i",
-                    data = countryData.getOrElse(Seq.empty)
-                ) }
+            @errorGroup(
+                field = f("largestAmountsOfMoney")
+            ) {
+                @for(i <- 0 until 3) {
+                    @defining(
+                        f(s"largestAmountsOfMoney[$i]")
+                    ) { field => @country_autocomplete(
+                            field = field,
+                            labelText = s"lbl.country.line${i + 1}",
+                            data = countryData.getOrElse(Seq.empty)
+                        )
+                    }
+                }
             }
         }
         @submit(edit)

--- a/app/views/msb/summary.scala.html
+++ b/app/views/msb/summary.scala.html
@@ -177,7 +177,7 @@
                             editUrl = controllers.msb.routes.SendTheLargestAmountsOfMoneyController.get(true).toString
                         ) {
                             <ul class="list list--comma">
-                            @lom.countryList.map { country =>
+                            @lom.countries.map { country =>
                                 <li>@country.name</li>
                             }
                             </ul>

--- a/release_notes/AMLS-4838.txt
+++ b/release_notes/AMLS-4838.txt
@@ -1,0 +1,1 @@
+ + [AMLS-4838] - 'Bug fix: Validation error messages not linked to group on MSB 'Where do you send the largest amounts of money' page'

--- a/test/controllers/msb/SendMoneyToOtherCountryControllerSpec.scala
+++ b/test/controllers/msb/SendMoneyToOtherCountryControllerSpec.scala
@@ -152,7 +152,7 @@ class SendMoneyToOtherCountryControllerSpec extends AmlsSpec with MockitoSugar {
         sendMoneyToOtherCountry = Some(SendMoneyToOtherCountry(true)),
         sendTheLargestAmountsOfMoney = Some(
           SendTheLargestAmountsOfMoney(
-            Country("United Kingdom", "GB")
+            Seq(Country("United Kingdom", "GB"))
           )
         ),
         mostTransactions = Some(

--- a/test/controllers/msb/SendTheLargestAmountsOfMoneyControllerSpec.scala
+++ b/test/controllers/msb/SendTheLargestAmountsOfMoneyControllerSpec.scala
@@ -64,7 +64,7 @@ class SendTheLargestAmountsOfMoneyControllerSpec extends AmlsSpec with MockitoSu
 
     "pre-populate the 'Where to Send The Largest Amounts Of Money' Page" in new Fixture  {
       val msb = Some(MoneyServiceBusiness(
-        sendTheLargestAmountsOfMoney = Some(SendTheLargestAmountsOfMoney(Country("United Kingdom", "GB")))))
+        sendTheLargestAmountsOfMoney = Some(SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB"))))))
 
       mockIsNewActivity(false)
       mockApplicationStatus(NotCompleted)
@@ -74,7 +74,7 @@ class SendTheLargestAmountsOfMoneyControllerSpec extends AmlsSpec with MockitoSu
       status(result) must be(OK)
 
       val document = Jsoup.parse(contentAsString(result))
-      document.select("select[name=country_1] > option[value=GB]").hasAttr("selected") must be(true)
+      document.select("select[name=largestAmountsOfMoney[0]] > option[value=GB]").hasAttr("selected") must be(true)
 
     }
 
@@ -103,7 +103,7 @@ class SendTheLargestAmountsOfMoneyControllerSpec extends AmlsSpec with MockitoSu
     "on post with valid data" in new Fixture {
 
       val newRequest = request.withFormUrlEncodedBody(
-        "country_1" -> "GS"
+        "largestAmountsOfMoney[0]" -> "GS"
       )
 
       mockCacheFetch[MoneyServiceBusiness](None, Some(MoneyServiceBusiness.key))
@@ -117,7 +117,7 @@ class SendTheLargestAmountsOfMoneyControllerSpec extends AmlsSpec with MockitoSu
     "on post with valid data in edit mode when the next page's data is in the store" in new Fixture {
 
       val newRequest = request.withFormUrlEncodedBody(
-        "country_1" -> "GB"
+        "largestAmountsOfMoney[0]" -> "GB"
       )
 
       val incomingModel = MoneyServiceBusiness(
@@ -129,7 +129,7 @@ class SendTheLargestAmountsOfMoneyControllerSpec extends AmlsSpec with MockitoSu
       )
 
       val outgoingModel = incomingModel.copy(
-        sendTheLargestAmountsOfMoney = Some(SendTheLargestAmountsOfMoney(Country("United Kingdom", "UK")))
+        sendTheLargestAmountsOfMoney = Some(SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "UK"))))
       )
 
       mockCacheFetch[MoneyServiceBusiness](Some(incomingModel), Some(MoneyServiceBusiness.key))
@@ -143,13 +143,13 @@ class SendTheLargestAmountsOfMoneyControllerSpec extends AmlsSpec with MockitoSu
     "on post with valid data in edit mode when the next page's data isn't in the store" in new Fixture {
 
       val newRequest = request.withFormUrlEncodedBody(
-        "country_1" -> "GB"
+        "largestAmountsOfMoney[0]" -> "GB"
       )
 
       val incomingModel = MoneyServiceBusiness()
 
       val outgoingModel = incomingModel.copy(
-        sendTheLargestAmountsOfMoney = Some(SendTheLargestAmountsOfMoney(Country("United Kingdom", "UK")))
+        sendTheLargestAmountsOfMoney = Some(SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "UK"))))
       )
 
       mockCacheFetch[MoneyServiceBusiness](Some(incomingModel), Some(MoneyServiceBusiness.key))
@@ -163,7 +163,7 @@ class SendTheLargestAmountsOfMoneyControllerSpec extends AmlsSpec with MockitoSu
     "on post with invalid data" in new Fixture {
 
       val newRequest = request.withFormUrlEncodedBody(
-        "country_1" -> ""
+        "largestAmountsOfMoney[0]" -> ""
       )
 
       mockCacheFetch[MoneyServiceBusiness](None, Some(MoneyServiceBusiness.key))
@@ -173,7 +173,7 @@ class SendTheLargestAmountsOfMoneyControllerSpec extends AmlsSpec with MockitoSu
       status(result) must be(BAD_REQUEST)
 
       val document = Jsoup.parse(contentAsString(result))
-      document.select("a[href=#country_1]").html() must include(Messages("error.required.country.name"))
+      document.select("a[href=#largestAmountsOfMoney]").html() must include(Messages("error.required.country.name"))
     }
   }
 }

--- a/test/controllers/msb/SummaryControllerSpec.scala
+++ b/test/controllers/msb/SummaryControllerSpec.scala
@@ -46,7 +46,7 @@ class SummaryControllerSpec extends AmlsSpec with MockitoSugar {
       sendMoneyToOtherCountry = Some(SendMoneyToOtherCountry(true)),
       fundsTransfer = Some(FundsTransfer(true)),
       branchesOrAgents = Some(BranchesOrAgents(Some(Seq(Country("United Kingdom", "GB"))))),
-      sendTheLargestAmountsOfMoney = Some(SendTheLargestAmountsOfMoney(Country("United Kingdom", "GB"))),
+      sendTheLargestAmountsOfMoney = Some(SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB")))),
       mostTransactions = Some(MostTransactions(Seq(Country("United Kingdom", "GB")))),
       transactionsInNext12Months = Some(TransactionsInNext12Months("12345678963")),
       ceTransactionsInNext12Months = Some(CETransactionsInNext12Months("12345678963")),

--- a/test/models/moneyservicebusiness/MoneyServiceBusinessSpec.scala
+++ b/test/models/moneyservicebusiness/MoneyServiceBusinessSpec.scala
@@ -115,7 +115,7 @@ class MoneyServiceBusinessSpec extends AmlsSpec with MoneyServiceBusinessTestDat
 trait MoneyServiceBusinessTestData {
 
   private val businessUseAnIPSP = BusinessUseAnIPSPYes("name", "123456789123456")
-  private val sendTheLargestAmountsOfMoney = SendTheLargestAmountsOfMoney(Country("United Kingdom", "GB"))
+  private val sendTheLargestAmountsOfMoney = SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB")))
 
   val completeMsb = MoneyServiceBusiness(
     throughput = Some(ExpectedThroughput.Second),
@@ -162,7 +162,7 @@ trait MoneyServiceBusinessTestData {
     "transactionsInNext12Months" -> Json.obj("txnAmount" -> "12345678963"),
     "fundsTransfer" -> Json.obj("transferWithoutFormalSystems" -> true),
     "mostTransactions" -> Json.obj("mostTransactionsCountries" -> Seq("GB")),
-    "sendTheLargestAmountsOfMoney" -> Json.obj("country_1" ->"GB"),
+    "sendTheLargestAmountsOfMoney" -> Json.obj("country_1" -> "GB"),
     "ceTransactionsInNext12Months" -> Json.obj("ceTransaction" -> "12345678963"),
     "fxTransactionsInNext12Months" -> Json.obj("fxTransaction" -> "12345678963"),
     "hasChanged" -> false,

--- a/test/models/moneyservicebusiness/SendTheLargestAmountsOfMoneySpec.scala
+++ b/test/models/moneyservicebusiness/SendTheLargestAmountsOfMoneySpec.scala
@@ -16,78 +16,108 @@
 
 package models.moneyservicebusiness
 
+import jto.validation.forms.UrlFormEncoded
+import jto.validation.{Invalid, Path, Rule, VA, Valid, ValidationError, Write}
 import models.Country
 import org.scalatestplus.play.PlaySpec
-import jto.validation.{Invalid, Path, Valid}
-import jto.validation.ValidationError
-import play.api.libs.json.{JsNull, JsPath, JsSuccess, Json}
+import play.api.libs.json.{JsSuccess, Json}
 
 class SendTheLargestAmountsOfMoneySpec extends PlaySpec {
 
 
   "SendTheLargestAmountsOfMoney" must {
 
-    "successfully validate the form Rule with option Yes" in {
-      SendTheLargestAmountsOfMoney.formRule.validate(
-        Map(
-          "country_1" -> Seq("AL"),
-          "country_2" -> Seq("DZ"),
-          "country_3" -> Seq("AS")
-        )
-      ) mustBe {
-        Valid(SendTheLargestAmountsOfMoney(
-          
-            Country("Albania", "AL"),
-            Some(Country("Algeria", "DZ")),
-            Some(Country("American Samoa", "AS"))
+    val rule: Rule[UrlFormEncoded, SendTheLargestAmountsOfMoney] = implicitly
+    val write: Write[SendTheLargestAmountsOfMoney, UrlFormEncoded] = implicitly
+
+    "roundtrip through json" in {
+
+      val model: SendTheLargestAmountsOfMoney =
+        SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB")))
+
+      Json.fromJson[SendTheLargestAmountsOfMoney](Json.toJson(model)) mustEqual JsSuccess(model)
+    }
+
+    "roundtrip through forms" in {
+
+      val model: SendTheLargestAmountsOfMoney =
+        SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB")))
+
+      rule.validate(write.writes(model)) mustEqual Valid(model)
+    }
+
+    "fail to validate when there are no countries" in {
+
+      val form: UrlFormEncoded = Map(
+        "largestAmountsOfMoney" -> Seq.empty
+      )
+
+      rule.validate(form) mustEqual Invalid(
+        Seq((Path \ "largestAmountsOfMoney") -> Seq(ValidationError("error.invalid.country")))
+      )
+    }
+
+    "fail to validate when there are more than 3 countries" in {
+
+      // scalastyle:off magic.number
+      val form: UrlFormEncoded = Map(
+        "largestAmountsOfMoney[]" -> Seq.fill(4)("GB")
+      )
+
+      rule.validate(form) mustEqual Invalid(
+        Seq((Path \ "largestAmountsOfMoney") -> Seq(ValidationError("error.maxLength", 3)))
+      )
+    }
+  }
+
+  "SendTheLargestAmountsOfMoney Form Writes" when {
+    "an item is repeated" must {
+      "serialise all items correctly" in {
+        SendTheLargestAmountsOfMoney.formW.writes(SendTheLargestAmountsOfMoney(List(
+          Country("Country2", "BB"),
+          Country("Country1", "AA"),
+          Country("Country1", "AA")
+        ))) must be (
+          Map(
+            "largestAmountsOfMoney[0]" -> List("BB"),
+            "largestAmountsOfMoney[1]" -> List("AA"),
+            "largestAmountsOfMoney[2]" -> List("AA")
           )
         )
       }
     }
+  }
 
+  "SendTheLargestAmountsOfMoney Form Reads" when {
+    "all countries are valid" must {
+      "Successfully read from the form" in {
 
-    "validate mandatory field when isOutside is  selected as Yes and country with invalid data" in {
-      val json = Map("country_1" -> Seq("ABC"))
-
-      SendTheLargestAmountsOfMoney.formRule.validate(json) must
-        be(Invalid(Seq(
-          (Path \ "country_1") -> Seq(ValidationError("error.required.country.name"))
-        )))
-    }
-
-    "validate mandatory field for min length when isOutside is  selected as Yes and country with invalid data" in {
-      val json = Map("country_1" -> Seq("A"))
-
-      SendTheLargestAmountsOfMoney.formRule.validate(json) must
-        be(Invalid(Seq(
-          (Path \ "country_1") -> Seq(ValidationError("error.required.country.name"))
-        )))
-    }
-
-    "validate mandatory country field" in {
-      SendTheLargestAmountsOfMoney.formRule.validate(Map("country_1" -> Seq(""))) must
-        be(Invalid(Seq(
-          (Path \ "country_1") -> Seq(ValidationError("error.required.country.name"))
-        )))
-    }
-
-    "successfully write model with formWrite" in {
-
-      val model = SendTheLargestAmountsOfMoney(Country("United Kingdom", "GB"), Some(Country("United Kingdom", "GB")))
-      SendTheLargestAmountsOfMoney.formWrites.writes(model) must
-        contain allOf (
-        "country_1" -> Seq("GB"),
-        "country_2" -> Seq("GB")
-        )
-    }
-
-    "JSON validation" must {
-      "successfully validate givcen values" in {
-        val data = SendTheLargestAmountsOfMoney(Country("United Kingdom", "GB"))
-
-        SendTheLargestAmountsOfMoney.format.reads(SendTheLargestAmountsOfMoney.format.writes(data)) must
-          be(JsSuccess(data))
+        SendTheLargestAmountsOfMoney.formR.validate(
+          Map(
+            "largestAmountsOfMoney[0]" -> Seq("GB"),
+            "largestAmountsOfMoney[1]" -> Seq("MK"),
+            "largestAmountsOfMoney[2]" -> Seq("JO")
+          )
+        ) must be(Valid(SendTheLargestAmountsOfMoney(Seq(
+          Country("United Kingdom", "GB"),
+          Country("Macedonia, the Former Yugoslav Republic of", "MK"),
+          Country("Jordan", "JO")
+        ))))
       }
-     }
+    }
+
+    "the second country is invalid" must {
+      "fail validation" in {
+
+        val x: VA[SendTheLargestAmountsOfMoney] = SendTheLargestAmountsOfMoney.formR.validate(
+          Map(
+            "largestAmountsOfMoney[0]" -> Seq("GB"),
+            "largestAmountsOfMoney[1]" -> Seq("hjjkhjkjh"),
+            "largestAmountsOfMoney[2]" -> Seq("MK")
+          )
+        )
+        x must be (Invalid(Seq((Path \ "largestAmountsOfMoney" \ 1) -> Seq(ValidationError("error.invalid.country")))))
+      }
+    }
   }
 }

--- a/test/models/renewal/ConversionsSpec.scala
+++ b/test/models/renewal/ConversionsSpec.scala
@@ -93,8 +93,8 @@ class ConversionsSpec extends WordSpec with MustMatchers {
       val converted = subscriptionRequest.withRenewalData(renewal)
 
       converted.msbSection.get.sendTheLargestAmountsOfMoney mustBe Some(
-        models.moneyservicebusiness.SendTheLargestAmountsOfMoney(
-          Country("United Kingdom", "GB"), Some(Country("France", "FR")), Some(Country("us", "US"))))
+        models.moneyservicebusiness.SendTheLargestAmountsOfMoney(Seq(
+          Country("United Kingdom", "GB"), Country("France", "FR"), Country("us", "US"))))
     }
 
     "convert the 'MSB most transactions' model" in new Fixture {

--- a/test/services/LandingServiceSpec.scala
+++ b/test/services/LandingServiceSpec.scala
@@ -62,7 +62,7 @@ class LandingServiceSpec extends AmlsSpec with ScalaFutures with FutureAwaits wi
   val msbSection = MoneyServiceBusiness(
     throughput = Some(ExpectedThroughput.Second),
     transactionsInNext12Months = Some(TransactionsInNext12Months("12345678963")),
-    sendTheLargestAmountsOfMoney = Some(MsbSendTheLargestAmountsOfMoney(Country("United Kingdom", "GB"))),
+    sendTheLargestAmountsOfMoney = Some(MsbSendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB")))),
     mostTransactions = Some(MsbMostTransactions(Seq(Country("United Kingdom", "GB")))),
     ceTransactionsInNext12Months = Some(CETransactionsInNext12Months("12345678963")),
     whichCurrencies = Some(MsbWhichCurrencies(Seq("USD", "GBP", "EUR"),None, None)),
@@ -403,7 +403,7 @@ class LandingServiceSpec extends AmlsSpec with ScalaFutures with FutureAwaits wi
     val msbSection = MoneyServiceBusiness(
       throughput = Some(ExpectedThroughput.Second),
       transactionsInNext12Months = Some(TransactionsInNext12Months("12345678963")),
-      sendTheLargestAmountsOfMoney = Some(MsbSendTheLargestAmountsOfMoney(Country("United Kingdom", "GB"))),
+      sendTheLargestAmountsOfMoney = Some(MsbSendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB")))),
       mostTransactions = Some(MsbMostTransactions(Seq(Country("United Kingdom", "GB")))),
       ceTransactionsInNext12Months = Some(CETransactionsInNext12Months("12345678963")),
       whichCurrencies = Some(MsbWhichCurrencies(Seq("USD", "GBP", "EUR"), None, None)),

--- a/test/services/UpdateMongoCacheServiceSpec.scala
+++ b/test/services/UpdateMongoCacheServiceSpec.scala
@@ -157,7 +157,7 @@ class UpdateMongoCacheServiceSpec extends AmlsSpec with MockitoSugar
       sendMoneyToOtherCountry = Some(SendMoneyToOtherCountry(true)),
       fundsTransfer = Some(FundsTransfer(true)),
       branchesOrAgents = Some(BranchesOrAgents(Some(Seq(Country("United Kingdom", "GB"))))),
-      sendTheLargestAmountsOfMoney = Some(SendTheLargestAmountsOfMoney(Country("United Kingdom", "GB"))),
+      sendTheLargestAmountsOfMoney = Some(SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB")))),
       mostTransactions = Some(MostTransactions(Seq(Country("United Kingdom", "GB")))),
       transactionsInNext12Months = Some(TransactionsInNext12Months("12345678963")),
       ceTransactionsInNext12Months = Some(CETransactionsInNext12Months("12345678963")),

--- a/test/views/msb/send_largest_amounts_of_moneySpec.scala
+++ b/test/views/msb/send_largest_amounts_of_moneySpec.scala
@@ -35,14 +35,14 @@ class send_largest_amounts_of_moneySpec extends AmlsSpec with MustMatchers {
   "send_largest_amounts_of_money view" must {
 
     "have the back link button" in new ViewFixture {
-      val form2: ValidForm[SendTheLargestAmountsOfMoney] = Form2(SendTheLargestAmountsOfMoney(Country("United Kingdom", "GB")))
+      val form2: ValidForm[SendTheLargestAmountsOfMoney] = Form2(SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB"))))
       def view = views.html.msb.send_largest_amounts_of_money(form2, true, mockAutoComplete.getCountries)
       doc.getElementsByAttributeValue("class", "link-back") must not be empty
     }
 
     "have correct title" in new ViewFixture {
 
-      val form2: ValidForm[SendTheLargestAmountsOfMoney] = Form2(SendTheLargestAmountsOfMoney(Country("United Kingdom", "GB")))
+      val form2: ValidForm[SendTheLargestAmountsOfMoney] = Form2(SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB"))))
 
       def view = views.html.msb.send_largest_amounts_of_money(form2, true, mockAutoComplete.getCountries)
 
@@ -54,7 +54,7 @@ class send_largest_amounts_of_moneySpec extends AmlsSpec with MustMatchers {
 
     "have correct headings" in new ViewFixture {
 
-      val form2: ValidForm[SendTheLargestAmountsOfMoney] = Form2(SendTheLargestAmountsOfMoney(Country("United Kingdom", "GB")))
+      val form2: ValidForm[SendTheLargestAmountsOfMoney] = Form2(SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB"))))
 
       def view = views.html.msb.send_largest_amounts_of_money(form2, true, mockAutoComplete.getCountries)
 
@@ -67,14 +67,14 @@ class send_largest_amounts_of_moneySpec extends AmlsSpec with MustMatchers {
 
       val form2: InvalidForm = InvalidForm(Map.empty,
         Seq(
-          (Path \ "countries") -> Seq(ValidationError("not a message Key"))
+          (Path \ "largestAmountsOfMoney") -> Seq(ValidationError("not a message Key"))
         ))
 
       def view = views.html.msb.send_largest_amounts_of_money(form2, true, mockAutoComplete.getCountries)
 
       errorSummary.html() must include("not a message Key")
 
-      doc.getElementById("countries")
+      doc.getElementById("largestAmountsOfMoney")
         .getElementsByClass("error-notification").first().html() must include("not a message Key")
 
     }

--- a/test/views/msb/summarySpec.scala
+++ b/test/views/msb/summarySpec.scala
@@ -83,7 +83,7 @@ class summarySpec extends AmlsSpec
       Some(SendMoneyToOtherCountry(true)),
       Some(FundsTransfer(false)),
       Some(BranchesOrAgents(Some(Seq(Country("United Kingdom", "GB"))))),
-      Some(SendTheLargestAmountsOfMoney(Country("United Kingdom", "GB"))),
+      Some(SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB")))),
       Some(MostTransactions(Seq(Country("United Kingdom", "GB")))),
       Some(TransactionsInNext12Months("10")),
       Some(CETransactionsInNext12Months("10")),


### PR DESCRIPTION
In this pull request there are implemented changes to SendTheLargestAmountsOfMoney model in order to display validation messages in similar way like it was done for MostTransactions. Updates to model, view, controller, specs and conversion methods. Loaded applications saved before changes and submitted them without problem, looks like there are no issues with compatibility.

## Related / Dependant PRs?

- PR in acceptance tests for that

## How Has This Been Tested?

- unit tests
- manual checks
- regression

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
