### PR TITLE
Amls 5071 - Remove ARIA role of tooltip from error summary list items

### DIFF
--- a/app/views/include/forms2/errorSummary.scala.html
+++ b/app/views/include/forms2/errorSummary.scala.html
@@ -23,7 +23,7 @@
         <h2 class="heading-medium" id="error-summary-heading">@Messages("err.summary")</h2>
         <ul class="error-summary-list">
             @form.errors.map { case (path, errors) =>
-                <li role="tooltip" class="validation-summary-message">
+                <li class="validation-summary-message">
                     @if(path.path.nonEmpty) {
                         <a href="#@form(path).id">@errors.toMessage</a>
                     } else {

--- a/release_notes/AMLS-5071.txt
+++ b/release_notes/AMLS-5071.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5071] - 'Remove ARIA role of tooltip from error summary list items'


### PR DESCRIPTION
Remove ARIA role of tooltip from error summary list items

## How Has This Been Tested?
Locally: Manual/Unit/Acceptance

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
