### PR TITLE
AMLS-5365 | Reverting mongo cache client changes.

### DIFF
--- a/app/services/cache/MongoCacheClient.scala
+++ b/app/services/cache/MongoCacheClient.scala
@@ -22,9 +22,8 @@ import javax.inject.Inject
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.api.libs.functional.FunctionalBuilder
 import play.api.libs.json._
-import play.modules.reactivemongo.{MongoDbConnection, ReactiveMongoComponent}
+import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.DefaultDB
 import reactivemongo.api.commands.WriteResult
 import reactivemongo.api.indexes.{Index, IndexType}
@@ -49,7 +48,7 @@ case class Cache(id: String, data: Map[String, JsValue], lastUpdated: DateTime =
     * If the data to be inserted is null then remove the entry by key
     */
   def upsert[T](key: String, data: JsValue, hasValue: Boolean)(implicit ev: Writes[T]) = {
-    val updated = if(hasValue) {
+    val updated = if (hasValue) {
       this.data + (key -> data)
     }
     else {
@@ -63,29 +62,9 @@ case class Cache(id: String, data: Map[String, JsValue], lastUpdated: DateTime =
   }
 }
 
-object Cache extends JodaReads with JodaWrites {
-  import play.api.libs.functional.syntax._
-  import play.api.libs.json.Reads._
-  import play.api.libs.json.OWrites._
-  import play.api.libs.json._
-
-  val datedCacheMapReads: Reads[Cache] =
-    ((JsPath \ "id").read[String] and
-      (JsPath \ "data").read[Map[String, JsValue]] and
-      (JsPath \ "lastUpdated").read[DateTime]) { (id, data, lastUpdated) =>
-      new Cache(id, data, lastUpdated)
-    }
-  val writeBuilder: FunctionalBuilder[OWrites]#CanBuild3[String, Map[String, JsValue], DateTime] =
-    (JsPath \ "id").write[String] and
-      (JsPath \ "data").write[Map[String, JsValue]] and
-      (JsPath \ "lastUpdated").write[DateTime]
-
-  val datedCacheMapWrites: OWrites[Cache] =
-    writeBuilder.apply { datedCacheMap: Cache =>
-      (datedCacheMap.id, datedCacheMap.data, datedCacheMap.lastUpdated)
-    }
-
-  implicit val formats: OFormat[Cache] = OFormat(datedCacheMapReads, datedCacheMapWrites)
+object Cache {
+  implicit val dateFormat = ReactiveMongoFormats.dateTimeFormats
+  implicit val format = Json.format[Cache]
 
   def apply(cacheMap: CacheMap): Cache = Cache(cacheMap.id, cacheMap.data)
 
@@ -96,7 +75,7 @@ object Cache extends JodaReads with JodaWrites {
   * Implements getEncryptedEntry[T], which will decrypt the entry on retrieval
   * This type itself is a type of Cache.
   *
-  * @param cache The cache to wrap.
+  * @param cache  The cache to wrap.
   * @param crypto The cryptography instance to use to decrypt values
   */
 class CryptoCache(cache: Cache, crypto: CompositeSymmetricCrypto) extends Cache(cache.id, cache.data) with CacheOps {
@@ -113,16 +92,20 @@ class MongoCacheClientFactory @Inject()(config: ApplicationConfig, applicationCr
 
 /**
   * Implements a client which utilises the GOV UK cache repository to store cached data in Mongo.
+  *
   * @param appConfig The application configuration
   */
-class MongoCacheClient(appConfig: ApplicationConfig, mongo: () => DefaultDB, applicationCrypto: ApplicationCrypto)
-  extends ReactiveRepository[Cache, BSONObjectID]("app-cache", mongo, Cache.formats)
+class MongoCacheClient(appConfig: ApplicationConfig, db: () => DefaultDB, applicationCrypto: ApplicationCrypto)
+  extends ReactiveRepository[Cache, BSONObjectID]("app-cache", db, Cache.format)
     with Conversions
     with CacheOps {
 
   private val logPrefix = "[MongoCacheClient]"
+
   private def debug(msg: String) = Logger.debug(s"$logPrefix $msg")
+
   private def error(msg: String, e: Throwable) = Logger.error(s"$logPrefix $msg", e)
+
   private def error(msg: String) = Logger.error(s"$logPrefix $msg")
 
   implicit val compositeSymmetricCrypto: CompositeSymmetricCrypto = applicationCrypto.JsonCrypto
@@ -130,8 +113,6 @@ class MongoCacheClient(appConfig: ApplicationConfig, mongo: () => DefaultDB, app
   val cacheExpiryInSeconds: Int = appConfig.cacheExpiryInSeconds
 
   createIndex("lastUpdated", "cacheExpiry", cacheExpiryInSeconds)
-
-  import reactivemongo.play.json.ImplicitBSONHandlers._
 
   /**
     * Inserts data into the cache with the specified key. If the data does not exist, it will be created.
@@ -146,26 +127,26 @@ class MongoCacheClient(appConfig: ApplicationConfig, mongo: () => DefaultDB, app
 
     fetchAll(Some(credId)) flatMap { maybeNewCache =>
 
-        val cache: Cache = maybeNewCache.getOrElse(Cache(credId, Map.empty))
+      val cache: Cache = maybeNewCache.getOrElse(Cache(credId, Map.empty))
 
-        val updatedCache: Cache = cache.copy(
-          id = credId,
-          data = cache.data + (key -> jsonData),
-          lastUpdated = DateTime.now(DateTimeZone.UTC)
-        )
+      val updatedCache: Cache = cache.copy(
+        id = credId,
+        data = cache.data + (key -> jsonData),
+        lastUpdated = DateTime.now(DateTimeZone.UTC)
+      )
 
-        val document = Json.toJson(updatedCache)
-        val modifier = BSONDocument("$set" -> document)
+      val document = Json.toJson(updatedCache)
+      val modifier = BSONDocument("$set" -> document)
 
-        collection.update(bsonIdQuery(credId), modifier, upsert = true) map { _ => updatedCache }
-      }
+      collection.update(bsonIdQuery(credId), modifier, upsert = true) map { _ => updatedCache }
     }
+  }
 
 
   /**
     * Removes the item with the specified key from the cache
     */
-  def removeByKey[T](credId: String,  key: String)(implicit writes: Writes[T]): Future[Cache] = {
+  def removeByKey[T](credId: String, key: String)(implicit writes: Writes[T]): Future[Cache] = {
 
     fetchAll(Some(credId)) flatMap { maybeNewCache =>
       val cache = maybeNewCache.getOrElse(Cache(credId, Map.empty))
@@ -201,7 +182,7 @@ class MongoCacheClient(appConfig: ApplicationConfig, mongo: () => DefaultDB, app
     */
   def find[T](credId: String, key: String)(implicit reads: Reads[T]): Future[Option[T]] =
     fetchAll(credId) map {
-      case Some(cache) => if(appConfig.mongoEncryptionEnabled) {
+      case Some(cache) => if (appConfig.mongoEncryptionEnabled) {
         decryptValue[T](cache, key)(new JsonDecryptor[T](), reads)
       } else {
         getValue[T](cache, key)
@@ -219,7 +200,7 @@ class MongoCacheClient(appConfig: ApplicationConfig, mongo: () => DefaultDB, app
 
   def fetchAll(credId: Option[String]): Future[Option[Cache]] = {
     credId match {
-      case Some(x) =>  collection.find(key(x)).one[Cache] map {
+      case Some(x) => collection.find(key(x)).one[Cache] map {
         case Some(c) if appConfig.mongoEncryptionEnabled => Some(new CryptoCache(c, compositeSymmetricCrypto))
         case c => c
       }
@@ -258,7 +239,8 @@ class MongoCacheClient(appConfig: ApplicationConfig, mongo: () => DefaultDB, app
 
     collection.update(bsonIdQuery(cache.id), BSONDocument("$set" -> Json.toJson(rebuiltCache)), upsert = true) map handleWriteResult
   }
-  def saveAll(cache: Cache, credId :String): Future[Boolean] = {
+
+  def saveAll(cache: Cache, credId: String): Future[Boolean] = {
     // Rebuild the cache and decrypt each key if necessary
     val rebuiltCache = Cache(credId, cache.data.foldLeft(Map.empty[String, JsValue]) { (acc, value) =>
       val plainText = tryDecrypt(Crypted(value._2.toString))
@@ -293,6 +275,7 @@ class MongoCacheClient(appConfig: ApplicationConfig, mongo: () => DefaultDB, app
     * Generates a BSON document query for an id
     */
   private def bsonIdQuery(id: String) = BSONDocument("_id" -> id)
+
   private def key(id: String) = bsonIdQuery(id)
 
   /**
@@ -315,7 +298,7 @@ class MongoCacheClient(appConfig: ApplicationConfig, mongo: () => DefaultDB, app
     case Failure(e) => throw e
   }
 
-  private def decryptOrGetValue[T](cache: Cache, key: String)(implicit reads: Reads[T] ) =
+  private def decryptOrGetValue[T](cache: Cache, key: String)(implicit reads: Reads[T]) =
     if (appConfig.mongoEncryptionEnabled) {
       decryptValue[T](cache, key)(new JsonDecryptor[T](), reads)
     } else {


### PR DESCRIPTION
Reverted changes to mongo cache client made when removing bootstrap and upgrading frontend to play 2.5.19 and later to 2.6

## Related / Dependant PRs?

- none

## How Has This Been Tested?

- manually
- unit tests
- regression

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
