### PR TITLE
AMLS-5369 | Updated Fee & Ref content, added print link and GA tracking

### DIFF
--- a/app/views/confirmation/confirm_amendvariation.scala.html
+++ b/app/views/confirmation/confirm_amendvariation.scala.html
@@ -21,7 +21,7 @@
 @(paymentReference: Option[String], total: Currency, amountToPay: Currency, maybeBreakdown: Option[Seq[BreakdownRow]], paymentsUrl: String)(implicit request: Request[_], m:Messages)
 
 @main(
-    title = Messages("confirmation.amendment.header")
+    title = Messages("confirmation.amendment.header") + " - " + Messages("confirmation.amendment.header.secondary")
 ) {
 
     <header class="page-header">

--- a/app/views/confirmation/confirm_amendvariation.scala.html
+++ b/app/views/confirmation/confirm_amendvariation.scala.html
@@ -31,6 +31,8 @@
 
     <p class="info"> @Messages("confirmation.amendment.info")</p>
 
+    <p class="make-note"> @Messages("confirmation.amendment.makenote")</p>
+
     <div class="reg-online--pay-fee">
         <p>@Messages("confirmation.fee") <span class="visuallyhidden">is</span>
             <span class="heading-large">@amountToPay</span></p>
@@ -43,6 +45,13 @@
     @maybeBreakdown.map { breakdown =>
         @breakdown_display(total, breakdown, Messages("confirmation.amendment.summary"))
     }
+
+    <div id="timelimit"><p>@Messages("confirmation.timelimit")</p></div>
+
+
+    @printLink(linkId = "confirmation-print",
+        gaTag = Some("fee-reference:click:print")
+    )
 
     <p><a id='continue-pay' class="button" href="@paymentsUrl">@Messages("button.continuetopayment")</a></p>
 

--- a/app/views/confirmation/confirm_renewal.scala.html
+++ b/app/views/confirmation/confirm_renewal.scala.html
@@ -21,7 +21,7 @@
 @(paymentReference: Option[String], total: Currency, breakdown: Seq[BreakdownRow], amountToPay: Currency, paymentsUrl: String)(implicit request: Request[_],m:Messages)
 
 @main(
-    title = Messages("confirmation.renewal.title")
+    title = Messages("confirmation.renewal.title") + " - " + Messages("confirmation.renewal.header.secondary")
 ) {
 
     <header class="page-header">

--- a/app/views/confirmation/confirm_renewal.scala.html
+++ b/app/views/confirmation/confirm_renewal.scala.html
@@ -42,6 +42,12 @@
 
     @breakdown_display(total, breakdown, Messages("confirmation.renewal.summary"))
 
+    <div id="timelimit"><p>@Messages("confirmation.timelimit")</p></div>
+
+    @printLink(linkId = "confirmation-print",
+        gaTag = Some("fee-reference:click:print")
+    )
+
     <p><a id='continue-pay' class="button" href="@paymentsUrl">@Messages("button.continuetopayment")</a></p>
 
 }

--- a/app/views/confirmation/confirmation_new.scala.html
+++ b/app/views/confirmation/confirmation_new.scala.html
@@ -79,6 +79,13 @@
         }
     }
 
+
+    <div id="timelimit"><p>@Messages("confirmation.timelimit")</p></div>
+
+    @printLink(linkId = "confirmation-print",
+        gaTag = Some("fee-reference:click:print")
+    )
+
     <p><a id="payfee" class="button" href="@paymentsUrl">@Messages("button.continuetopayment")</a></p>
 
 }

--- a/conf/messages
+++ b/conf/messages
@@ -778,14 +778,15 @@ amendment.sidebar.text = You don’t need to re-submit your application until yo
 amendment.sidebar.button.text = Submit amendment
 
 #### Confirmation page ####
-confirmation.title = You’ve submitted your application
-confirmation.header = Application fee and reference
+confirmation.title = Your fee and payment reference
+confirmation.header = Your fee and payment reference
 confirmation.header.secondary = Update information
 confirmation.lede = You’ve submitted your application.
 confirmation.thankyou = Thank you for registering online.
 confirmation.thankyou.p = You now need to pay the registration fee. Your application won’t be reviewed by HM Revenue and Customs until the fee is paid.
