### PR TITLE
Live bug | Status pages bug fix

### DIFF
--- a/app/views/include/forms2/submitWithPlaceholder.scala.html
+++ b/app/views/include/forms2/submitWithPlaceholder.scala.html
@@ -1,0 +1,30 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(
+ edit: Boolean = false,
+ buttonMessageKey : Option[String] = None,
+ buttonId : Option[String] = None,
+ gaTag : Option[String] = None,
+ placeholder: Option[String] = None
+ )(implicit m: Messages)
+
+<div class="form-group-footer">
+    <button type="submit" name="submit" class="button" @if(gaTag.isDefined) {data-journey-click = "@gaTag"} id="@buttonId.getOrElse("")">
+        @Messages(buttonMessageKey.getOrElse("button.saveandcontinue"))
+        @if(placeholder.isDefined){<span class="visually-hidden"> for @placeholder.get</span>}
+    </button>
+</div>

--- a/app/views/include/status/application_deregistered.scala.html
+++ b/app/views/include/status/application_deregistered.scala.html
@@ -14,11 +14,19 @@
  * limitations under the License.
  *@
 
+@import views.html.include.forms2.form
+@import forms.EmptyForm
+@import views.html.include.forms2.submitWithPlaceholder
+
 @(businessName: Option[String])(implicit request: Request[_], m: Messages, lang: Lang)
 
 <p id="application-deregistered-description-1">@Messages("your.registration.status.deregistered.line1")</p>
 <p id="application-deregistered-description-2">@Messages("your.registration.status.deregistered.line2")</p>
 
-<a href="@controllers.routes.StatusController.newSubmission()" id="new.application.button" data-journey-click = "new-application:click:deregistered" class="button" type="submit">
- @Messages("your.registration.status.new.application.button")
- @if(businessName.isDefined){<span class="visually-hidden"> for @businessName.get</span>}</a>
+@form(EmptyForm, controllers.routes.StatusController.newSubmission()) {
+ @submitWithPlaceholder(
+  buttonMessageKey = Some("your.registration.status.new.application.button"),
+  buttonId = Some("new.application.button"),
+  gaTag = Some("new-application:click:deregistered"),
+  placeholder = businessName)
+}

--- a/app/views/include/status/application_expired.scala.html
+++ b/app/views/include/status/application_expired.scala.html
@@ -14,11 +14,19 @@
  * limitations under the License.
  *@
 
+@import forms.EmptyForm
+@import views.html.include.forms2.form
+@import views.html.include.forms2.submitWithPlaceholder
+
 @(businessName: Option[String])(implicit request: Request[_], m: Messages, lang: Lang)
 
 <p id="application-expired-description-1">@Messages("your.registration.status.expired.line1")</p>
 <p id="application-expired-description-2">@Messages("your.registration.status.expired.line2")</p>
 
-<a href="@controllers.routes.StatusController.newSubmission()" id="new.application.button" data-journey-click = "new-application:click:expired" class="button" type="submit">
- @Messages("your.registration.status.new.application.button")
- @if(businessName.isDefined){<span class="visually-hidden"> for @businessName.get</span>}</a>
+@form(EmptyForm, controllers.routes.StatusController.newSubmission()) {
+ @submitWithPlaceholder(
+   buttonMessageKey = Some("your.registration.status.new.application.button"),
+   buttonId = Some("new.application.button"),
+   gaTag = Some("new-application:click:expired"),
+   placeholder = businessName)
+}

--- a/app/views/include/status/application_rejected.scala.html
+++ b/app/views/include/status/application_rejected.scala.html
@@ -14,11 +14,19 @@
  * limitations under the License.
  *@
 
+@import views.html.include.forms2.form
+@import forms.EmptyForm
+@import views.html.include.forms2.submitWithPlaceholder
+
 @(businessName: Option[String])(implicit request: Request[_], m: Messages, lang: Lang)
 
 <p id="application-rejected-description-1">@Messages("your.registration.status.rejected.line1")</p>
 <p id="application-rejected-description-2">@Messages("your.registration.status.rejected.line2")</p>
 
