### PR TITLE
AMLS-5209 | RP address rejects spaces in mandatory fields

### DIFF
--- a/app/models/FormTypes.scala
+++ b/app/models/FormTypes.scala
@@ -71,6 +71,8 @@ object FormTypes {
   def maxDateWithMsg(maxDate: LocalDate, msg: String) = max(maxDate).withMessage(msg)
   def minDateWithMsg (minDate: LocalDate, msg: String) = min(minDate).withMessage(msg)
 
+  def trimNotEmpty = validateWith[String]("error.required") { !_.trim.isEmpty }
+
   val notEmptyStrip = Rule.zero[String] map {
     _.trim
   }

--- a/app/models/responsiblepeople/PersonAddress.scala
+++ b/app/models/responsiblepeople/PersonAddress.scala
@@ -70,17 +70,17 @@ object PersonAddress {
       import models.FormTypes._
       import utils.MappingUtils.Implicits._
 
-      (__ \ "isUK").read[Boolean].withMessage("error.required.uk.or.overseas") flatMap {
+    (__ \ "isUK").read[Boolean].withMessage("error.required.uk.or.overseas") flatMap {
         case true => (
-            (__ \ "addressLine1").read(notEmpty.withMessage("error.required.address.line1") andThen validateAddress) ~
-            (__ \ "addressLine2").read(notEmpty.withMessage("error.required.address.line2") andThen validateAddress) ~
+            (__ \ "addressLine1").read(trimNotEmpty.withMessage("error.required.address.line1") andThen validateAddress) ~
+            (__ \ "addressLine2").read(trimNotEmpty.withMessage("error.required.address.line2") andThen validateAddress) ~
             (__ \ "addressLine3").read(optionR(validateAddress)) ~
             (__ \ "addressLine4").read(optionR(validateAddress)) ~
             (__ \ "postCode").read(notEmptyStrip andThen postcodeType)
           )(PersonAddressUK.apply _)
         case false => (
-            (__ \ "addressLineNonUK1").read(notEmpty.withMessage("error.required.address.line1") andThen validateAddress) ~
-            (__ \ "addressLineNonUK2").read(notEmpty.withMessage("error.required.address.line2") andThen validateAddress) ~
+            (__ \ "addressLineNonUK1").read(trimNotEmpty.withMessage("error.required.address.line1") andThen validateAddress) ~
+            (__ \ "addressLineNonUK2").read(trimNotEmpty.withMessage("error.required.address.line2") andThen validateAddress) ~
             (__ \ "addressLineNonUK3").read(optionR(validateAddress)) ~
             (__ \ "addressLineNonUK4").read(optionR(validateAddress)) ~
             (__ \ "country").read(validateCountry)

--- a/release_notes/AMLS-5209.txt
+++ b/release_notes/AMLS-5209.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5209] - 'Fixed RP address accepting empty spaces'


### PR DESCRIPTION
On the following questions, mandatory fields where only spaces are entered are no longer valid:

- Where does Jane Doe live?
- What was Jane Does previous address?
- What was Jane Does other previous address?

## Related / Dependant PRs?

## How Has This Been Tested?

Manual testing

![Screen Shot 2019-08-20 at 15 44 14](https://user-images.githubusercontent.com/43992493/63357474-67123000-c361-11e9-9254-3bc78bfb5ad5.png)

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.