-confirmation.submission.info = Your application will not be reviewed by HMRC until you pay the fee.
+confirmation.submission.info = Make a note of your payment reference as you’ll need it to pay your fee.
 confirmation.notice = You must make a note of this reference number and registration fee. You’ll need them to make the payment.
+confirmation.timelimit = You have 28 days to pay your fee.
 confirmation.reference.notice = You must make a note of this reference number.
 confirmation.fee = Your fee
 confirmation.no.fee = There are no fees to pay for these changes.
@@ -811,12 +812,13 @@ confirmation.whathappensnext.p.1 = You’ll receive an email from HM Revenue and
 confirmation.whathappensnext.p.2 = When you receive the email, sign back in to this website to see if your application has been approved or rejected.
 confirmation.itemisedfeelink = How your fee has been calculated
 
-confirmation.amendment.title = You’ve submitted an updated application
-confirmation.amendment.header = Updated application fee and reference
+confirmation.amendment.title = Your fee and payment reference
+confirmation.amendment.header = Your fee and payment reference
 confirmation.amendment.header.secondary = Update information
 confirmation.amendment.lede = You’ve submitted an updated application
 confirmation.amendment.thankyou.p = Because of the changes you’ve made, you need to pay an additional fee.
-confirmation.amendment.info = Because of the changes you’ve made, you need to pay an additional fee. Your changes won’t be reviewed by HM Revenue and Customs until the fee is paid.
+confirmation.amendment.info = You’ll need to pay a fee because of updates you have made.
+confirmation.amendment.makenote = Make a note of your payment reference as you’ll need it to pay your fee.
 confirmation.amendment.previousfees.p = You still need to pay your previous fees, if you’ve not paid them already.
 confirmation.amendment.fee = Your amendment fee
 confirmation.amendment.breakdown = How your fee has been calculated:
@@ -828,16 +830,16 @@ confirmation.amendment.details.list.02 = not paid any of your previous fees - yo
 confirmation.amendment.details.list.03 = paid some of your fees so far, but not all of them - you need to deduct what you’ve paid from the total of the itemised breakdown and pay what’s left
 confirmation.amendment.details.02 = Your application won’t be reviewed by HM Revenue and Customs until all the fees are paid.
 
-confirmation.variation.title = You’ve submitted your updated information
-confirmation.variation.header = Updated fee and reference
+confirmation.variation.title = Your fee and payment reference
+confirmation.variation.header = Your fee and payment reference
 confirmation.variation.header.secondary = Update information
 confirmation.variation.lede = You’ve updated your information
 confirmation.variation.info = You need to pay a fee for the updates you’ve made. Your changes won’t be reviewed by HMRC Revenue and Customs until the fee is paid.
 confirmation.variation.summary = This shows your total fees for each item.
 
-confirmation.renewal.title = Renewal fee and reference
-confirmation.renewal.header = Renewal fee and reference
-confirmation.renewal.info = Your renewal will not be reviewed by HMRC until you have paid the fee.
+confirmation.renewal.title = Your fee and payment reference
+confirmation.renewal.header = Your fee and payment reference
+confirmation.renewal.info = Make a note of your payment reference as you’ll need it to pay your fee.
 confirmation.renewal.header.secondary = Submit renewal
 confirmation.renewal.summary = This shows your total renewal fees for each item.
 

--- a/conf/messages
+++ b/conf/messages
@@ -812,7 +812,7 @@ confirmation.whathappensnext.p.1 = You’ll receive an email from HM Revenue and
 confirmation.whathappensnext.p.2 = When you receive the email, sign back in to this website to see if your application has been approved or rejected.
 confirmation.itemisedfeelink = How your fee has been calculated
 
-confirmation.amendment.title = Your fee and payment reference
+confirmation.amendment.title = You’ve submitted an updated application
 confirmation.amendment.header = Your fee and payment reference
 confirmation.amendment.header.secondary = Update information
 confirmation.amendment.lede = You’ve submitted an updated application
@@ -830,7 +830,7 @@ confirmation.amendment.details.list.02 = not paid any of your previous fees - yo
 confirmation.amendment.details.list.03 = paid some of your fees so far, but not all of them - you need to deduct what you’ve paid from the total of the itemised breakdown and pay what’s left
 confirmation.amendment.details.02 = Your application won’t be reviewed by HM Revenue and Customs until all the fees are paid.
 
