### PR TITLE
Remove depricated HMRC test lib

### DIFF
--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -50,13 +50,11 @@ private object AppDependencies {
   private val scalatestVersion = "2.2.6"
   private val pegdownVersion = "1.6.0"
   private val jsoupVersion = "1.9.2"
-  private val hmrctestVersion = "2.4.0"
 
   object Test {
     def apply() = new ScopeDependencies {
       override val scope = "test"
       override lazy val dependencies = Seq(
-        "uk.gov.hmrc" %% "hmrctest" % hmrctestVersion % scope,
         "org.scalatest" %% "scalatest" % scalatestVersion % scope,
         "org.scalacheck" %% "scalacheck" % "1.12.5" % scope,
         "org.pegdown" % "pegdown" % pegdownVersion % scope,

--- a/test/utils/DateHelperSpec.scala
+++ b/test/utils/DateHelperSpec.scala
@@ -17,18 +17,18 @@
 package utils
 
 import org.joda.time.LocalDate
-import org.scalatest.mock.MockitoSugar
-import uk.gov.hmrc.play.test.UnitSpec
 
-class DateHelperSpec extends UnitSpec with MockitoSugar  {
-  "isNotFutureDate" must {
-    "return false if the date is later than current date" in {
-      DateHelper.isNotFutureDate(LocalDate.now().plusDays(1)) shouldBe false
-    }
+class DateHelperSpec extends AmlsSpec  {
+  "DateHelper" should {
+    "isNotFutureDate" when {
+      "return false if the date is later than current date" in {
+        DateHelper.isNotFutureDate(LocalDate.now().plusDays(1)) mustBe false
+      }
 
-    "return true if the date is equal to or earlier than the current date" in {
-      DateHelper.isNotFutureDate(LocalDate.now()) shouldBe true
-      DateHelper.isNotFutureDate(LocalDate.now().minusDays(1)) shouldBe true
+      "return true if the date is equal to or earlier than the current date" in {
+        DateHelper.isNotFutureDate(LocalDate.now()) mustBe true
+        DateHelper.isNotFutureDate(LocalDate.now().minusDays(1)) mustBe true
+      }
     }
   }
 }

--- a/test/utils/FeeRateHelperSpec.scala
+++ b/test/utils/FeeRateHelperSpec.scala
@@ -16,20 +16,18 @@
 
 package utils
 
-import uk.gov.hmrc.play.test.UnitSpec
-
-class FeeRateHelperSpec extends UnitSpec {
+class FeeRateHelperSpec extends AmlsSpec {
   "fetch" must {
     "translate a specified value" in {
-      FeeRateHelper.fetch(Some(115.00)) shouldBe 115.00
+      FeeRateHelper.fetch(Some(115.00)) mustBe 115.00
     }
 
     "return a zero value where 0" in {
-      FeeRateHelper.fetch(Some(0)) shouldBe 0
+      FeeRateHelper.fetch(Some(0)) mustBe 0
     }
 
     "return a zero value where not specified" in {
-      FeeRateHelper.fetch(None) shouldBe 0
+      FeeRateHelper.fetch(None) mustBe 0
     }
   }
 }


### PR DESCRIPTION
Remove hmrctest lib as soon to be deprecated. 

<img width="596" alt="Screenshot 2019-06-05 at 10 14 47" src="https://user-images.githubusercontent.com/40767309/58945044-fb192600-877a-11e9-91b1-903022c9bf1e.png">


## Related / Dependant PRs?

N/A

## How Has This Been Tested?

Unit

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
