### PR TITLE
Fixing warnings

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -65,6 +65,9 @@ object ApplicationConfig extends ApplicationConfig with ServicesConfig {
   lazy val timeout = getInt("timeout.seconds")
   lazy val timeoutCountdown = getInt("timeout.countdown")
 
+  lazy val ampWhatYouNeedUrl = s"${baseUrl("amls-art-market-participant-frontend")}/amls-art-market-participant-frontend/what-you-need"
+  lazy val ampSummeryUrl     = s"${baseUrl("amls-art-market-participant-frontend")}/amls-art-market-participant-frontend/check-your-answers"
+
   def businessCustomerUrl = getConfigString("business-customer.url")
 
   private implicit lazy val app:Application = Play.current

--- a/app/models/ViewResponse.scala
+++ b/app/models/ViewResponse.scala
@@ -55,8 +55,6 @@ object ViewResponse {
 
   implicit val jsonWrites = Json.writes[ViewResponse]
 
-  implicit val formatOption = Reads.optionWithNull[ViewResponse]
-
   def constructReads(
                  etmpFormBundleNumber:String,
                  businessMatchingSection: BusinessMatching,
@@ -118,5 +116,7 @@ object ViewResponse {
       (__ \ "hvdSection").readNullable[Hvd] and
       (__ \ "supervisionSection").readNullable[Supervision]
   }.apply(ViewResponse.constructReads _)
+
+  implicit val formatOption = Reads.optionWithNull[ViewResponse]
 
 }

--- a/app/models/amp/Amp.scala
+++ b/app/models/amp/Amp.scala
@@ -17,14 +17,13 @@
 package models.amp
 
 import java.time.LocalDateTime
+
+import config.ApplicationConfig
 import models.registrationprogress.{Completed, NotStarted, Section, Started}
-import play.api.Mode.Mode
-import play.api.{Configuration, Play}
 import play.api.libs.json._
 import play.api.mvc.Call
 import typeclasses.MongoKey
 import uk.gov.hmrc.http.cache.client.CacheMap
-import uk.gov.hmrc.play.config.ServicesConfig
 
 final case class Amp(id: String,
                      data: JsObject = Json.obj(),
@@ -81,25 +80,23 @@ final case class Amp(id: String,
   }
 }
 
-object Amp extends ServicesConfig {
+object Amp  {
 
   val redirectCallType       = "GET"
   val key                    = "amp"
-  lazy val ampWhatYouNeedUrl = s"${baseUrl("amls-art-market-participant-frontend")}/amls-art-market-participant-frontend/what-you-need"
-  lazy val ampSummeryUrl     = s"${baseUrl("amls-art-market-participant-frontend")}/amls-art-market-participant-frontend/check-your-answers"
 
   private def generateRedirect(destinationUrl: String) = {
     Call(redirectCallType, destinationUrl)
   }
 
   def section(implicit cache: CacheMap): Section = {
-    val notStarted = Section(key, NotStarted, false, generateRedirect(ampWhatYouNeedUrl))
+    val notStarted = Section(key, NotStarted, false, generateRedirect(ApplicationConfig.ampWhatYouNeedUrl))
     cache.getEntry[Amp](key).fold(notStarted) {
       model =>
         if (model.isComplete) {
-          Section(key, Completed, model.hasChanged, generateRedirect(ampSummeryUrl))
+          Section(key, Completed, model.hasChanged, generateRedirect(ApplicationConfig.ampSummeryUrl))
         } else {
-          Section(key, Started, model.hasChanged, generateRedirect(ampWhatYouNeedUrl))
+          Section(key, Started, model.hasChanged, generateRedirect(ApplicationConfig.ampWhatYouNeedUrl))
         }
     }
   }
@@ -133,7 +130,5 @@ object Amp extends ServicesConfig {
         (__ \ "hasAccepted").write[Boolean]
       ) (unlift(Amp.unapply))
   }
-
-  override protected def mode: Mode = Play.current.mode
-  override protected def runModeConfiguration: Configuration = Play.current.configuration
+  
 }

--- a/app/models/asp/Asp.scala
+++ b/app/models/asp/Asp.scala
@@ -45,7 +45,6 @@ object Asp {
   import play.api.libs.functional.syntax._
   import play.api.libs.json._
 
-  implicit val formatOption = Reads.optionWithNull[Asp]
 
   def section(implicit cache: CacheMap): Section = {
     val messageKey = "asp"
@@ -74,6 +73,8 @@ object Asp {
       (__ \ "hasChanged").readNullable[Boolean].map(_.getOrElse(false)) and
       (__ \ "hasAccepted").readNullable[Boolean].map(_.getOrElse(false))
   }.apply(Asp.apply _)
+
+  implicit val formatOption = Reads.optionWithNull[Asp]
 
   implicit def default(details: Option[Asp]): Asp =
     details.getOrElse(Asp())

--- a/app/models/businessmatching/updateservice/UpdateService.scala
+++ b/app/models/businessmatching/updateservice/UpdateService.scala
@@ -38,8 +38,6 @@ object UpdateService{
 
   val key = "updateservice"
 
-  implicit val formatOption = Reads.optionWithNull[UpdateService]
-
   implicit val jsonWrites = Json.writes[UpdateService]
 
   implicit val jsonReads: Reads[UpdateService] = {
@@ -48,5 +46,7 @@ object UpdateService{
       (__ \ "tradingPremisesSubmittedActivities").readNullable[TradingPremisesActivities] and
       (__ \ "inNewServiceFlow").readNullable[Boolean].map(_.getOrElse(false))
   }.apply(UpdateService.apply _)
+
+  implicit val formatOption = Reads.optionWithNull[UpdateService]
 
 }

--- a/app/models/estateagentbusiness/EstateAgentBusiness.scala
+++ b/app/models/estateagentbusiness/EstateAgentBusiness.scala
@@ -74,8 +74,6 @@ object EstateAgentBusiness {
 
   val key = "estate-agent-business"
 
-  implicit val formatOption = Reads.optionWithNull[EstateAgentBusiness]
-
   implicit val reads: Reads[EstateAgentBusiness] = (
     __.read(Reads.optionNoError[Services]) and
       __.read(Reads.optionNoError[RedressScheme]) and
@@ -97,6 +95,8 @@ object EstateAgentBusiness {
           _ ++ _
         } + ("hasChanged" -> JsBoolean(model.hasChanged)) + ("hasAccepted" -> JsBoolean(model.hasAccepted))
     }
+
+  implicit val formatOption = Reads.optionWithNull[EstateAgentBusiness]
 
   implicit def default(aboutYou: Option[EstateAgentBusiness]): EstateAgentBusiness =
     aboutYou.getOrElse(EstateAgentBusiness())

--- a/app/models/hvd/Hvd.scala
+++ b/app/models/hvd/Hvd.scala
@@ -105,8 +105,6 @@ object Hvd {
 
   val key = "hvd"
 
-  implicit val formatOption = Reads.optionWithNull[Hvd]
-
   def section(implicit cache: CacheMap): Section = {
     val notStarted = Section(key, NotStarted, false, controllers.hvd.routes.WhatYouNeedController.get())
     cache.getEntry[Hvd](key).fold(notStarted)  {
@@ -152,6 +150,8 @@ object Hvd {
   }
 
   implicit val writes: Writes[Hvd] = Json.writes[Hvd]
+
+  implicit val formatOption = Reads.optionWithNull[Hvd]
 
   implicit def default(hvd: Option[Hvd]): Hvd =
     hvd.getOrElse(Hvd())

--- a/app/models/moneyservicebusiness/MoneyServiceBusiness.scala
+++ b/app/models/moneyservicebusiness/MoneyServiceBusiness.scala
@@ -127,8 +127,6 @@ object MoneyServiceBusiness {
 
   val key = "msb"
 
-  implicit val formatOption = Reads.optionWithNull[MoneyServiceBusiness]
-
   def section(implicit cache: CacheMap): Section = {
     val messageKey = key
     val notStarted = Section(messageKey, NotStarted, false, controllers.msb.routes.WhatYouNeedController.get())
@@ -170,6 +168,8 @@ object MoneyServiceBusiness {
   }
 
   implicit val writes: Writes[MoneyServiceBusiness] = Json.writes[MoneyServiceBusiness]
+
+  implicit val formatOption = Reads.optionWithNull[MoneyServiceBusiness]
 
   implicit def default(value: Option[MoneyServiceBusiness]): MoneyServiceBusiness = {
     value.getOrElse(MoneyServiceBusiness())

--- a/app/models/responsiblepeople/ResponsiblePerson.scala
+++ b/app/models/responsiblepeople/ResponsiblePerson.scala
@@ -19,7 +19,6 @@ package models.responsiblepeople
 import models.registrationprogress.{Completed, NotStarted, Section, Started}
 import models.responsiblepeople.TimeAtAddress.{SixToElevenMonths, ZeroToFiveMonths}
 import org.joda.time.LocalDate
-import play.api.libs.json.Reads
 import typeclasses.MongoKey
 import uk.gov.hmrc.http.cache.client.CacheMap
 import utils.StatusConstants
@@ -234,8 +233,6 @@ object ResponsiblePerson {
       _.hasChanged
     }
 
-  implicit val formatOption = Reads.optionWithNull[Seq[ResponsiblePerson]]
-
   def filter(rp: Seq[ResponsiblePerson]): Seq[ResponsiblePerson] =
     rp.filterNot(_.status.contains(StatusConstants.Deleted)).filterNot(_ == ResponsiblePerson())
 
@@ -377,6 +374,8 @@ object ResponsiblePerson {
       }
     }
   }
+
+  implicit val formatOption = Reads.optionWithNull[Seq[ResponsiblePerson]]
 
   private def hasUkPassportNumber(rp: ResponsiblePerson): Boolean = rp.ukPassport match {
     case Some(UKPassportYes(_)) => true

--- a/app/models/supervision/Supervision.scala
+++ b/app/models/supervision/Supervision.scala
@@ -80,8 +80,6 @@ object Supervision {
 
   val key = "supervision"
 
-  implicit val formatOption = Reads.optionWithNull[Supervision]
-
   implicit val mongoKey = new MongoKey[Supervision] {
     override def apply(): String = "supervision"
   }
@@ -106,6 +104,8 @@ object Supervision {
   }
 
   implicit val writes: Writes[Supervision] = Json.writes[Supervision]
+
+  implicit val formatOption = Reads.optionWithNull[Supervision]
 
   implicit def default(supervision: Option[Supervision]): Supervision =
     supervision.getOrElse(Supervision())

--- a/app/models/tcsp/Tcsp.scala
+++ b/app/models/tcsp/Tcsp.scala
@@ -92,8 +92,6 @@ object Tcsp {
   import play.api.libs.json._
   import utils.MappingUtils._
 
-  implicit val formatOption = Reads.optionWithNull[Tcsp]
-
   def section(implicit cache: CacheMap): Section = {
     val messageKey = "tcsp"
     val notStarted = Section(messageKey, NotStarted, false, controllers.tcsp.routes.WhatYouNeedController.get())
@@ -166,4 +164,7 @@ object Tcsp {
   }.apply(Tcsp.apply _)
   implicit def default(tcsp: Option[Tcsp]): Tcsp =
     tcsp.getOrElse(Tcsp())
+
+  implicit val formatOption = Reads.optionWithNull[Tcsp]
+
 }

--- a/app/models/tradingpremises/TradingPremises.scala
+++ b/app/models/tradingpremises/TradingPremises.scala
@@ -112,8 +112,6 @@ object TradingPremises {
 
   val key = "trading-premises"
 
-  implicit val formatOption = Reads.optionWithNull[Seq[TradingPremises]]
-
   def anyChanged(newModel: Seq[TradingPremises]): Boolean = newModel exists {
     _.hasChanged
   }
@@ -205,6 +203,8 @@ object TradingPremises {
   }
 
   implicit val writes: Writes[TradingPremises] = Json.writes[TradingPremises]
+
+  implicit val formatOption = Reads.optionWithNull[Seq[TradingPremises]]
 
   implicit def default(tradingPremises: Option[TradingPremises]): TradingPremises =
     tradingPremises.getOrElse(TradingPremises())

--- a/test/models/amp/AmpSpec.scala
+++ b/test/models/amp/AmpSpec.scala
@@ -18,7 +18,6 @@ package models.amp
 import java.time.{LocalDate, LocalDateTime, ZoneOffset}
 
 import config.ApplicationConfig
-import models.amp.Amp.baseUrl
 import models.registrationprogress.{Completed, NotStarted, Section, Started}
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.cache.client.CacheMap
@@ -131,25 +130,23 @@ class AmpSpec extends AmlsSpec with AmpValues {
 
     "have a section function that" must {
       implicit val cache         = mock[CacheMap]
-      lazy val ampWhatYouNeedUrl = s"${baseUrl("amls-art-market-participant-frontend")}/amls-art-market-participant-frontend/what-you-need"
-      lazy val ampSummeryUrl     = s"${baseUrl("amls-art-market-participant-frontend")}/amls-art-market-participant-frontend/check-your-answers"
 
       "return a NotStarted Section when model is empty" in {
-        val notStartedSection = Section("amp", NotStarted, false, Call("GET", ampWhatYouNeedUrl))
+        val notStartedSection = Section("amp", NotStarted, false, Call("GET", ApplicationConfig.ampWhatYouNeedUrl))
 
         when(cache.getEntry[Amp]("amp")) thenReturn None
         Amp.section must be(notStartedSection)
       }
 
       "return a Completed Section when model is complete" in {
-        val completedSection = Section("amp", Completed, false, Call("GET", ampSummeryUrl))
+        val completedSection = Section("amp", Completed, false, Call("GET", ApplicationConfig.ampSummeryUrl))
 
         when(cache.getEntry[Amp]("amp")) thenReturn Some(completeModel)
         Amp.section must be(completedSection)
       }
 
       "return a Started Section when model is incomplete" in {
-        val startedSection = Section("amp", Started, false, Call("GET", ampWhatYouNeedUrl))
+        val startedSection = Section("amp", Started, false, Call("GET", ApplicationConfig.ampWhatYouNeedUrl))
 
         when(cache.getEntry[Amp]("amp")) thenReturn Some(missingTypeOfParticipantDetailModel)
         Amp.section must be(startedSection)


### PR DESCRIPTION
Fixed some uninitialised variable warnings (moved use of Reads below declaration in models), and the use of deprecated Play.current in Amp (moved URLs to ApplicationConfig and removed redundant superclass)

## Related / Dependant PRs?

## How Has This Been Tested?

Ran spec tests

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [ ] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
