### PR TITLE
Revert "Amls 5839 - Reordered error message UK bank account"

### DIFF
--- a/app/models/bankdetails/BankAccountSubsteps.scala
+++ b/app/models/bankdetails/BankAccountSubsteps.scala
@@ -113,9 +113,8 @@ object Account {
     From[UrlFormEncoded] { __ =>
       import jto.validation.forms.Rules._
       (
-        (__ \ "sortCode").read(sortCodeType) ~
-        (__ \ "accountNumber").read(ukBankAccountNumberType)
-
+        (__ \ "accountNumber").read(ukBankAccountNumberType) ~
+        (__ \ "sortCode").read(sortCodeType)
       ) (UKAccount.apply)
   }
 

--- a/release_notes/AMLS-5839.txt
+++ b/release_notes/AMLS-5839.txt
@@ -1,1 +1,0 @@
- + [AMLS-5839] - 'Reordered bank account error messages'

--- a/test/models/bankdetails/AccountSpec.scala
+++ b/test/models/bankdetails/AccountSpec.scala
@@ -145,7 +145,7 @@ class AccountSpec extends PlaySpec with MockitoSugar {
         "sortCode" -> Seq("000000")
       )
 
-      Account.ukFormRead.validate(urlFormEncoded) must be(Valid(UKAccount("000000", "12345678")))
+      Account.ukFormRead.validate(urlFormEncoded) must be(Valid(UKAccount("12345678", "000000")))
     }
 
     "displaySortCode" must {
@@ -300,7 +300,7 @@ class AccountSpec extends PlaySpec with MockitoSugar {
         "sortCode" -> Seq("000000")
       )
 
-      Account.ukFormRead.validate(urlFormEncoded) must be(Valid(UKAccount("000000", "12345678")))
+      Account.ukFormRead.validate(urlFormEncoded) must be(Valid(UKAccount("12345678", "000000")))
     }
 
     "Form Write validation for UKAccount" in {


### PR DESCRIPTION
Reverts hmrc/amls-frontend#1399

Potentially writing sort code and account number into the incorrect fields in mongo. 