### PR TITLE
Amls 5142 - Making certain BM questions editable when pending approval

### DIFF
--- a/app/views/businessmatching/summary.scala.html
+++ b/app/views/businessmatching/summary.scala.html
@@ -57,7 +57,6 @@
                     @checkYourAnswers(
                         question = Messages("businessmatching.registrationnumber.title"),
                         editUrl = controllers.businessmatching.routes.CompanyRegistrationNumberController.get(true).toString,
-                        allowEdit = !isPending,
                         editLinkTag = "edit-registration-number"
                     ) {
                         <p id="registration-number">@model.companyRegistrationNumber.map { number =>
@@ -130,7 +129,6 @@
                         @checkYourAnswers(
                             question = Messages("businessmatching.psr.number.title"),
                             editUrl = controllers.businessmatching.routes.PSRNumberController.get(true).toString,
-                            allowEdit = !isPending,
                             editLinkTag = "edit-psr-number"
                         ) {
                             <p id="psr">@psr match {

--- a/release_notes/AMLS-5142.txt
+++ b/release_notes/AMLS-5142.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5142] - - "Making BM questions editable in a pending state"

--- a/test/controllers/businessmatching/SummaryControllerSpec.scala
+++ b/test/controllers/businessmatching/SummaryControllerSpec.scala
@@ -94,26 +94,6 @@ class SummaryControllerSpec extends AmlsSpec with BusinessMatchingGenerator {
       status(result) must be(SEE_OTHER)
     }
 
-    "hide the edit links when not in pre-approved status and is pending" in new Fixture {
-      val model = businessMatchingWithTypesGen(Some(LPrLLP)).sample.get
-
-      mockGetModel(Some(model))
-
-      when {
-        controller.statusService.isPreSubmission(any())
-      } thenReturn false
-
-      when {
-        controller.statusService.isPending(any())
-      } thenReturn true
-
-      val result = controller.get()(request)
-      status(result) mustBe OK
-
-      val html = Jsoup.parse(contentAsString(result))
-      html.select("a.change-answer").size mustBe 0
-    }
-
     "show the 'Register Services' page when the user wants to change their services" in new Fixture {
       val model = BusinessMatching(
         activities = Some(BusinessActivities(Set(EstateAgentBusinessService)))


### PR DESCRIPTION
This ticket was to make sure the PSR and CRN questions within business matching are editable no matter what state they are in. Hence removing the pending status toggles.
## Related / Dependant PRs?

<!--- List any related issues here -->
Manual
Unit

<!--- Please describe how you tested your changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
