### PR TITLE
AMLS-5294 | Invalid input not working correctly on countries and currency pages

### DIFF
--- a/app/controllers/msb/MostTransactionsController.scala
+++ b/app/controllers/msb/MostTransactionsController.scala
@@ -26,7 +26,7 @@ import models.moneyservicebusiness.{MoneyServiceBusiness, MostTransactions}
 import services.businessmatching.ServiceFlow
 import services.{AutoCompleteService, StatusService}
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.AuthAction
+import utils.{AuthAction, ControllerHelper}
 
 import scala.concurrent.Future
 
@@ -54,7 +54,7 @@ class MostTransactionsController @Inject()(authAction: AuthAction,
       implicit request =>
         Form2[MostTransactions](request.body) match {
           case f: InvalidForm =>
-            Future.successful(BadRequest(views.html.msb.most_transactions(f, edit, autoCompleteService.getCountries)))
+            Future.successful(BadRequest(views.html.msb.most_transactions(alignFormDataWithValidationErrors(f), edit, autoCompleteService.getCountries)))
           case ValidForm(_, data) =>
             cacheConnector.fetchAll(request.credId) flatMap { maybeCache =>
               val result = for {
@@ -75,6 +75,10 @@ class MostTransactionsController @Inject()(authAction: AuthAction,
             }
         }
   }
+
+  def alignFormDataWithValidationErrors(form: InvalidForm): InvalidForm =
+    ControllerHelper.stripEmptyValuesFromFormWithArray(form, "mostTransactionsCountries", index => index / 2)
+
 
   private def shouldAnswerCurrencyExchangeQuestions(msbServices: Set[BusinessMatchingMsbService],
                                                      register: ServiceChangeRegister,

--- a/app/controllers/msb/SendTheLargestAmountsOfMoneyController.scala
+++ b/app/controllers/msb/SendTheLargestAmountsOfMoneyController.scala
@@ -66,6 +66,6 @@ class SendTheLargestAmountsOfMoneyController @Inject()(authAction: AuthAction,
   }
 
   def alignFormDataWithValidationErrors(form: InvalidForm): InvalidForm =
-    ControllerHelper.stripEmptyValuesFromFormWithArray(form, "countries")
+    ControllerHelper.stripEmptyValuesFromFormWithArray(form, "largestAmountsOfMoney", index => index / 2)
 
 }

--- a/app/controllers/msb/SendTheLargestAmountsOfMoneyController.scala
+++ b/app/controllers/msb/SendTheLargestAmountsOfMoneyController.scala
@@ -23,7 +23,7 @@ import javax.inject.Inject
 import models.moneyservicebusiness.{MoneyServiceBusiness, SendTheLargestAmountsOfMoney}
 import services.businessmatching.ServiceFlow
 import services.{AutoCompleteService, StatusService}
-import utils.AuthAction
+import utils.{AuthAction, ControllerHelper}
 import views.html.msb.send_largest_amounts_of_money
 
 import scala.concurrent.Future
@@ -51,7 +51,7 @@ class SendTheLargestAmountsOfMoneyController @Inject()(authAction: AuthAction,
     implicit request =>
       Form2[SendTheLargestAmountsOfMoney](request.body) match {
         case f: InvalidForm =>
-          Future.successful(BadRequest(send_largest_amounts_of_money(f, edit, autoCompleteService.getCountries)))
+          Future.successful(BadRequest(send_largest_amounts_of_money(alignFormDataWithValidationErrors(f), edit, autoCompleteService.getCountries)))
         case ValidForm(_, data) =>
           for {
             msb <-
@@ -64,4 +64,8 @@ class SendTheLargestAmountsOfMoneyController @Inject()(authAction: AuthAction,
           }
       }
   }
+
+  def alignFormDataWithValidationErrors(form: InvalidForm): InvalidForm =
+    ControllerHelper.stripEmptyValuesFromFormWithArray(form, "countries")
+
 }

--- a/app/controllers/msb/WhichCurrenciesController.scala
+++ b/app/controllers/msb/WhichCurrenciesController.scala
@@ -51,8 +51,7 @@ class WhichCurrenciesController @Inject() (authAction: AuthAction,
     implicit request => {
       Form2[WhichCurrencies](request.body) match {
         case f: InvalidForm =>
-          Future.successful(BadRequest(views.html.msb.which_currencies(
-            alignFormDataWithValidationErrors(f), edit)))
+          Future.successful(BadRequest(views.html.msb.which_currencies(alignFormDataWithValidationErrors(f), edit)))
         case ValidForm(_, data: WhichCurrencies) =>
               for {
                 msb <- dataCacheConnector.fetch[MoneyServiceBusiness](request.credId, MoneyServiceBusiness.key)

--- a/app/controllers/renewal/CustomersOutsideUKController.scala
+++ b/app/controllers/renewal/CustomersOutsideUKController.scala
@@ -76,7 +76,7 @@ class CustomersOutsideUKController @Inject()(val dataCacheConnector: DataCacheCo
   }
 
   def alignFormDataWithValidationErrors(form: InvalidForm): InvalidForm =
-    ControllerHelper.stripEmptyValuesFromFormWithArray(form, "countries")
+    ControllerHelper.stripEmptyValuesFromFormWithArray(form, "countries", index => index / 2)
 }
 
 

--- a/app/controllers/renewal/CustomersOutsideUKController.scala
+++ b/app/controllers/renewal/CustomersOutsideUKController.scala
@@ -23,7 +23,7 @@ import javax.inject.{Inject, Singleton}
 import models.businessmatching._
 import models.renewal.{CustomersOutsideUK, Renewal}
 import services.{AutoCompleteService, RenewalService}
-import utils.AuthAction
+import utils.{AuthAction, ControllerHelper}
 import views.html.renewal._
 
 import scala.concurrent.Future
@@ -51,7 +51,7 @@ class CustomersOutsideUKController @Inject()(val dataCacheConnector: DataCacheCo
       implicit request =>
         Form2[CustomersOutsideUK](request.body) match {
           case f: InvalidForm =>
-            Future.successful(BadRequest(customers_outside_uk(f, edit, autoCompleteService.getCountries)))
+            Future.successful(BadRequest(customers_outside_uk(alignFormDataWithValidationErrors(f), edit, autoCompleteService.getCountries)))
           case ValidForm(_, data) => {
             dataCacheConnector.fetchAll(request.credId).flatMap { optionalCache =>
               (for {
@@ -75,6 +75,8 @@ class CustomersOutsideUKController @Inject()(val dataCacheConnector: DataCacheCo
         }
   }
 
+  def alignFormDataWithValidationErrors(form: InvalidForm): InvalidForm =
+    ControllerHelper.stripEmptyValuesFromFormWithArray(form, "countries")
 }
 
 

--- a/app/controllers/renewal/MostTransactionsController.scala
+++ b/app/controllers/renewal/MostTransactionsController.scala
@@ -24,7 +24,7 @@ import models.businessmatching._
 import models.renewal.{MostTransactions, Renewal}
 import play.api.mvc.Result
 import services.{AutoCompleteService, RenewalService}
-import utils.AuthAction
+import utils.{AuthAction, ControllerHelper}
 
 import scala.concurrent.Future
 
@@ -51,7 +51,7 @@ class MostTransactionsController @Inject()(val authAction: AuthAction,
       implicit request =>
         Form2[MostTransactions](request.body) match {
           case f: InvalidForm =>
-            Future.successful(BadRequest(views.html.renewal.most_transactions(f, edit, autoCompleteService.getCountries)))
+            Future.successful(BadRequest(views.html.renewal.most_transactions(alignFormDataWithValidationErrors(f), edit, autoCompleteService.getCountries)))
           case ValidForm(_, data) =>
             cache.fetchAll(request.credId).flatMap {
               optMap =>
@@ -72,6 +72,10 @@ class MostTransactionsController @Inject()(val authAction: AuthAction,
             }
         }
   }
+
+  def alignFormDataWithValidationErrors(form: InvalidForm): InvalidForm =
+    ControllerHelper.stripEmptyValuesFromFormWithArray(form, "mostTransactionsCountries", index => index / 2)
+
 
   private def redirectTo(services: Set[BusinessMatchingMsbService], businessActivities: Set[BusinessActivity]): Result = {
       (services, businessActivities) match {

--- a/app/controllers/renewal/SendTheLargestAmountsOfMoneyController.scala
+++ b/app/controllers/renewal/SendTheLargestAmountsOfMoneyController.scala
@@ -22,7 +22,7 @@ import forms.{EmptyForm, Form2, InvalidForm, ValidForm}
 import javax.inject.{Inject, Singleton}
 import models.renewal.{Renewal, SendTheLargestAmountsOfMoney}
 import services.{AutoCompleteService, RenewalService}
-import utils.AuthAction
+import utils.{AuthAction, ControllerHelper}
 import views.html.renewal.send_largest_amounts_of_money
 
 import scala.concurrent.Future
@@ -51,7 +51,7 @@ class SendTheLargestAmountsOfMoneyController @Inject()(
     implicit request =>
       Form2[SendTheLargestAmountsOfMoney](request.body) match {
         case f: InvalidForm =>
-          Future.successful(BadRequest(send_largest_amounts_of_money(f, edit, autoCompleteService.getCountries)))
+          Future.successful(BadRequest(send_largest_amounts_of_money(alignFormDataWithValidationErrors(f), edit, autoCompleteService.getCountries)))
         case ValidForm(_, data) =>
           for {
             renewal <- renewalService.getRenewal(request.credId)
@@ -59,6 +59,10 @@ class SendTheLargestAmountsOfMoneyController @Inject()(
           } yield redirectTo(edit, renewal)
       }
   }
+
+  def alignFormDataWithValidationErrors(form: InvalidForm): InvalidForm =
+    ControllerHelper.stripEmptyValuesFromFormWithArray(form, "largestAmountsOfMoney")
+
 
   def redirectTo(edit:Boolean, renewal: Renewal) = edit match {
     case true if !mostTransactionsDataRequired(renewal)  => Redirect(routes.SummaryController.get())

--- a/app/controllers/renewal/SendTheLargestAmountsOfMoneyController.scala
+++ b/app/controllers/renewal/SendTheLargestAmountsOfMoneyController.scala
@@ -61,7 +61,7 @@ class SendTheLargestAmountsOfMoneyController @Inject()(
   }
 
   def alignFormDataWithValidationErrors(form: InvalidForm): InvalidForm =
-    ControllerHelper.stripEmptyValuesFromFormWithArray(form, "largestAmountsOfMoney")
+    ControllerHelper.stripEmptyValuesFromFormWithArray(form, "largestAmountsOfMoney", index => index / 2)
 
 
   def redirectTo(edit:Boolean, renewal: Renewal) = edit match {

--- a/release_notes/AMLS-5294.txt
+++ b/release_notes/AMLS-5294.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5294] - 'Fixed handling of invalid inputs on remaining countries and currencies pages'

--- a/test/controllers/msb/MostTransactionsControllerSpec.scala
+++ b/test/controllers/msb/MostTransactionsControllerSpec.scala
@@ -125,8 +125,11 @@ class MostTransactionsControllerSpec extends AmlsSpec with MockitoSugar {
 
     "return a Bad request with errors on invalid submission" in new Fixture {
 
-      val result = controller.post()(request)
+      val newRequest = request.withFormUrlEncodedBody("mostTransactionsCountries[0]" -> "adsadsdsdsaads")
+
+      val result = controller.post()(newRequest)
       val document = Jsoup.parse(contentAsString(result))
+
 
       status(result) mustEqual BAD_REQUEST
 

--- a/test/controllers/renewal/MostTransactionsControllerSpec.scala
+++ b/test/controllers/renewal/MostTransactionsControllerSpec.scala
@@ -134,7 +134,11 @@ class MostTransactionsControllerSpec extends AmlsSpec with MockitoSugar {
 
     "return a Bad request with errors on invalid submission" in new Fixture {
 
-      val result = controller.post()(request)
+      val newRequest = request.withFormUrlEncodedBody(
+        "mostTransactionsCountries[0]" -> "GBasdadsdas"
+      )
+
+      val result = controller.post()(newRequest)
       val document = Jsoup.parse(contentAsString(result))
 
       status(result) mustEqual BAD_REQUEST

--- a/test/controllers/renewal/WhichCurrenciesControllerSpec.scala
+++ b/test/controllers/renewal/WhichCurrenciesControllerSpec.scala
@@ -181,7 +181,9 @@ class WhichCurrenciesControllerSpec extends AmlsSpec with MockitoSugar {
 
     "return a bad request" when {
       "the form fails validation" in new FormSubmissionFixture {
-        val result = controller.post()(request)
+        val newRequest = request.withFormUrlEncodedBody("currencies[0]" -> "1dfasdffds")
+
+        val result = controller.post()(newRequest)
 
         status(result) mustBe BAD_REQUEST
         verify(renewalService, never()).updateRenewal(any(),any())(any(), any())


### PR DESCRIPTION
Fixed the handling of invalid input on countries and currencies pages. Empty fields are stripped out of the form data used to repopulate pages when invalid data has been inputted - this aligns the user's input with the errors displayed by the page.

## Related / Dependant PRs?


## How Has This Been Tested?

Ran and amended unit tests, manual testing

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.