### PR TITLE
AMLS-5906 | Bug fix for aria described by whitespace

### DIFF
--- a/app/views/include/forms2/date.scala.html
+++ b/app/views/include/forms2/date.scala.html
@@ -39,7 +39,9 @@
     <fieldset
             class="form-field form-date"
             id="@field.id"
-            @if(hintText.nonEmpty || field.hasErrors) { aria-describedby="@if(hintText.nonEmpty){@{field.id}-hint}@if(field.hasErrors){@{field.id}-error-notification}"}
+            @if(hintText.nonEmpty && field.hasErrors) {aria-describedby="@if(hintText.nonEmpty){@{field.id}-hint }@if(field.hasErrors){@{field.id}-error-notification}"}
+            @if(hintText.nonEmpty && !field.hasErrors) {aria-describedby="@if(hintText.nonEmpty){@{field.id}-hint}"}
+            @if(hintText.isEmpty && field.hasErrors) {aria-describedby="@if(field.hasErrors){@{field.id}-error-notification}"}
     >
         @legend(
             legend = labelText,

--- a/release_notes/AMLS-5096.txt
+++ b/release_notes/AMLS-5096.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5096] - 'Bug fix for aria described by whitespace'

--- a/test/views/include/dateSpec.scala
+++ b/test/views/include/dateSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.include
+
+import forms.{Form2, InvalidForm, ValidForm}
+import jto.validation.{Path, ValidationError}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import org.scalatestplus.play.PlaySpec
+import utils.AmlsViewSpec
+import views.html.include.heading
+import play.api.test.Helpers._
+
+class dateSpec extends PlaySpec with AmlsViewSpec {
+
+  trait Fixture {
+  }
+
+  "The Html output" must {
+    "render the ariaDescribedBy with error and hint" in new Fixture {
+      val errors: Seq[(Path, Seq[ValidationError])] = Seq((Path \ "date", Seq(ValidationError("some.error", ""))))
+      val formx = InvalidForm(Map("" -> Seq("")), errors)
+      val date = views.html.include.forms2.date(formx, p="date", hintText = "jhgjhgjgkjkjk")
+
+      val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
+      aria must not be "date-hintdate-error-notification"
+
+    }
+  }
+}

