### PR TITLE
Amls 5622 | Fixed aria-described-by in date fieldsets

### DIFF
--- a/app/views/businessdetails/activity_start_date.scala.html
+++ b/app/views/businessdetails/activity_start_date.scala.html
@@ -37,8 +37,7 @@
             p = "startDate",
             heading = "businessdetails.activity.start.date.title",
             section = "summary.businessdetails",
-            example = true,
-            legendHidden = false
+            hintText = "lbl.date.example"
         )
 
         @submit(false)

--- a/app/views/changeofficer/remove_responsible_person.scala.html
+++ b/app/views/changeofficer/remove_responsible_person.scala.html
@@ -47,7 +47,7 @@
               f = f,
               p = "date",
               labelText = "",
-              example = true
+              hintText = "lbl.date.example"
             )
         }
 

--- a/app/views/date_of_change.scala.html
+++ b/app/views/date_of_change.scala.html
@@ -36,7 +36,7 @@
       f = f,
       p = "dateOfChange",
       heading = "dateofchange.title",
-      example = true,
+      hintText = "lbl.date.example",
       section = subheadingMessage
     )
 

--- a/app/views/hvd/cash_payment_first_date.scala.html
+++ b/app/views/hvd/cash_payment_first_date.scala.html
@@ -37,8 +37,7 @@
             p = "paymentDate",
             heading = "hvd.cash.payment.date.title",
             hintText = "hvd.cash.payment.date.example",
-            section = "summary.hvd",
-            example = false
+            section = "summary.hvd"
         )
 
         @submit(edit)

--- a/app/views/include/forms2/date.scala.html
+++ b/app/views/include/forms2/date.scala.html
@@ -22,7 +22,6 @@
     p: String = "",
     labelText: String = "",
     hintText: String = "",
-    example: Boolean = true,
     hintId: String = "",
     jsHidden: Boolean = false,
     legendHidden: Boolean = false,
@@ -40,7 +39,7 @@
     <fieldset
             class="form-field form-date"
             id="@field.id"
-            @if(hintText.nonEmpty || field.hasErrors) { aria-describedby="@if(hintText.nonEmpty) {@{field.id}-hint} @if(field.hasErrors) {@{field.id}-error-notification}"}
+            @if(hintText.nonEmpty || field.hasErrors) { aria-describedby="@if(hintText.nonEmpty) {form-field--hint} @if(field.hasErrors) {@{field.id}-error-notification}"}
     >
         @legend(
             legend = labelText,
@@ -50,9 +49,6 @@
         )
         @if(hintText.nonEmpty) {
             <span class="form-field--hint">@Messages(hintText)</span>
-        }
-        @if(example) {
-            <span class="form-field--hint"@if(hintId.nonEmpty) { id="@hintId-hint"}>@Messages("lbl.date.example")</span>
         }
         @if(field.hasErrors) {
             <span class="error-notification" data-journey="error - field:user input:@field.id" id="@{field.id}-error-notification">

--- a/app/views/include/forms2/date.scala.html
+++ b/app/views/include/forms2/date.scala.html
@@ -39,7 +39,7 @@
     <fieldset
             class="form-field form-date"
             id="@field.id"
-            @if(hintText.nonEmpty || field.hasErrors) { aria-describedby="@if(hintText.nonEmpty) {form-field--hint} @if(field.hasErrors) {@{field.id}-error-notification}"}
+            @if(hintText.nonEmpty || field.hasErrors) { aria-describedby="@if(hintText.nonEmpty) {@{field.id}-hint} @if(field.hasErrors) {@{field.id}-error-notification}"}
     >
         @legend(
             legend = labelText,
@@ -48,7 +48,7 @@
             supportingContent = supportingContent
         )
         @if(hintText.nonEmpty) {
-            <span class="form-field--hint">@Messages(hintText)</span>
+            <span id="@{field.id}-hint" class="form-field--hint">@Messages(hintText)</span>
         }
         @if(field.hasErrors) {
             <span class="error-notification" data-journey="error - field:user input:@field.id" id="@{field.id}-error-notification">
@@ -63,8 +63,7 @@
             attrType = "number",
             attrMinMax = AttrMinMax(attrMin = "1", attrMax = "31"),
             attrPattern = "[0-9]{2}",
-            attrStep = "1",
-            attrDescribedBy = s"${hintId}"
+            attrStep = "1"
         )
         @input(
             labelText = "lbl.month",

--- a/app/views/include/forms2/input.scala.html
+++ b/app/views/include/forms2/input.scala.html
@@ -83,7 +83,7 @@
     }
     <input name="@field.name" class="form-control @if(attrType=="number"){ input--no-spinner} @classes.mkString(" ")"
             value="@field.value" id="@field.id"
-            @if(hintText.nonEmpty || field.hasErrors || attrDescribedBy.nonEmpty) { aria-describedby="@if(hintText.nonEmpty) {@{field.id}-hint} @if(field.hasErrors) {@{field.id}-error-notification}" @if(attrDescribedBy.nonEmpty){@attrDescribedBy-hint}}
+            @if(hintText.nonEmpty || field.hasErrors || attrDescribedBy.nonEmpty) { aria-describedby="@if(hintText.nonEmpty) {@{field.id}-hint} @if(field.hasErrors) {@{field.id}-error-notification} @if(attrDescribedBy.nonEmpty){@{attrDescribedBy}-hint}" }
             @if(attrType.nonEmpty) { type="@attrType" } else { type="text" }
             @if(attrMinMax.attrMin.nonEmpty) { min="@attrMinMax.attrMin" }
             @if(attrMinMax.attrMax.nonEmpty) { max="@attrMinMax.attrMax" }

--- a/app/views/responsiblepeople/address/new_home_date_of_change.scala.html
+++ b/app/views/responsiblepeople/address/new_home_date_of_change.scala.html
@@ -36,7 +36,7 @@
       f = f,
       p = "dateOfChange",
       heading = Messages("responsiblepeople.new.home.date.of.change.heading", personName),
-      example = true,
+      hintText = "lbl.date.example",
       section = "summary.responsiblepeople"
     )
 

