### PR TITLE
Amls 5476 - Bug fix: Approval fee is not rendering in fees table for amp people

### DIFF
--- a/app/utils/ActivitiesHelper.scala
+++ b/app/utils/ActivitiesHelper.scala
@@ -25,6 +25,6 @@ object ActivitiesHelper {
 
   def acSectors(activities: Set[BusinessActivity]): Boolean = {
     (activities.contains(HighValueDealing) || activities.contains(AccountancyServices) ||
-      activities.contains(EstateAgentBusinessService))
+      activities.contains(EstateAgentBusinessService) || activities.contains(ArtMarketParticipant))
   }
 }

--- a/release_notes/AMLS-5476.txt
+++ b/release_notes/AMLS-5476.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5476] - 'Bug fix: Approval fee is not rendering in fees table for AMP'


### PR DESCRIPTION
As above. Included AMP in sectors for which RP need to have AC. 

## Related / Dependant PRs?

- first to be merged: https://github.com/hmrc/amls-stub/pull/137

## How Has This Been Tested?

- manually

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
