### PR TITLE
Amls 5894 | Fix for empty countries lists in renewal

### DIFF
--- a/app/models/renewal/Conversions.scala
+++ b/app/models/renewal/Conversions.scala
@@ -42,6 +42,7 @@ object Conversions {
           throughput = renewal.totalThroughput contramap TotalThroughput.convert,
           transactionsInNext12Months = renewal.transactionsInLast12Months contramap TransactionsInLast12Months.convert,
           sendTheLargestAmountsOfMoney = renewal.sendTheLargestAmountsOfMoney contramap SendTheLargestAmountsOfMoney.convert,
+          sendMoneyToOtherCountry = renewal.sendMoneyToOtherCountry contramap SendMoneyToOtherCountry.convert,
           mostTransactions = renewal.mostTransactions contramap MostTransactions.convert,
           ceTransactionsInNext12Months = renewal.ceTransactionsInLast12Months contramap CETransactionsInLast12Months.convert,
           whichCurrencies = renewal.whichCurrencies contramap WhichCurrencies.convert,

--- a/app/models/renewal/SendMoneyToOtherCountry.scala
+++ b/app/models/renewal/SendMoneyToOtherCountry.scala
@@ -36,6 +36,13 @@ object SendMoneyToOtherCountry {
   implicit val formWrites: Write[SendMoneyToOtherCountry, UrlFormEncoded] = Write {x =>
     "money" -> x.money.toString
   }
+
+  def convert(model: SendMoneyToOtherCountry): models.moneyservicebusiness.SendMoneyToOtherCountry = {
+    model match {
+      case SendMoneyToOtherCountry(true) => models.moneyservicebusiness.SendMoneyToOtherCountry(true)
+      case _ => models.moneyservicebusiness.SendMoneyToOtherCountry(false)
+    }
+  }
 }
 
 

--- a/release_notes/AMLS-5894.txt
+++ b/release_notes/AMLS-5894.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5894] - | 'Bug fix for empty countries list'

--- a/test/models/renewal/ConversionsSpec.scala
+++ b/test/models/renewal/ConversionsSpec.scala
@@ -97,6 +97,14 @@ class ConversionsSpec extends WordSpec with MustMatchers {
           Country("United Kingdom", "GB"), Country("France", "FR"), Country("us", "US"))))
     }
 
+    "convert the 'MSB send money to other country' model" in new Fixture {
+      val model = SendMoneyToOtherCountry(true)
+      val renewal = Renewal(sendMoneyToOtherCountry = Some(model))
+      val converted = subscriptionRequest.withRenewalData((renewal))
+
+      converted.msbSection.get.sendMoneyToOtherCountry mustBe Some(models.moneyservicebusiness.SendMoneyToOtherCountry(true))
+    }
+
     "convert the 'MSB most transactions' model" in new Fixture {
       val model = MostTransactions(Seq(Country("United Kingdom", "GB")))
       val renewal = Renewal(mostTransactions = Some(model))

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -303,7 +303,9 @@ class SubmissionServiceSpec extends AmlsSpec
         ceTransactionsInLast12Months = Some(CETransactionsInLast12Months("12345678963")),
         transactionsInLast12Months = Some(TransactionsInLast12Months("2500")),
         percentageOfCashPaymentOver15000 = Some(PercentageOfCashPaymentOver15000.First),
-        receiveCashPayments = Some(CashPayments(CashPaymentsCustomerNotMet(true), Some(HowCashPaymentsReceived(PaymentMethods(true,true,Some("other"))))))
+        receiveCashPayments = Some(CashPayments(CashPaymentsCustomerNotMet(true), Some(HowCashPaymentsReceived(PaymentMethods(true,true,Some("other")))))),
+        sendMoneyToOtherCountry = Some(SendMoneyToOtherCountry(true)),
+        fxTransactionsInLast12Months = Some(FXTransactionsInLast12Months("10"))
       )
 
       val result = await(submissionService.renewal("12345678", Some(amlsRegistrationNumber), ("accType", "id"), renewal))
@@ -322,8 +324,10 @@ class SubmissionServiceSpec extends AmlsSpec
 
       submission.msbSection mustBe defined
       submission.msbSection.get.throughput mustBe defined
+      submission.msbSection.get.sendMoneyToOtherCountry mustBe defined
       submission.msbSection.get.mostTransactions mustBe defined
       submission.msbSection.get.sendTheLargestAmountsOfMoney mustBe defined
+      submission.msbSection.get.fxTransactionsInNext12Months mustBe defined
       submission.msbSection.get.whichCurrencies mustBe defined
       submission.msbSection.get.ceTransactionsInNext12Months mustBe defined
       submission.msbSection.get.transactionsInNext12Months mustBe defined


### PR DESCRIPTION
This will fix the problem with empty lists being send while renewing the application.

Initial thoughts were that we are creating empty lists in frontend, but after small investigation I've found that we are missing one question when converting renewal data to subscription request. This was the problem. Because of that the AMLS while creating the request was using not updated data for this question and was creating empty lists in result.

## Related / Dependant PRs?

- none

## How Has This Been Tested?

- manually
- regression
- unit tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