-<a href="@controllers.routes.StatusController.newSubmission()" id="new.application.button" data-journey-click = "new-application:click:rejected" class="button" type="submit">
- @Messages("your.registration.status.new.application.button")
- @if(businessName.isDefined){<span class="visually-hidden"> for @businessName.get</span>}</a>
+ @form(EmptyForm, controllers.routes.StatusController.newSubmission()) {
+  @submitWithPlaceholder(
+   buttonMessageKey = Some("your.registration.status.new.application.button"),
+   buttonId = Some("new.application.button"),
+   gaTag = Some("new-application:click:rejected"),
+   placeholder = businessName)
+ }

--- a/app/views/include/status/application_revoked.scala.html
+++ b/app/views/include/status/application_revoked.scala.html
@@ -14,11 +14,19 @@
  * limitations under the License.
  *@
 
+@import views.html.include.forms2.form
+@import forms.EmptyForm
+@import views.html.include.forms2.submitWithPlaceholder
+
 @(businessName: Option[String])(implicit request: Request[_], m: Messages, lang: Lang)
 
 <p id="application-revoked-description-1">@Messages("your.registration.status.revoked.line1")</p>
 <p id="application-revoked-description-2">@Messages("your.registration.status.revoked.line2")</p>
 
-<a href="@controllers.routes.StatusController.newSubmission()" id="new.application.button" data-journey-click = "new-application:click:revoked" class="button" type="submit">
- @Messages("your.registration.status.new.application.button")
- @if(businessName.isDefined){<span class="visually-hidden"> for @businessName.get</span>}</a>
+ @form(EmptyForm, controllers.routes.StatusController.newSubmission()) {
+  @submitWithPlaceholder(
+   buttonMessageKey = Some("your.registration.status.new.application.button"),
+   buttonId = Some("new.application.button"),
+   gaTag = Some("new-application:click:revoked"),
+   placeholder = businessName)
+ }

--- a/app/views/include/status/application_withdrawn.scala.html
+++ b/app/views/include/status/application_withdrawn.scala.html
@@ -14,11 +14,19 @@
  * limitations under the License.
  *@
 
+@import views.html.include.forms2.form
+@import views.html.include.forms2.submitWithPlaceholder
+@import forms.EmptyForm
+
 @(businessName: Option[String])(implicit request: Request[_], m: Messages, lang: Lang)
 
 <p id="application-withdrawn-description-1">@Messages("your.registration.status.withdrawn.line1")</p>
 <p id="application-withdrawn-description-2">@Messages("your.registration.status.withdrawn.line2")</p>
 
-<a href="@controllers.routes.StatusController.newSubmission()" id="new.application.button" data-journey-click = "new-application:click:withdrawn" class="button" type="submit">
- @Messages("your.registration.status.new.application.button")
- @if(businessName.isDefined){<span class="visually-hidden"> for @businessName.get</span>}</a>
+ @form(EmptyForm, controllers.routes.StatusController.newSubmission()) {
+  @submitWithPlaceholder(
+   buttonMessageKey = Some("your.registration.status.new.application.button"),
+   buttonId = Some("new.application.button"),
+   gaTag = Some("new-application:click:withdrawn"),
+   placeholder = businessName)
+ }

--- a/release_notes/BUG-FIX.txt
+++ b/release_notes/BUG-FIX.txt
@@ -1,0 +1,1 @@
+ + [BUG-FIX] - 'Start a new application button not working'

--- a/test/views/status/your_registrationSpec.scala
+++ b/test/views/status/your_registrationSpec.scala
@@ -108,9 +108,9 @@ class your_registrationSpec extends AmlsViewSpec with MustMatchers with AmlsRefe
 
       doc.getElementById("application-withdrawn-description-1").text() must be("You have withdrawn your application to register with HMRC.")
       doc.getElementById("application-withdrawn-description-2").text() must be("Your business is not registered with HMRC under the Money Laundering Regulations.")