-confirmation.variation.title = Your fee and payment reference
+confirmation.variation.title = You’ve submitted your updated information
 confirmation.variation.header = Your fee and payment reference
 confirmation.variation.header.secondary = Update information
 confirmation.variation.lede = You’ve updated your information

--- a/public/print.css
+++ b/public/print.css
@@ -23,11 +23,12 @@
      .messaging,
      .no-print,
      .declaration,
-     .button {
+     .button,
+      details.details:not([open]) {
          display: none !important;
      }
 
-     .print-left {
+     .print-left, .heading-secondary {
         text-align:left;
         margin:auto;
      }

--- a/release_notes/AMLS-5369.txt
+++ b/release_notes/AMLS-5369.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5369] - 'Updated Fee & Reference content, added print link and GA tracking'

--- a/test/controllers/ConfirmationControllerSpec.scala
+++ b/test/controllers/ConfirmationControllerSpec.scala
@@ -196,7 +196,7 @@ class ConfirmationControllerSpec extends AmlsSpec
 
       val result = controller.get()(request)
       status(result) mustBe OK
-      Jsoup.parse(contentAsString(result)).title must include("Application fee and reference")
+      Jsoup.parse(contentAsString(result)).title must include("Your fee and payment reference")
       contentAsString(result) must include(paymentReferenceNumber)
     }
 

--- a/test/views/confirmation/AmendmentConfirmationViewSpec.scala
+++ b/test/views/confirmation/AmendmentConfirmationViewSpec.scala
@@ -57,6 +57,18 @@ class AmendmentConfirmationViewSpec extends AmlsSpec with MustMatchers  with Pay
       doc.select(".info").text mustBe Messages("confirmation.amendment.info")
     }
 
+    "show the advice to print out the page" in new ViewFixture {
+      doc.select(".make-note").text mustBe Messages("confirmation.amendment.makenote")
+    }
+
+    "show the correct time limit" in new ViewFixture {
+      doc.select("#timelimit").text mustBe Messages("confirmation.timelimit")
+    }
+
+    "show the link to print the page" in new ViewFixture {
+      doc.select(".print-link").text mustBe Messages("link.print")
+    }
+
     "show the correct fee" in new ViewFixture {
       doc.select(".reg-online--pay-fee .heading-large").first.text mustBe "£150.00"
     }

--- a/test/views/confirmation/RenewalConfirmationViewSpec.scala
+++ b/test/views/confirmation/RenewalConfirmationViewSpec.scala
@@ -56,6 +56,14 @@ class RenewalConfirmationViewSpec extends AmlsSpec with PaymentGenerator {
       doc.select(".info").text mustBe Messages("confirmation.renewal.info")
     }
 
+    "show the correct time limit" in new ViewFixture {
+      doc.select("#timelimit").text mustBe Messages("confirmation.timelimit")
+    }
+
+    "show the link to print the page" in new ViewFixture {
+      doc.select(".print-link").text mustBe Messages("link.print")
+    }
+
     "show the correct fee" in new ViewFixture {
       doc.select(".reg-online--pay-fee .heading-large").first.text mustBe "£150.00"
     }

--- a/test/views/confirmation/SubmitRegistrationConfirmationViewSpec.scala
+++ b/test/views/confirmation/SubmitRegistrationConfirmationViewSpec.scala
@@ -52,6 +52,14 @@ class SubmitRegistrationConfirmationViewSpec extends AmlsSpec with PaymentGenera
       doc.select(".info").text mustBe Messages("confirmation.submission.info")
     }
 
+    "show the correct time limit" in new ViewFixture {
+      doc.select("#timelimit").text mustBe Messages("confirmation.timelimit")
+    }
+
+    "show the link to print the page" in new ViewFixture {
+      doc.select(".print-link").text mustBe Messages("link.print")
+    }
+
     "show the correct fee" in new ViewFixture {
       doc.select(".reg-online--pay-fee .heading-large").first.text mustBe s"£$fee.00"
     }


### PR DESCRIPTION
1. Content updated
2. Print link added (table link hidden if not expanded, as per discussion with Martin Underhill)
3. Button already reads "Continue to payment"
4. GA tracking added, using "fee-reference:click:print"

## Related / Dependant PRs?

## How Has This Been Tested?

Manual tests, updated spec tests

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
