### PR TITLE
EAB Services date of change redirect to redress scheme fix

### DIFF
--- a/app/controllers/estateagentbusiness/ServicesDateOfChangeController.scala
+++ b/app/controllers/estateagentbusiness/ServicesDateOfChangeController.scala
@@ -51,9 +51,7 @@ class ServicesDateOfChangeController  @Inject()( val dataCacheConnector: DataCac
                       case Some(service) => {
                         eab.copy(services = Some(service.copy(dateOfChange = Some(data))))
                       }
-                      case None => {
-                        eab
-                      }
+                      case None => eab
                     })
                 } yield {
                   eab.services.map(candidate => candidate.services.contains(Residential)) match {

--- a/app/controllers/estateagentbusiness/ServicesDateOfChangeController.scala
+++ b/app/controllers/estateagentbusiness/ServicesDateOfChangeController.scala
@@ -23,7 +23,6 @@ import javax.inject.Inject
 import models.DateOfChange
 import models.businessdetails.BusinessDetails
 import models.estateagentbusiness.{EstateAgentBusiness, Residential}
-import play.Logger
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.AuthAction
 import views.html.date_of_change
@@ -42,7 +41,6 @@ class ServicesDateOfChangeController  @Inject()( val dataCacheConnector: DataCac
       implicit request =>
         getModelWithDateMap(request.credId) flatMap {
           case (eab, startDate) =>
-            println("ACHI (eab, startDate): " + (eab, startDate))
             Form2[DateOfChange](request.body.asFormUrlEncoded.get ++ startDate) match {
               case f: InvalidForm =>
                 Future.successful(BadRequest(date_of_change(f, "summary.estateagentbusiness", routes.ServicesDateOfChangeController.post())))
@@ -58,7 +56,6 @@ class ServicesDateOfChangeController  @Inject()( val dataCacheConnector: DataCac
                       }
                     })
                 } yield {
-                  Logger.debug("ACHI: " + eab)
                   eab.services.map(candidate => candidate.services.contains(Residential)) match {
                     case Some(true) => Redirect(routes.ResidentialRedressSchemeController.get(true))
                     case _          => Redirect(routes.SummaryController.get())

--- a/release_notes/AMLS-5501.txt
+++ b/release_notes/AMLS-5501.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5501] - 'EAB Services date of change redirect to redress scheme fix'

--- a/test/controllers/estateagentbusiness/ServicesDateOfChangeControllerSpec.scala
+++ b/test/controllers/estateagentbusiness/ServicesDateOfChangeControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.estateagentbusiness
 import connectors.DataCacheConnector
 import controllers.actions.SuccessfulAuthAction
 import models.businessdetails.{ActivityStartDate, BusinessDetails}
-import models.estateagentbusiness.EstateAgentBusiness
+import models.estateagentbusiness._
 import org.joda.time.LocalDate
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -52,7 +52,7 @@ class ServicesDateOfChangeControllerSpec extends AmlsSpec with MockitoSugar  {
       contentAsString(result) must include(Messages("summary.estateagentbusiness"))
     }
 
-    "submit with valid data" in new Fixture {
+    "submit with valid data and redirect to CYA for non residential" in new Fixture {
 
       val newRequest = request.withFormUrlEncodedBody(
         "dateOfChange.day" -> "24",
@@ -60,12 +60,14 @@ class ServicesDateOfChangeControllerSpec extends AmlsSpec with MockitoSugar  {
         "dateOfChange.year" -> "1990"
       )
 
+      val eab = EstateAgentBusiness(Some(Services(Set(Commercial),None)),None,None)
+
       val mockCacheMap = mock[CacheMap]
       when(mockCacheMap.getEntry[BusinessDetails](BusinessDetails.key))
-        .thenReturn(Some(BusinessDetails(activityStartDate = Some(ActivityStartDate(new LocalDate(1990, 2, 24))))))
+        .thenReturn(Some(BusinessDetails(activityStartDate = Some(ActivityStartDate(new LocalDate(1990, 2, 22))))))
 
       when(mockCacheMap.getEntry[EstateAgentBusiness](EstateAgentBusiness.key))
-        .thenReturn(None)
+        .thenReturn(Some(eab))
 
       when(controller.dataCacheConnector.fetchAll(any())( any()))
         .thenReturn(Future.successful(Some(mockCacheMap)))
@@ -76,6 +78,34 @@ class ServicesDateOfChangeControllerSpec extends AmlsSpec with MockitoSugar  {
       val result = controller.post()(newRequest)
       status(result) must be(SEE_OTHER)
       redirectLocation(result) must be(Some(controllers.estateagentbusiness.routes.SummaryController.get().url))
+    }
+
+    "submit and redirect to redress scheme for residential" in new Fixture {
+
+      val newRequest = request.withFormUrlEncodedBody(
+        "dateOfChange.day" -> "24",
+        "dateOfChange.month" -> "2",
+        "dateOfChange.year" -> "1990"
+      )
+
+      val eab = EstateAgentBusiness(Some(Services(Set(Residential),None)),None,None)
+
+      val mockCacheMap = mock[CacheMap]
+      when(mockCacheMap.getEntry[BusinessDetails](BusinessDetails.key))
+        .thenReturn(Some(BusinessDetails(activityStartDate = Some(ActivityStartDate(new LocalDate(1990, 2, 22))))))
+
+      when(mockCacheMap.getEntry[EstateAgentBusiness](EstateAgentBusiness.key))
+        .thenReturn(Some(eab))
+
+      when(controller.dataCacheConnector.fetchAll(any())( any()))
+        .thenReturn(Future.successful(Some(mockCacheMap)))
+
+      when(controller.dataCacheConnector.save[EstateAgentBusiness](any(), any(), any())
+        ( any(), any())).thenReturn(Future.successful(emptyCache))
+
+      val result = controller.post()(newRequest)
+      status(result) must be(SEE_OTHER)
+      redirectLocation(result) must be(Some(controllers.estateagentbusiness.routes.ResidentialRedressSchemeController.get(true).url))
     }
 
     "fail submission when invalid date is supplied" in new Fixture {


### PR DESCRIPTION
EAB should redirect to redress scheme from date of change when editing services and Residential is selected.  

## Related / Dependant PRs?

N/A

## How Has This Been Tested?

Local + Unit

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
