### PR TITLE
Amls 5796 - Cache validation and refresh from API5 if no cache when hitting status controller

### DIFF
--- a/app/services/RenewalService.scala
+++ b/app/services/RenewalService.scala
@@ -84,6 +84,18 @@ class RenewalService @Inject()(dataCache: DataCacheConnector) {
     isComplete.getOrElse(false)
   }
 
+  def isCachePresent(credId: String)(implicit headerCarrier: HeaderCarrier, ec: ExecutionContext) = {
+
+    val isCache = for {
+      cache <- dataCache.fetchAll(credId)
+    } yield cache match {
+      case Some(c) => true
+      case _ => false
+    }
+
+    isCache
+  }
+
   private def checkCompletionOfMsb(renewal: Renewal, msbServices: Option[BusinessMatchingMsbServices]) = {
 
     val validationRule = compileOpt {

--- a/release_notes/AMLS-5796.txt
+++ b/release_notes/AMLS-5796.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5796] - 'Cache validation and refresh from API5 if no cache when hitting status controller'

--- a/test/controllers/StatusControllerSpec.scala
+++ b/test/controllers/StatusControllerSpec.scala
@@ -221,6 +221,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
       when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
         .thenReturn(Future.successful((NotCompleted, Some(statusResponse))))
 
+      when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
+
       val result = controller.get()(request)
       status(result) must be(OK)
 
@@ -260,6 +262,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
 
           when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
             .thenReturn(Future.successful((SubmissionReadyForReview, None)))
+
+          when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
 
           val result = controller.get()(request)
           status(result) must be(OK)
@@ -301,6 +305,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
           .thenReturn(Future.successful((SubmissionDecisionApproved, Some(readStatusResponse))))
 
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
+
         val result = controller.get()(request)
         status(result) must be(OK)
 
@@ -321,6 +327,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
 
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
           .thenReturn(Future.successful((SubmissionDecisionRejected, None)))
+
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
 
         val result = controller.get()(request)
         status(result) must be(OK)
@@ -344,6 +352,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
 
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
           .thenReturn(Future.successful((SubmissionDecisionRevoked, None)))
+
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
 
         val result = controller.get()(request)
         status(result) must be(OK)
@@ -369,6 +379,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
           .thenReturn(Future.successful((SubmissionDecisionExpired, None)))
 
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
+
         val result = controller.get()(request)
         status(result) must be(OK)
 
@@ -388,6 +400,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
 
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
           .thenReturn(Future.successful((SubmissionWithdrawn, None)))
+
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
 
         val result = controller.get()(request)
         status(result) must be(OK)
@@ -409,6 +423,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
           .thenReturn(Future.successful((DeRegistered, None)))
 
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
+
         val result = controller.get()(request)
         status(result) must be(OK)
 
@@ -429,6 +445,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
           .thenReturn(Future.successful((RenewalSubmitted(Some(LocalDate.now)), None)))
 
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
+
         val result = controller.get()(request)
         status(result) must be(OK)
 
@@ -446,6 +464,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
 
         when(cacheMap.getEntry[SubscriptionResponse](Matchers.contains(SubscriptionResponse.key))(any()))
           .thenReturn(Some(SubscriptionResponse("", "", Some(SubscriptionFees("", 0, None, None, None, None, 0, None, 0)))))
+
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
 
         val renewalDate = LocalDate.now().plusDays(15)
 
@@ -478,6 +498,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
 
         when(controller.renewalService.isRenewalComplete(any(), any[String]())(any(), any()))
           .thenReturn(Future.successful(false))
+
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
 
         val renewalDate = LocalDate.now().plusDays(15)
 
@@ -530,6 +552,8 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
 
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
           .thenReturn(Future.successful((ReadyForRenewal(Some(renewalDate)), Some(readStatusResponse))))
+
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
 
         private val completeRenewal = Renewal(
           Some(InvolvedInOtherYes("test")),
@@ -602,8 +626,39 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with PrivateMe
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
           .thenReturn(Future.successful(SubmissionDecisionApproved, statusResponse.some))
 
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
+
         val result = controller.get()(request)
         val doc = Jsoup.parse(contentAsString(result))
+
+        doc.select(s"a[href=${controllers.deregister.routes.DeRegisterApplicationController.get().url}]").text mustBe Messages("your.registration.deregister.link")
+      }
+
+      "the status is 'approved' and there is no current mongo cache" in new Fixture {
+        val reviewDetails = ReviewDetails("BusinessName", Some(BusinessType.LimitedCompany),
+          Address("line1", "line2", Some("line3"), Some("line4"), Some("AA1 1AA"), Country("United Kingdom", "GB")), "XE0001234567890")
+
+        val statusResponse = mock[ReadStatusResponse]
+        when(statusResponse.currentRegYearEndDate).thenReturn(LocalDate.now.some)
+        when(statusResponse.safeId).thenReturn(None)
+
+        when(controller.dataCache.fetch[BusinessMatching](any(), any())(any(), any()))
+          .thenReturn(Future.successful(Some(BusinessMatching(Some(reviewDetails), Some(BusinessActivities(Set(TelephonePaymentService)))))))
+
+        when(controller.landingService.cacheMap(any[String])(any(), any()))
+          .thenReturn(Future.successful(Some(cacheMap)))
+
+        when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any()))
+          .thenReturn(Future.successful(SubmissionDecisionApproved, statusResponse.some))
+
+        when(controller.landingService.refreshCache(any(), any(), any())(any(), any())).thenReturn(Future.successful(cacheMap))
+
+        when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(false))
+
+        val result = controller.get()(request)
+        val doc = Jsoup.parse(contentAsString(result))
+
+        verify(controller.landingService).refreshCache(any(), any(), any())(any(), any())
 
         doc.select(s"a[href=${controllers.deregister.routes.DeRegisterApplicationController.get().url}]").text mustBe Messages("your.registration.deregister.link")
       }


### PR DESCRIPTION
We've identified what's causing a number of errors we didn't understand why were happening.

The errors;
```
Cannot get business matching or renewal date
Unable to redirect from Turnover page
Unable to retrieve SafeID from reviewDetails
Could not match activities against given options
```

I believe are being caused by the same problem.

When investigating in local dev I found that you could bypass the landing controller (bit that checks if the cache should be reloaded from API5) by bookmarking the application status page and going to that bookmark while already signed in to GG in an active session.

If I login in one window; then close the window and drop the cache (replicate the 30 day expiry); then hit my application status book mark the service does not reload the cache. The page renders from API9 as expected and prompts the user to start their renewal. The user starts the renewal by answering the first question. This then creates a cache for the user however; it has only the renewal section and no other sections. The system then throws the 'unable to redirect from turnover page' and the user drops back to the application status page. If the user attempts to go to the about your business page then they get the 'Unable to retrieve SafeID from reviewDetails' error and the 'Could not match activities against given options' error.

I discussed this scenario with Mike Pratt who then proved the theory in the QA environment. In addition to proving this in QA Mike Pratt was able to trace a few of the live user journeys through Splunk and was able to verify this scenario to be the case in production.

Fix: The fix is to modify the GET method in the application status page to first fetch the cache. If the cache is present then carry on as normal. If the cache is not present then reload from API5 before proceeding. This means the user should always have the data required to proceed.

## Related / Dependant PRs?

N/A

## How Has This Been Tested?

Unit + Local

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