--- a/app/views/responsiblepeople/date_of_birth.scala.html
+++ b/app/views/responsiblepeople/date_of_birth.scala.html
@@ -37,7 +37,7 @@
             p = "dateOfBirth",
             heading = Messages("responsiblepeople.date.of.birth.heading", personName),
             section = "summary.responsiblepeople",
-            example = true
+            hintText = "lbl.date.example"
         )
 
         @submit()

--- a/app/views/responsiblepeople/legal_name_change_date.scala.html
+++ b/app/views/responsiblepeople/legal_name_change_date.scala.html
@@ -37,7 +37,7 @@
             p = "date",
             heading = Messages("responsiblepeople.legalnamechangedate.heading", personName),
             section = "summary.responsiblepeople",
-            example = true
+            hintText = "lbl.date.example"
         )
         @submit(edit)
     }

--- a/app/views/responsiblepeople/position_within_business_start_date.scala.html
+++ b/app/views/responsiblepeople/position_within_business_start_date.scala.html
@@ -53,8 +53,7 @@
             heading = Messages("responsiblepeople.position_within_business.startDate.heading", personName),
             section = "summary.responsiblepeople",
             hintText = "responsiblepeople.position_within_business.startDate.hint",
-            supportingContent = supportingContent,
-            example = false
+            supportingContent = supportingContent
         )
 
         @submit()

--- a/app/views/responsiblepeople/remove_responsible_person.scala.html
+++ b/app/views/responsiblepeople/remove_responsible_person.scala.html
@@ -48,7 +48,7 @@
                 heading = Messages("responsiblepeople.remove.named.responsible.person", personName),
                 section = "summary.responsiblepeople",
                 supportingContent = content,
-                example = true
+                hintText = "lbl.date.example"
             )
         } else {
             @content

--- a/app/views/supervision/supervision_end.scala.html
+++ b/app/views/supervision/supervision_end.scala.html
@@ -37,7 +37,7 @@
                 p = "endDate",
                 heading = "supervision.supervision_end.title",
                 section = "summary.supervision",
-                example = true
+                hintText = "lbl.date.example"
             )
 
         @submit(edit)

--- a/app/views/supervision/supervision_start.scala.html
+++ b/app/views/supervision/supervision_start.scala.html
@@ -41,7 +41,7 @@
                 p = "startDate",
                 heading = "supervision.supervision_start.title",
                 section = "summary.supervision",
-                example = true
+                hintText = "lbl.date.example"
             )
 
         @submit(edit)

--- a/app/views/tradingpremises/activity_start_date.scala.html
+++ b/app/views/tradingpremises/activity_start_date.scala.html
@@ -36,7 +36,6 @@
         @date(
             f = f,
             p = "startDate",
-            example = false,
             hintId = "dob",
             hintText = Messages("lbl.date.example"),
             heading = "tradingpremises.startDate.title",

--- a/app/views/tradingpremises/agent_name.scala.html
+++ b/app/views/tradingpremises/agent_name.scala.html
@@ -44,8 +44,7 @@
             f = f,
             p = "agentDateOfBirth",
             labelText = "tradingpremises.agentname.name.dateOfBirth.lbl",
-            hintText = "tradingpremises.agentname.name.dateOfBirth.hint",
-            example = false
+            hintText = "tradingpremises.agentname.name.dateOfBirth.hint"
         )
 
         @submit(edit)

--- a/app/views/tradingpremises/remove_trading_premises.scala.html
+++ b/app/views/tradingpremises/remove_trading_premises.scala.html
@@ -48,7 +48,8 @@
                 p = "endDate",
                 heading = "tradingpremises.remove.trading.premises.enddate.lbl",
                 section = "summary.tradingpremises",
-                supportingContent = content
+                supportingContent = content,
+                hintText = "lbl.date.example"
             )
         } else {
             @content

--- a/release_notes/AMLS-5622.txt
+++ b/release_notes/AMLS-5622.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5622] - 'Added parameter aria-described-by to date template'


### PR DESCRIPTION
This ticket was to add aria-described-by to fieldset list of parameters - but it was already there but used in not right way. So in this PR after discussion with @tempertemper we've decided to get rid of example parameter in date template. It was necessary because both -example- as well as -hintText- parameters were basically doing the same thing.

Now only hintText is being used where necessary to provide hint and there's correct link to aria-described-by.

## Related / Dependant PRs?

- none 

## How Has This Been Tested?

- manually

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