--- a/test/views/include/dateSpec.scala
+++ b/test/views/include/dateSpec.scala
@@ -35,7 +35,7 @@ class dateSpec extends PlaySpec with AmlsViewSpec {
     "render the ariaDescribedBy with error and hint" in new Fixture {
       val errors: Seq[(Path, Seq[ValidationError])] = Seq((Path \ "date", Seq(ValidationError("some.error", ""))))
       val formx = InvalidForm(Map("" -> Seq("")), errors)
-      val date = views.html.include.forms2.date(formx, p = "date", hintText = "jhgjhgjgkjkjk")
+      val date = views.html.include.forms2.date(formx, p = "date", hintText = "select all")
 
       val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
       aria must be("date-hint date-error-notification")
@@ -52,7 +52,7 @@ class dateSpec extends PlaySpec with AmlsViewSpec {
     }
     "render the ariaDescribedBy with hint" in new Fixture {
       val formx = ValidForm(Map("" -> Seq("")), EmptyForm)
-      val date = views.html.include.forms2.date(formx, p = "date", hintText = "jhgjhgjgkjkjk")
+      val date = views.html.include.forms2.date(formx, p = "date", hintText = "select all")
 
       val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
       aria must be("date-hint")

--- a/test/views/include/dateSpec.scala
+++ b/test/views/include/dateSpec.scala
@@ -28,35 +28,26 @@ import play.api.test.Helpers._
 
 class dateSpec extends PlaySpec with AmlsViewSpec {
 
-  trait Fixture {
-  }
-
   "The Html output" must {
-    "render the ariaDescribedBy with error and hint" in new Fixture {
+    "render the ariaDescribedBy with error and hint" in {
       val errors: Seq[(Path, Seq[ValidationError])] = Seq((Path \ "date", Seq(ValidationError("some.error", ""))))
       val invalidForm = InvalidForm(Map("" -> Seq("")), errors)
       val date = views.html.include.forms2.date(invalidForm, p = "date", hintText = "select all")
-
       val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
       aria must be("date-hint date-error-notification")
-
     }
-    "render the ariaDescribedBy with error" in new Fixture {
+    "render the ariaDescribedBy with error" in {
       val errors: Seq[(Path, Seq[ValidationError])] = Seq((Path \ "date", Seq(ValidationError("some.error", ""))))
       val invalidForm = InvalidForm(Map("" -> Seq("")), errors)
       val date = views.html.include.forms2.date(invalidForm, p = "date")
-
       val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
       aria must be("date-error-notification")
-
     }
-    "render the ariaDescribedBy with hint" in new Fixture {
+    "render the ariaDescribedBy with hint" in {
       val validForm = ValidForm(Map("" -> Seq("")), EmptyForm)
       val date = views.html.include.forms2.date(validForm, p = "date", hintText = "select all")
-
       val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
       aria must be("date-hint")
-
     }
   }
 }

--- a/test/views/include/dateSpec.scala
+++ b/test/views/include/dateSpec.scala
@@ -34,8 +34,8 @@ class dateSpec extends PlaySpec with AmlsViewSpec {
   "The Html output" must {
     "render the ariaDescribedBy with error and hint" in new Fixture {
       val errors: Seq[(Path, Seq[ValidationError])] = Seq((Path \ "date", Seq(ValidationError("some.error", ""))))
-      val formx = InvalidForm(Map("" -> Seq("")), errors)
-      val date = views.html.include.forms2.date(formx, p = "date", hintText = "select all")
+      val invalidForm = InvalidForm(Map("" -> Seq("")), errors)
+      val date = views.html.include.forms2.date(invalidForm, p = "date", hintText = "select all")
 
       val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
       aria must be("date-hint date-error-notification")
@@ -43,16 +43,16 @@ class dateSpec extends PlaySpec with AmlsViewSpec {
     }
     "render the ariaDescribedBy with error" in new Fixture {
       val errors: Seq[(Path, Seq[ValidationError])] = Seq((Path \ "date", Seq(ValidationError("some.error", ""))))
-      val formx = InvalidForm(Map("" -> Seq("")), errors)
-      val date = views.html.include.forms2.date(formx, p = "date")
+      val invalidForm = InvalidForm(Map("" -> Seq("")), errors)
+      val date = views.html.include.forms2.date(invalidForm, p = "date")
 
       val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
       aria must be("date-error-notification")
 
     }
     "render the ariaDescribedBy with hint" in new Fixture {
-      val formx = ValidForm(Map("" -> Seq("")), EmptyForm)
-      val date = views.html.include.forms2.date(formx, p = "date", hintText = "select all")
+      val validForm = ValidForm(Map("" -> Seq("")), EmptyForm)
+      val date = views.html.include.forms2.date(validForm, p = "date", hintText = "select all")
 
       val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
       aria must be("date-hint")

--- a/test/views/include/dateSpec.scala
+++ b/test/views/include/dateSpec.scala
@@ -38,7 +38,7 @@ class dateSpec extends PlaySpec with AmlsViewSpec {
       val date = views.html.include.forms2.date(formx, p = "date", hintText = "jhgjhgjgkjkjk")
 
       val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
-      aria must not be "date-hintdate-error-notification"
+      aria must be("date-hint date-error-notification")
 
     }
     "render the ariaDescribedBy with error" in new Fixture {

--- a/test/views/include/dateSpec.scala
+++ b/test/views/include/dateSpec.scala
@@ -16,7 +16,7 @@
 
 package views.include
 
-import forms.{Form2, InvalidForm, ValidForm}
+import forms.{EmptyForm, Form2, InvalidForm, ValidForm}
 import jto.validation.{Path, ValidationError}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -35,10 +35,27 @@ class dateSpec extends PlaySpec with AmlsViewSpec {
     "render the ariaDescribedBy with error and hint" in new Fixture {
       val errors: Seq[(Path, Seq[ValidationError])] = Seq((Path \ "date", Seq(ValidationError("some.error", ""))))
       val formx = InvalidForm(Map("" -> Seq("")), errors)
-      val date = views.html.include.forms2.date(formx, p="date", hintText = "jhgjhgjgkjkjk")
+      val date = views.html.include.forms2.date(formx, p = "date", hintText = "jhgjhgjgkjkjk")
 
       val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
       aria must not be "date-hintdate-error-notification"
+
+    }
+    "render the ariaDescribedBy with error" in new Fixture {
+      val errors: Seq[(Path, Seq[ValidationError])] = Seq((Path \ "date", Seq(ValidationError("some.error", ""))))
+      val formx = InvalidForm(Map("" -> Seq("")), errors)
+      val date = views.html.include.forms2.date(formx, p = "date")
+
+      val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
+      aria must be("date-error-notification")
+
+    }
+    "render the ariaDescribedBy with hint" in new Fixture {
+      val formx = ValidForm(Map("" -> Seq("")), EmptyForm)
+      val date = views.html.include.forms2.date(formx, p = "date", hintText = "jhgjhgjgkjkjk")
+
+      val aria = Jsoup.parse(contentAsString(date)).getElementsByTag("fieldset").attr("aria-describedby")
+      aria must be("date-hint")
 
     }
   }


### PR DESCRIPTION
This is a fix to add whitespace to the aria-described-by field on date pages when there is an error and hint text,

## Related / Dependant PRs?

<!--- List any related issues here -->

## How Has This Been Tested?
Manually
Unit
<!--- Please describe how you tested your changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
