### PR TITLE
AMLS-5214 Live bug fix customers outside uk

### DIFF
--- a/app/models/renewal/Renewal.scala
+++ b/app/models/renewal/Renewal.scala
@@ -18,7 +18,7 @@ package models.renewal
 
 import cats.data.Validated.{Invalid, Valid}
 import jto.validation.{Path, Rule, ValidationError}
-import models.ValidationRule
+import models.{Country, ValidationRule}
 import play.api.libs.json.{Json, Reads}
 
 case class Renewal(
@@ -118,9 +118,10 @@ object Renewal {
       (__ \ "involvedInOtherActivities").readNullable[InvolvedInOther] and
         (__ \ "businessTurnover").readNullable[BusinessTurnover] and
         (__ \ "turnover").readNullable[AMLSTurnover] and
-        ((__ \ "customersOutsideUK" \"isOutside").read[Boolean].map(c => Option(CustomersOutsideIsUK(c))) or
+        ((__ \ "customersOutsideUK" \"isOutside").read[Boolean].map(c => Option(CustomersOutsideIsUK(c))) orElse
           (__ \ "customersOutsideIsUK").readNullable[CustomersOutsideIsUK]) and
-        (__ \ "customersOutsideUK").readNullable[CustomersOutsideUK] and
+        ((__ \ "customersOutsideUK" \"countries").readNullable[Seq[Country]].map(c => Option(CustomersOutsideUK(c))) orElse
+          (__ \ "customersOutsideUK").readNullable[CustomersOutsideUK]) and
         (__ \ "percentageOfCashPaymentOver15000").readNullable[PercentageOfCashPaymentOver15000] and
         (__ \ "receiveCashPayments").readNullable[CashPayments] and
         (__ \ "totalThroughput").readNullable[TotalThroughput] and

--- a/release_notes/AMLS-5214.txt
+++ b/release_notes/AMLS-5214.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5214] - - Bug fix Customers Not Met in person question not backward compatible

--- a/test/models/renewal/RenewalSpec.scala
+++ b/test/models/renewal/RenewalSpec.scala
@@ -20,15 +20,108 @@ import models.Country
 import play.api.libs.json.{JsSuccess, Json}
 import utils.AmlsSpec
 
+import scala.collection.Seq
+
 class RenewalSpec extends AmlsSpec {
 
   "The Renewal model" must {
+    "succesfully validate if model is complete" when {
+      "json is complete" in {
+        val completeRenewal = Renewal(customersOutsideIsUK = Some(CustomersOutsideIsUK(true)),
+          customersOutsideUK = Some(CustomersOutsideUK(Some(Seq(Country("United Kingdom", "GB"))))))
+
+        val json = Json.obj(
+          "customersOutsideIsUK" -> Json.obj(
+            "isOutside" -> true
+          ),
+          "customersOutsideUK" -> Json.obj(
+            "countries" -> Seq("GB")
+          ),
+          "hasChanged" -> false,
+          "hasAccepted" -> true
+        )
+
+        json.as[Renewal] must be(completeRenewal)
+      }
+    }
+
+    "succesfully validate json" when {
+      "CustomersOutsideIsUK is false" in {
+        val renewal = Renewal(customersOutsideIsUK = Some(CustomersOutsideIsUK(false)), customersOutsideUK = Some(CustomersOutsideUK(None)))
+
+        val json = Json.obj(
+          "customersOutsideUK" -> Json.obj(
+            "isOutside" -> false
+          ),
+          "hasChanged" -> false,
+          "hasAccepted" -> true
+        )
+
+        json.as[Renewal] must be(renewal)
+      }
+    }
 
     "serialize to and from JSON" in {
 
-      val model = Renewal()
+     val completeRenewal = Renewal(
+        Some(InvolvedInOtherYes("test")),
+        Some(BusinessTurnover.First),
+        Some(AMLSTurnover.First),
+        Some(CustomersOutsideIsUK(false)),
+        None,
+        Some(PercentageOfCashPaymentOver15000.First),
+        Some(CashPayments(CashPaymentsCustomerNotMet(true), Some(HowCashPaymentsReceived(PaymentMethods(true,true,Some("other")))))),
+        Some(TotalThroughput("01")),
+        Some(WhichCurrencies(Seq("EUR"), None, Some(MoneySources(None, None, None)))),
+        Some(TransactionsInLast12Months("1500")),
+        Some(SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB")))),
+        Some(MostTransactions(Seq(Country("United Kingdom", "GB")))),
+        Some(CETransactionsInLast12Months("123")),
+        hasChanged = true
+      )
 
-      Json.fromJson[Renewal](Json.toJson(model)) mustBe JsSuccess(model)
+      val json = Json.parse("""
+         {"involvedInOtherActivities":
+         {"involvedInOther":true,"details":"test"},
+         "businessTurnover":{"businessTurnover":"01"},
+         "turnover":{"turnover":"01"},
+         "customersOutsideIsUK":{"isOutside":false},
+         "percentageOfCashPaymentOver15000":{"percentage":"01"},
+         "receiveCashPayments":{"receivePayments":true,"paymentMethods":{"courier":true,"direct":true,"other":true,"details":"other"}},
+         "totalThroughput":{"throughput":"01"},
+         "whichCurrencies":{"currencies":["EUR"],
+         "usesForeignCurrencies":null,"moneySources":{}},
+         "transactionsInLast12Months":{"transfers":"1500"},
+         "sendTheLargestAmountsOfMoney":{"country_1":"GB"},
+         "mostTransactions":{"mostTransactionsCountries":["GB"]},
+         "ceTransactionsInLast12Months":{"ceTransaction":"123"},
+         "hasChanged":true,
+         "hasAccepted":true}
+          """.stripMargin)
+
+      Json.fromJson[Renewal](json) mustBe JsSuccess(completeRenewal)
+    }
+
+    "roundtrip through json" in {
+
+      val completeRenewal = Renewal(
+        Some(InvolvedInOtherYes("test")),
+        Some(BusinessTurnover.First),
+        Some(AMLSTurnover.First),
+        Some(CustomersOutsideIsUK(false)),
+        None,
+        Some(PercentageOfCashPaymentOver15000.First),
+        Some(CashPayments(CashPaymentsCustomerNotMet(true), Some(HowCashPaymentsReceived(PaymentMethods(true,true,Some("other")))))),
+        Some(TotalThroughput("01")),
+        Some(WhichCurrencies(Seq("EUR"), None, Some(MoneySources(None, None, None)))),
+        Some(TransactionsInLast12Months("1500")),
+        Some(SendTheLargestAmountsOfMoney(Seq(Country("United Kingdom", "GB")))),
+        Some(MostTransactions(Seq(Country("United Kingdom", "GB")))),
+        Some(CETransactionsInLast12Months("123")),
+        hasChanged = true
+      )
+
+      Json.fromJson[Renewal](Json.toJson(completeRenewal)) mustEqual JsSuccess(completeRenewal)
     }
 
   }


### PR DESCRIPTION
Live bug fix - users cannot load renewals when selected no on customers outside uk question.

## Related / Dependant PRs?

- none

## How Has This Been Tested?

- unit tests, manually, regression

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