-      doc.getElementById("new.application.button").attr("href") must be(controllers.routes.StatusController.newSubmission().url)
       Option(doc.getElementById("update-information")) must be(None)
       doc.getElementById("registration-status").html() must include("Not supervised. Application withdrawn.")
+      doc.getElementById("new.application.button").html() must include("Start a new application")
     }
 
     "contain correct content for status SubmissionDecisionRejected" in new ViewFixture {
@@ -124,9 +124,9 @@ class your_registrationSpec extends AmlsViewSpec with MustMatchers with AmlsRefe
 
       doc.getElementById("application-rejected-description-1").text() must be("Your application to register with HMRC has been rejected.")
       doc.getElementById("application-rejected-description-2").text() must be("Your business is not registered with HMRC. Your business must not carry out activities that are covered by the Money Laundering Regulations.")
-      doc.getElementById("new.application.button").attr("href") must be(controllers.routes.StatusController.newSubmission().url)
       Option(doc.getElementById("update-information")) must be(None)
       doc.getElementById("registration-status").html() must include("Not supervised. Application rejected.")
+      doc.getElementById("new.application.button").html() must include("Start a new application")
     }
 
     "contain correct content for status SubmissionDecisionRevoked" in new ViewFixture {
@@ -140,9 +140,9 @@ class your_registrationSpec extends AmlsViewSpec with MustMatchers with AmlsRefe
 
       doc.getElementById("application-revoked-description-1").text() must be("Your registration has been revoked.")
       doc.getElementById("application-revoked-description-2").text() must be("Your business is not registered with HMRC. Your business must not carry out activities that are covered by the Money Laundering Regulations.")
-      doc.getElementById("new.application.button").attr("href") must be(controllers.routes.StatusController.newSubmission().url)
       Option(doc.getElementById("update-information")) must be(None)
       doc.getElementById("registration-status").html() must include("Not supervised. Registration revoked.")
+      doc.getElementById("new.application.button").html() must include("Start a new application")
     }
 
     "contain correct content for status SubmissionDecisionExpired" in new ViewFixture {
@@ -156,9 +156,9 @@ class your_registrationSpec extends AmlsViewSpec with MustMatchers with AmlsRefe
 
       doc.getElementById("application-expired-description-1").text() must be("Your registration has expired.")
       doc.getElementById("application-expired-description-2").text() must be("Your business is not registered with HMRC under the Money Laundering Regulations.")
-      doc.getElementById("new.application.button").attr("href") must be(controllers.routes.StatusController.newSubmission().url)
       Option(doc.getElementById("update-information")) must be(None)
       doc.getElementById("registration-status").html() must include("Not supervised. Registration expired.")
+      doc.getElementById("new.application.button").html() must include("Start a new application")
     }
 
     "contain correct content for status DeRegistered" in new ViewFixture {
@@ -173,9 +173,9 @@ class your_registrationSpec extends AmlsViewSpec with MustMatchers with AmlsRefe
 
       doc.getElementById("application-deregistered-description-1").text() must be("You have deregistered your business.")
       doc.getElementById("application-deregistered-description-2").text() must be("Your business is not registered with HMRC under the Money Laundering Regulations.")
-      doc.getElementById("new.application.button").attr("href") must be(controllers.routes.StatusController.newSubmission().url)
       Option(doc.getElementById("update-information")) must be(None)
       doc.getElementById("registration-status").html() must include("Not supervised. Deregistered on " + DateHelper.formatDate(deregistrationDate.value) + ".")
+      doc.getElementById("new.application.button").html() must include("Start a new application")
     }
 
     "contain registration information for status SubmissionReady" in new ViewFixture {


### PR DESCRIPTION
Start a new application button was not working on status pages: revoked, deregistered, withdrawn, rejected, expired. This can be tested only in QA.

## Related / Dependant PRs?

- none

## How Has This Been Tested?

- manually

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
