### PR TITLE
Amls 4983 - Extended date validation for start date for trading premises

### DIFF
--- a/app/models/FormTypes.scala
+++ b/app/models/FormTypes.scala
@@ -195,8 +195,10 @@ object FormTypes {
   val futureDateRule: Rule[LocalDate, LocalDate] = maxDateWithMsg(LocalDate.now, "error.future.date")
   val endOfCenturyDateRule: Rule[LocalDate, LocalDate] = maxDateWithMsg(new LocalDate(2099, 12, 31), "error.future.date")
   val pastStartDateRule: Rule[LocalDate, LocalDate] = minDateWithMsg(new LocalDate(1900, 1, 1), "error.allowed.start.date")
+  val pastStartDateRuleExtended: Rule[LocalDate, LocalDate] = minDateWithMsg(new LocalDate(1700, 1, 1), "error.allowed.start.date.extended")
   val localDateFutureRule: Rule[UrlFormEncoded, LocalDate] = localDateRuleWithPattern andThen pastStartDateRule andThen futureDateRule
   val allowedPastAndFutureDateRule: Rule[UrlFormEncoded, LocalDate] = localDateRuleWithPattern andThen pastStartDateRule andThen endOfCenturyDateRule
+  val allowedPastAndFutureDateRuleExtended: Rule[UrlFormEncoded, LocalDate] = localDateRuleWithPattern andThen pastStartDateRuleExtended andThen endOfCenturyDateRule
 
   val dateOfChangeActivityStartDateRuleMapping = Rule.fromMapping[(Option[LocalDate], LocalDate), LocalDate] {
     case (Some(d1), d2) if d2.isAfter(d1) => Valid(d2)

--- a/app/models/tradingpremises/ActivityStartDate.scala
+++ b/app/models/tradingpremises/ActivityStartDate.scala
@@ -30,7 +30,7 @@ object ActivityStartDate {
 
   implicit val formRule: Rule[UrlFormEncoded, ActivityStartDate] = From[UrlFormEncoded] { __ =>
     import jto.validation.forms.Rules._
-      (__ \ "startDate").read(allowedPastAndFutureDateRule) map ActivityStartDate.apply
+      (__ \ "startDate").read(allowedPastAndFutureDateRuleExtended) map ActivityStartDate.apply
   }
 
   implicit val formWrites: Write[ActivityStartDate, UrlFormEncoded] =

--- a/conf/messages
+++ b/conf/messages
@@ -202,6 +202,7 @@ error.invalid.tp.trading.name = You can’t enter more than 120 characters
 error.expected.jodadate.format = Enter a valid date. The day must be a number between 1 and 31. The month must be a number between 1 and 12. The year must be a 4-digit number.
 error.future.date = The date can’t be in the future
 error.allowed.start.date = The year can’t be before 1900
+error.allowed.start.date.extended = The date your business started trading from these premises must be after 1700
 error.required.tp.date = Enter a date.
 error.invalid.tp.date = Enter a valid date. It must be a number between 1 and 31.
 error.required.tp.month = Enter a month.

--- a/release_notes/AMLS-4983.txt
+++ b/release_notes/AMLS-4983.txt
@@ -1,0 +1,1 @@
+ + [AMLS-4983] - 1700 Update error message and widen validation for business start date

--- a/test/models/tradingpremises/ActivityStartDateSpec.scala
+++ b/test/models/tradingpremises/ActivityStartDateSpec.scala
@@ -68,14 +68,14 @@ class ActivityStartDateSpec extends PlaySpec {
       }
 
       "fail validation" when {
-        "given a day in the past before start of 1900" in {
+        "given a day in the past before start of 1700" in {
           val model = Map(
             "startDate.day" -> Seq("31"),
             "startDate.month" -> Seq("12"),
-            "startDate.year" -> Seq("1899")
+            "startDate.year" -> Seq("1699")
           )
           ActivityStartDate.formRule.validate(model) must be(Invalid(Seq(
-            Path \ "startDate" -> Seq(ValidationError("error.allowed.start.date"))
+            Path \ "startDate" -> Seq(ValidationError("error.allowed.start.date.extended"))
           )))
         }
       }


### PR DESCRIPTION
Validation now allows dates between 1700 and 2099 for activity start date in trading premises section for individual trading premise.

## Related / Dependant PRs?

- for this to work with backend service need to be implemented schema change for appropriate field

## How Has This Been Tested?

- manually, unit tests (however submissions, amendments will not work without proper schema in place)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
