### PR TITLE
AMLS-5420 | Hide "supervision details"

### DIFF
--- a/app/controllers/businessmatching/updateservice/add/NeedMoreInformationController.scala
+++ b/app/controllers/businessmatching/updateservice/add/NeedMoreInformationController.scala
@@ -25,7 +25,7 @@ import models.businessmatching.updateservice.ServiceChangeRegister
 import models.businessmatching.{BillPaymentServices, TelephonePaymentService}
 import models.flowmanagement.{AddBusinessTypeFlowModel, NeedMoreInformationPageId}
 import services.flowmanagement.Router
-import utils.AuthAction
+import utils.{AuthAction, ControllerHelper}
 import views.html.businessmatching.updateservice.add.new_service_information
 
 import scala.concurrent.Future
@@ -41,6 +41,7 @@ class NeedMoreInformationController @Inject()(authAction: AuthAction,
         (for {
           model <- OptionT(dataCacheConnector.fetch[ServiceChangeRegister](request.credId, ServiceChangeRegister.key))
           activity <- OptionT.fromOption[Future](model.addedActivities)
+          cacheMap <- OptionT(dataCacheConnector.fetchAll(request.credId))
         } yield {
           val activityNames = activity filterNot {
             case BillPaymentServices | TelephonePaymentService => true
@@ -49,7 +50,7 @@ class NeedMoreInformationController @Inject()(authAction: AuthAction,
             _.getMessage()
           }
 
-          Ok(new_service_information(activityNames))
+          Ok(new_service_information(activityNames, ControllerHelper.supervisionComplete(cacheMap)))
         }) getOrElse InternalServerError("Get: Unable to show New Service Information page")
   }
 

--- a/app/views/businessmatching/updateservice/add/new_service_information.scala.html
+++ b/app/views/businessmatching/updateservice/add/new_service_information.scala.html
@@ -18,7 +18,7 @@
 @import forms2._
 @import forms.EmptyForm
 
-@(activities: Set[String])(implicit request: Request[_], messages: Messages)
+@(activities: Set[String], hideSupervisionDetails:Boolean)(implicit request: Request[_], messages: Messages)
 
 @header = {
     @components.back_link()
@@ -30,37 +30,41 @@
     heading = header
 ) {
 
-    @activities match {
-        case list if list.contains("Accountancy service provider") && (list.size == 1) => {
-            <p>@Messages("businessmatching.updateservice.newserviceinformation.info.asp")</p>
+    @if(activities.size == 1) {
+        @activities match {
+            case list if list.contains("Accountancy service provider") => {
+                @if(hideSupervisionDetails) {
+                    <p>@Messages("businessmatching.updateservice.newserviceinformation.info.onlyasp")</p>
+                } else {
+                    <p>@Messages("businessmatching.updateservice.newserviceinformation.info.asp")</p>
+                }
+            }
+            case list if list.contains("Trust or company service provider") => {
+                @if(hideSupervisionDetails) {
+                    <p>@Messages("businessmatching.updateservice.newserviceinformation.info.onlytcsp")</p>
+                } else {
+                    <p>@Messages("businessmatching.updateservice.newserviceinformation.info.tcsp")</p>
+                }
+            }
+            case _ => {
+                <p>@Messages("businessmatching.updateservice.newserviceinformation.info.1", (activities.mkString(" ")).toLowerCase)</p>
+            }
         }
-        case list if list.contains("Trust or company service provider") && (list.size == 1) => {
-            <p>@Messages("businessmatching.updateservice.newserviceinformation.info.tcsp")</p>
-        }
-        case list if list.contains("Trust or company service provider") || list.contains("Accountancy service provider") && (list.size > 1) => {
-            <p>@Messages("businessmatching.updateservice.newserviceinformation.info.2")</p>
-                <ul class="list list-bullet">
-                    @activities.toList.sorted.map { ba =>
+    }
+
+    @if(activities.size > 1) {
+        <p>@Messages("businessmatching.updateservice.newserviceinformation.info.2")</p>
+        <ul class="list list-bullet">
+            @activities.toList.sorted.map { ba =>
                 <li>@Character.toLowerCase(ba.charAt(0))@ba.substring(1)</li>
             }
+            @if((activities.contains("Trust or company service provider") || activities.contains("Accountancy service provider")) && !hideSupervisionDetails) {
                 <li>@Messages("businessmatching.updateservice.newserviceinformation.info.supervision")</li>
-                </ul>
-            <p>@Messages("businessmatching.updateservice.newserviceinformation.info.3")</p>
-            <p>@Messages("businessmatching.updateservice.newserviceinformation.info.4")</p>
-        }
-        case list if list.size > 1 => {
-            <p>@Messages("businessmatching.updateservice.newserviceinformation.info.2")</p>
-                <ul class="list list-bullet">
-                    @activities.toList.sorted.map { ba =>
-                <li>@Character.toLowerCase(ba.charAt(0))@ba.substring(1)</li>
             }
-                </ul>
-            <p>@Messages("businessmatching.updateservice.newserviceinformation.info.3")</p>
-            <p>@Messages("businessmatching.updateservice.newserviceinformation.info.4")</p>
-        }
-        case list if list.size == 1 => {
-            <p>@Messages("businessmatching.updateservice.newserviceinformation.info.1", (activities.mkString(" ")).toLowerCase)</p>
-        }
+        </ul>
+
+        <p>@Messages("businessmatching.updateservice.newserviceinformation.info.3")</p>
+        <p>@Messages("businessmatching.updateservice.newserviceinformation.info.4")</p>
     }
 
     @form(EmptyForm, controllers.businessmatching.updateservice.add.routes.NeedMoreInformationController.post()) {

--- a/conf/messages
+++ b/conf/messages
@@ -1390,6 +1390,8 @@ businessmatching.updateservice.newserviceinformation.info.3 = You may need to up
 businessmatching.updateservice.newserviceinformation.info.4 = You may need to update other information about your business.
 businessmatching.updateservice.newserviceinformation.info.asp = You’ll need to complete the accountancy service provider and supervision details sections.
 businessmatching.updateservice.newserviceinformation.info.tcsp = You’ll need to complete the trust or company service provider and supervision details sections.
+businessmatching.updateservice.newserviceinformation.info.onlyasp = You’ll need to complete the accountancy service provider section.
+businessmatching.updateservice.newserviceinformation.info.onlytcsp = You’ll need to complete the trust or company service provider section.
 businessmatching.updateservice.newserviceinformation.info.supervision = supervision details
 
 businessmatching.updateservice.summary.whichtradingpremises.count = You’ve chosen {0} trading premises

--- a/release_notes/AMLS-5420.txt
+++ b/release_notes/AMLS-5420.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5420] - 'Hide "supervision details" on "Update other information" page if section is complete'

--- a/test/views/businessmatching/updateservice/add/new_service_informationSpec.scala
+++ b/test/views/businessmatching/updateservice/add/new_service_informationSpec.scala
@@ -29,7 +29,7 @@ class new_service_informationSpec extends AmlsSpec with MustMatchers {
   trait ViewFixture extends Fixture {
     implicit val requestWithToken = addToken(request)
 
-    def view = new_service_information(Set(AccountancyServices.getMessage()))
+    def view = new_service_information(Set(AccountancyServices.getMessage()), false)
   }
 
   "The new_service_information view" must {
@@ -50,28 +50,51 @@ class new_service_informationSpec extends AmlsSpec with MustMatchers {
       doc.getElementsByAttributeValue("class", "link-back") must not be empty
     }
 
-    "show the correct content when only ASP is selected" in new ViewFixture {
-      doc.body().text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.asp"))
-    }
+    "show the correct content" when {
 
-    "show the correct content when only TCSP is selected" in new ViewFixture {
-      override def view = new_service_information(Set(TrustAndCompanyServices.getMessage()))
+      "supervision section is not complete" when {
 
-      doc.body().text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.tcsp"))
-    }
+        "only ASP is selected" in new ViewFixture {
+          doc.getElementById("content").text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.asp"))
+        }
 
-    "show the correct content when only both ASP and TCSP are selected" in new ViewFixture {
-      override def view = new_service_information(Set(TrustAndCompanyServices.getMessage(), AccountancyServices.getMessage()))
+        "only TCSP is selected" in new ViewFixture {
+          override def view = new_service_information(Set(TrustAndCompanyServices.getMessage()), false)
+          doc.getElementById("content").text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.tcsp"))
+        }
 
-      doc.body().text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.supervision"))
-      doc.body().text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.3"))
-      doc.body().text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.4"))
-      doc.body().text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.2"))
+        "both ASP and TCSP are selected" in new ViewFixture {
+          override def view = new_service_information(Set(TrustAndCompanyServices.getMessage(), AccountancyServices.getMessage()), false)
+          doc.getElementById("content").text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.supervision"))
+          doc.getElementById("content").text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.3"))
+          doc.getElementById("content").text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.4"))
+          doc.getElementById("content").text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.2"))
+        }
+      }
+
+      "supervision section is complete" when {
+
+        "both ASP and TCSP are selected" in new ViewFixture {
+          override def view = new_service_information(Set(TrustAndCompanyServices.getMessage(), AccountancyServices.getMessage()), true)
+          doc.getElementById("content").text() mustNot include(Messages("businessmatching.updateservice.newserviceinformation.info.supervision"))
+        }
+
+        "only ASP is selected" in new ViewFixture {
+          override def view = new_service_information(Set(AccountancyServices.getMessage()), true)
+          doc.getElementById("content").text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.onlyasp"))
+          doc.getElementById("content").text() mustNot include(Messages("businessmatching.updateservice.newserviceinformation.info.supervision"))
+        }
+
+        "only TCSP is selected" in new ViewFixture {
+          override def view = new_service_information(Set(TrustAndCompanyServices.getMessage()), true)
+          doc.getElementById("content").text() must include(Messages("businessmatching.updateservice.newserviceinformation.info.onlytcsp"))
+          doc.getElementById("content").text() mustNot include(Messages("businessmatching.updateservice.newserviceinformation.info.supervision"))
+        }
+      }
     }
 
     "not show the return link" in new ViewFixture {
       doc.body().text() must not include Messages("link.return.registration.progress")
     }
   }
-
 }


### PR DESCRIPTION
Hide "supervision details" on "Update other information" page if section is complete.

"Supervision details" is shown on the "You need to update other information" page, if either ASP or TCSP is added and the supervision details section is not completed.

If only one service is added, it will read (where [text in brackets] is conditional on supervision details being complete):

"_You’ll need to complete the SERVICE [and supervision details] section[s]_".

If more than one is added, the services and "supervision details" will be displayed in bullet points.

"_You’ll need to complete the following sections:_
- _accountancy service provider_
- _trust or company service provider_
- _[supervision details]_"

## Related / Dependant PRs?

## How Has This Been Tested?

Manual testing, updated unit tests

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
