### PR TITLE
Add H1 to standard error page for tracking.

### DIFF
--- a/app/views/error.scala.html
+++ b/app/views/error.scala.html
@@ -21,5 +21,6 @@
 @main(
     title = title
 ) {
+    <h1>@heading</h1>
     <p>@message</p>
 }

--- a/release_notes/AMLS-5220.txt
+++ b/release_notes/AMLS-5220.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5220] - 'Add H1 to standard error page for tracking'


### PR DESCRIPTION
Add H1 to standard error page for tracking.

![Screenshot 2019-08-12 at 17 08 33](https://user-images.githubusercontent.com/40767309/62926861-4a985580-bdad-11e9-830a-ccbbd100f2ac.png)


## Related / Dependant PRs?

N/A

## How Has This Been Tested?

Local

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
