### PR TITLE
Amls 5759 | Update H1 on Confirm the postcode page in pre-application and improve routing

### DIFF
--- a/app/controllers/LandingController.scala
+++ b/app/controllers/LandingController.scala
@@ -205,11 +205,18 @@ class LandingController @Inject()(val landingService: LandingService,
             landingService.updateReviewDetails(rd, credId) map { _ => {
               auditConnector.sendExtendedEvent(ServiceEntrantEvent(rd.businessName, rd.utr.getOrElse(""), rd.safeId))
 
-              FormTypes.postcodeType.validate(rd.businessAddress.postcode.getOrElse("")) match {
-                case Valid(_) => Redirect(controllers.businessmatching.routes.BusinessTypeController.get())
-                case Invalid(_) => Redirect(controllers.businessmatching.routes.ConfirmPostCodeController.get())
+              (rd.businessAddress.postcode, rd.businessAddress.country) match {
+                  case (Some(postcode), Country("United Kingdom", "GB")) => {
+                    FormTypes.postcodeType.validate(postcode) match {
+                      case Valid(_) => Redirect(controllers.businessmatching.routes.BusinessTypeController.get())
+                      case Invalid(_) => Redirect(controllers.businessmatching.routes.ConfirmPostCodeController.get())
+                    }
+                  }
+                  case (_, Country("United Kingdom", "GB")) => Redirect(controllers.businessmatching.routes.ConfirmPostCodeController.get())
+                  case (_, country) if !country.isUK && !country.isEmpty => Redirect(controllers.businessmatching.routes.BusinessTypeController.get())
+                  case (_, _) => Redirect(controllers.businessmatching.routes.ConfirmPostCodeController.get())
+                }
               }
-            }
             }
           case (None, None) =>
             // $COVERAGE-OFF$

--- a/app/controllers/businessdetails/ConfirmRegisteredOfficeController.scala
+++ b/app/controllers/businessdetails/ConfirmRegisteredOfficeController.scala
@@ -23,7 +23,7 @@ import connectors.DataCacheConnector
 import controllers.{AmlsBaseController, CommonPlayDependencies}
 import forms.{EmptyForm, Form2, InvalidForm, ValidForm}
 import models.businesscustomer.Address
-import models.businessdetails.{BusinessDetails, ConfirmRegisteredOffice, RegisteredOffice, RegisteredOfficeUK}
+import models.businessdetails._
 import models.businessmatching.BusinessMatching
 import play.api.mvc.MessagesControllerComponents
 import utils.AuthAction
@@ -37,15 +37,26 @@ class ConfirmRegisteredOfficeController @Inject () (val dataCache: DataCacheConn
                                                     val ds: CommonPlayDependencies,
                                                     val cc: MessagesControllerComponents) extends AmlsBaseController(ds, cc) {
 
-
   def updateBMAddress(bm: BusinessMatching): Option[RegisteredOffice] = {
-    bm.reviewDetails.fold[Option[RegisteredOffice]](None)(dtls => Some(RegisteredOfficeUK(
-      dtls.businessAddress.line_1,
-      dtls.businessAddress.line_2,
-      dtls.businessAddress.line_3,
-      dtls.businessAddress.line_4,
-      dtls.businessAddress.postcode.getOrElse("")
-    )))
+    bm.reviewDetails.fold[Option[RegisteredOffice]](None)(dtls =>
+      if(dtls.businessAddress.postcode.isDefined) {
+        Some(RegisteredOfficeUK(
+          dtls.businessAddress.line_1,
+          dtls.businessAddress.line_2,
+          dtls.businessAddress.line_3,
+          dtls.businessAddress.line_4,
+          dtls.businessAddress.postcode.getOrElse("")
+        ))
+      } else {
+        Some(RegisteredOfficeNonUK(
+          dtls.businessAddress.line_1,
+          dtls.businessAddress.line_2,
+          dtls.businessAddress.line_3,
+          dtls.businessAddress.line_4,
+          dtls.businessAddress.country
+        ))
+      }
+    )
   }
 
   def getAddress(businessMatching: Future[Option[BusinessMatching]]): Future[Option[Address]] = {

--- a/app/controllers/businessdetails/ConfirmRegisteredOfficeController.scala
+++ b/app/controllers/businessdetails/ConfirmRegisteredOfficeController.scala
@@ -38,22 +38,22 @@ class ConfirmRegisteredOfficeController @Inject () (val dataCache: DataCacheConn
                                                     val cc: MessagesControllerComponents) extends AmlsBaseController(ds, cc) {
 
   def updateBMAddress(bm: BusinessMatching): Option[RegisteredOffice] = {
-    bm.reviewDetails.fold[Option[RegisteredOffice]](None)(dtls =>
-      if(dtls.businessAddress.postcode.isDefined) {
+    bm.reviewDetails.fold[Option[RegisteredOffice]](None)(rd =>
+      if(rd.businessAddress.postcode.isDefined) {
         Some(RegisteredOfficeUK(
-          dtls.businessAddress.line_1,
-          dtls.businessAddress.line_2,
-          dtls.businessAddress.line_3,
-          dtls.businessAddress.line_4,
-          dtls.businessAddress.postcode.getOrElse("")
+          rd.businessAddress.line_1,
+          rd.businessAddress.line_2,
+          rd.businessAddress.line_3,
+          rd.businessAddress.line_4,
+          rd.businessAddress.postcode.getOrElse("")
         ))
       } else {
         Some(RegisteredOfficeNonUK(
-          dtls.businessAddress.line_1,
-          dtls.businessAddress.line_2,
-          dtls.businessAddress.line_3,
-          dtls.businessAddress.line_4,
-          dtls.businessAddress.country
+          rd.businessAddress.line_1,
+          rd.businessAddress.line_2,
+          rd.businessAddress.line_3,
+          rd.businessAddress.line_4,
+          rd.businessAddress.country
         ))
       }
     )
@@ -105,7 +105,7 @@ class ConfirmRegisteredOfficeController @Inject () (val dataCache: DataCacheConn
             }
 
             dataCache.save[BusinessDetails](request.credId, BusinessDetails.key, businessDetails.copy(registeredOffice = address)) map { _ =>
-              if (data.isRegOfficeOrMainPlaceOfBusiness) {
+              if (data.isRegOfficeOrMainPlaceOfBusiness && address.isDefined) {
                 Redirect(routes.ContactingYouController.get(edit))
               } else {
                 Redirect(routes.RegisteredOfficeIsUKController.get(edit))

--- a/app/controllers/businessmatching/ConfirmPostCodeController.scala
+++ b/app/controllers/businessmatching/ConfirmPostCodeController.scala
@@ -20,10 +20,12 @@ import javax.inject.{Inject, Singleton}
 import connectors.DataCacheConnector
 import controllers.{AmlsBaseController, CommonPlayDependencies}
 import forms.{EmptyForm, Form2, InvalidForm, ValidForm}
+import models.Country
 import models.businesscustomer.ReviewDetails
 import models.businessmatching.{BusinessMatching, ConfirmPostcode}
 import play.api.mvc.MessagesControllerComponents
 import utils.AuthAction
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import views.html.businessmatching.confirm_postcode
 
@@ -43,7 +45,7 @@ class ConfirmPostCodeController @Inject()(authAction: AuthAction,
 
   def updateReviewDetails(reviewDetails: Option[ReviewDetails], postCodeModel: ConfirmPostcode): Option[models.businesscustomer.ReviewDetails] = {
     reviewDetails.fold[Option[ReviewDetails]](None) { dtls =>
-      val updatedAddr = dtls.businessAddress.copy(postcode = Some(postCodeModel.postCode))
+      val updatedAddr = dtls.businessAddress.copy(postcode = Some(postCodeModel.postCode), country = Country("United Kingdom", "GB"))
       Some(dtls.copy(businessAddress = updatedAddr))
     }
   }
@@ -56,7 +58,8 @@ class ConfirmPostCodeController @Inject()(authAction: AuthAction,
           case ValidForm(_, data) =>
             for {
               bm <- dataCacheConnector.fetch[BusinessMatching](request.credId, BusinessMatching.key)
-              _ <- dataCacheConnector.save[BusinessMatching](request.credId, BusinessMatching.key, bm.copy(reviewDetails = updateReviewDetails(bm.reviewDetails, data)))
+              _ <- dataCacheConnector.save[BusinessMatching](request.credId, BusinessMatching.key,
+                bm.copy(reviewDetails = updateReviewDetails(bm.reviewDetails, data)))
             } yield {
               Redirect(routes.BusinessTypeController.get())
             }

--- a/app/models/Country.scala
+++ b/app/models/Country.scala
@@ -23,6 +23,14 @@ import play.api.libs.json._
 
 case class Country(name: String, code: String) {
   override def toString: String = name
+
+  def isUK = {
+    this == Country("United Kingdom", "GB")
+  }
+
+  def isEmpty = {
+    this == Country("", "")
+  }
 }
 
 object Country {

--- a/app/models/FormTypes.scala
+++ b/app/models/FormTypes.scala
@@ -146,8 +146,10 @@ object FormTypes {
   def validateAddress(line: String) = maxLength(maxAddressLength).withMessage(s"error.max.length.address.$line") andThen addressTypePatternWithMessage(s"error.text.validation.address.$line")
 
   private val postcodeRequired = required("error.required.postcode")
+  def postcodeRequiredWithMessage(errorMessage: String) = required(errorMessage)
 
   val postcodeType = postcodeRequired andThen postcodePattern
+  def postcodeTypeWithMsg(errorMessage: String) = postcodeRequiredWithMessage(errorMessage) andThen postcodePattern
 
 
   /** Contact Details Rules **/

--- a/app/models/businesscustomer/ReviewDetails.scala
+++ b/app/models/businesscustomer/ReviewDetails.scala
@@ -61,8 +61,13 @@ object ReviewDetails {
 
   implicit val writes = Json.writes[ReviewDetails]
 
-  implicit def convert(addr: BusinessMatchingAddress): Address =
-    Address(addr.line_1, addr.line_2, addr.line_3, addr.line_4, addr.postcode, Country("", addr.country))
+  implicit def convert(addr: BusinessMatchingAddress): Address = {
+      val country = models.countries collectFirst {
+        case country@Country(_, code) if code == addr.country => country
+      } getOrElse Country("", addr.country)
+
+      Address(addr.line_1, addr.line_2, addr.line_3, addr.line_4, addr.postcode, country)
+    }
 
   implicit def convert(details: BusinessMatchingReviewDetails): ReviewDetails = {
     ReviewDetails(details.businessName, Functor[Option].lift(toBusinessType)(details.businessType), details.businessAddress, details.safeId, details.utr)

--- a/app/models/businessmatching/ConfirmPostcode.scala
+++ b/app/models/businessmatching/ConfirmPostcode.scala
@@ -29,7 +29,7 @@ object ConfirmPostcode {
 
   implicit val formReads: Rule[UrlFormEncoded, ConfirmPostcode] = From[UrlFormEncoded] { __ =>
     import jto.validation.forms.Rules._
-    (__ \ "postCode").read(postcodeType) map ConfirmPostcode.apply
+    (__ \ "postCode").read(postcodeTypeWithMsg("businessmatching.confirm.postcode.error.empty")) map ConfirmPostcode.apply
   }
 
   implicit val formWrites: Write[ConfirmPostcode, UrlFormEncoded] = Write {

--- a/app/views/businessmatching/confirm_postcode.scala.html
+++ b/app/views/businessmatching/confirm_postcode.scala.html
@@ -37,8 +37,7 @@
         @input(
             field = f("postCode"),
             heading = "businessmatching.confirm.postcode.title",
-            section = "summary.businessmatching",
-            labelText = "lbl.address.postcode"
+            section = "summary.businessmatching"
         )
 
         @submit(returnLink = false)

--- a/conf/messages
+++ b/conf/messages
@@ -1612,7 +1612,8 @@ businessmatching.cannotcontinuewiththeapplication.heading = You can’t continue
 businessmatching.summary.icon.title = You’re applying to register the following business with HMRC under the Money Laundering Regulations.
 businessmatching.summary.business.address.lbl = Your business
 businessmatching.button.confirm.start = Confirm and start application
-businessmatching.confirm.postcode.title = Confirm the postcode for your business
+businessmatching.confirm.postcode.title = What is your business’s postcode?
+businessmatching.confirm.postcode.error.empty = Enter your business’s postcode
 
 
 businessmatching.summary.noedit.anchortext = Return to about your business

--- a/release_notes/AMLS-5759.txt
+++ b/release_notes/AMLS-5759.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5759] - 'Update H1 on Confirm the postcode page in pre-application and improve routing'

--- a/test/controllers/LandingControllerWithoutAmendmentsSpec.scala
+++ b/test/controllers/LandingControllerWithoutAmendmentsSpec.scala
@@ -193,7 +193,7 @@ class LandingControllerWithoutAmendmentsSpec extends AmlsSpec with StatusGenerat
 
       "the landing service has no saved form and " when {
 
-        "the landing service has valid review details" in new Fixture {
+        "the landing service has valid review details with UK postcode" in new Fixture {
 
           val details = Some(ReviewDetails(businessName = "Test",
             businessType = None,
@@ -211,7 +211,7 @@ class LandingControllerWithoutAmendmentsSpec extends AmlsSpec with StatusGenerat
           verify(controllerNoAmlsNumber.auditConnector).sendExtendedEvent(any[ExtendedDataEvent])(any(), any())
         }
 
-        "the landing service has review details with invalid postcode" in new Fixture {
+        "the landing service has review details with invalid UK postcode" in new Fixture {
 
           val details = Some(ReviewDetails(businessName = "Test",
             businessType = None,
@@ -226,6 +226,55 @@ class LandingControllerWithoutAmendmentsSpec extends AmlsSpec with StatusGenerat
           status(result) must be(SEE_OTHER)
           redirectLocation(result) mustBe Some(controllers.businessmatching.routes.ConfirmPostCodeController.get().url)
         }
+
+        "the landing service has review details without UK postcode" in new Fixture {
+
+          val details = Some(ReviewDetails(businessName = "Test",
+            businessType = None,
+            businessAddress = Address("Line 1", "Line 2", None, None, None, Country("United Kingdom", "GB")),
+            safeId = ""))
+
+          when(controllerNoAmlsNumber.landingService.cacheMap(any[String]())(any(), any())) thenReturn Future.successful(None)
+          when(controllerNoAmlsNumber.landingService.reviewDetails(any(), any(), any())).thenReturn(Future.successful(details))
+          when(controllerNoAmlsNumber.landingService.updateReviewDetails(any(), any[String]())(any(), any())).thenReturn(Future.successful(mock[CacheMap]))
+
+          val result = controllerNoAmlsNumber.get()(request)
+          status(result) must be(SEE_OTHER)
+          redirectLocation(result) mustBe Some(controllers.businessmatching.routes.ConfirmPostCodeController.get().url)
+        }
+
+        "the landing service has review details without postcode but other country" in new Fixture {
+
+          val details = Some(ReviewDetails(businessName = "Test",
+            businessType = None,
+            businessAddress = Address("Line 1", "Line 2", None, None, None, Country("USA", "US")),
+            safeId = ""))
+
+          when(controllerNoAmlsNumber.landingService.cacheMap(any[String]())(any(), any())) thenReturn Future.successful(None)
+          when(controllerNoAmlsNumber.landingService.reviewDetails(any(), any(), any())).thenReturn(Future.successful(details))
+          when(controllerNoAmlsNumber.landingService.updateReviewDetails(any(), any[String]())(any(), any())).thenReturn(Future.successful(mock[CacheMap]))
+
+          val result = controllerNoAmlsNumber.get()(request)
+          status(result) must be(SEE_OTHER)
+          redirectLocation(result) mustBe Some(controllers.businessmatching.routes.BusinessTypeController.get().url)
+        }
+
+        "the landing service has review details without postcode and country" in new Fixture {
+
+          val details = Some(ReviewDetails(businessName = "Test",
+            businessType = None,
+            businessAddress = Address("Line 1", "Line 2", None, None, None, Country("", "")),
+            safeId = ""))
+
+          when(controllerNoAmlsNumber.landingService.cacheMap(any[String]())(any(), any())) thenReturn Future.successful(None)
+          when(controllerNoAmlsNumber.landingService.reviewDetails(any(), any(), any())).thenReturn(Future.successful(details))
+          when(controllerNoAmlsNumber.landingService.updateReviewDetails(any(), any[String]())(any(), any())).thenReturn(Future.successful(mock[CacheMap]))
+
+          val result = controllerNoAmlsNumber.get()(request)
+          status(result) must be(SEE_OTHER)
+          redirectLocation(result) mustBe Some(controllers.businessmatching.routes.ConfirmPostCodeController.get().url)
+        }
+
 
         "the landing service has no valid review details" in new Fixture {
           when(controllerNoAmlsNumber.landingService.cacheMap(any[String]())(any(), any())) thenReturn Future.successful(None)

--- a/test/controllers/businessdetails/ConfirmRegisteredOfficeControllerSpec.scala
+++ b/test/controllers/businessdetails/ConfirmRegisteredOfficeControllerSpec.scala
@@ -169,6 +169,33 @@ class ConfirmRegisteredOfficeControllerSpec extends AmlsSpec with MockitoSugar {
 
       }
 
+      "successfully redirect to the page on selection of Option 'Yes' [this is registered address] and review details is None" in new Fixture {
+
+        val newRequest = requestWithUrlEncodedBody(
+          "isRegOfficeOrMainPlaceOfBusiness" -> "true"
+        )
+
+        val mockCacheMap = mock[CacheMap]
+        when(mockCacheMap.getEntry[BusinessMatching](BusinessMatching.key))
+          .thenReturn(Some(BusinessMatching(None)))
+        when(controller.dataCache.save[BusinessMatching](any(), any(), any())(any(), any()))
+          .thenReturn(Future.successful(emptyCache))
+        when(mockCacheMap.getEntry[BusinessDetails](BusinessDetails.key))
+          .thenReturn(Some(businessDetails))
+        when(controller.dataCache.fetchAll(any())(any[HeaderCarrier]))
+          .thenReturn(Future.successful(Some(mockCacheMap)))
+
+        val result = controller.post()(newRequest)
+        status(result) must be(SEE_OTHER)
+        redirectLocation(result) must be(Some(controllers.businessdetails.routes.RegisteredOfficeIsUKController.get().url))
+        verify(
+          controller.dataCache).save[BusinessDetails](any(), any(),
+          meq(businessDetails.copy(registeredOffice = None)))(any(), any()
+        )
+
+      }
+
+
       "on post invalid data" in new Fixture {
 
         val newRequest = requestWithUrlEncodedBody(

--- a/test/models/businessmatching/ConfirmPostcodeSpec.scala
+++ b/test/models/businessmatching/ConfirmPostcodeSpec.scala
@@ -38,7 +38,7 @@ class ConfirmPostcodeSpec extends PlaySpec with MockitoSugar {
       "fail validation" when {
         "missing a mandatory field represented by an empty string" in {
           val result = ConfirmPostcode.formReads.validate(Map("postCode" -> Seq("")))
-          result mustBe Invalid(Seq((Path \ "postCode") -> Seq(ValidationError("error.required.postcode"))))
+          result mustBe Invalid(Seq((Path \ "postCode") -> Seq(ValidationError("businessmatching.confirm.postcode.error.empty"))))
         }
         "missing a mandatory field represented by an empty Map" in {
           val result = ConfirmPostcode.formReads.validate(Map.empty)

--- a/test/models/businessmatching/ReviewDetailsSpec.scala
+++ b/test/models/businessmatching/ReviewDetailsSpec.scala
@@ -16,6 +16,7 @@
 
 package models.businessmatching
 
+import connectors.BusinessMatchingAddress
 import models.Country
 import models.businesscustomer.ReviewDetails
 import models.businesscustomer.Address
@@ -49,15 +50,12 @@ class ReviewDetailsSpec extends PlaySpec with MockitoSugar {
   )
 
   "Review Details Model" must {
-
     "validate correctly with a `Some` business type" in {
-
       Json.fromJson[ReviewDetails](json) mustEqual JsSuccess(model)
       Json.toJson(model) mustEqual (json)
     }
 
     "validate successfully with an invalid business type" in {
-
       val model = suite.model.copy(
         businessType = None
       )
@@ -77,7 +75,6 @@ class ReviewDetailsSpec extends PlaySpec with MockitoSugar {
     }
 
     "validate correctly with a `None` business type" in {
-
       val model = suite.model.copy(businessType = None)
 
       val json = Json.obj(
@@ -91,6 +88,84 @@ class ReviewDetailsSpec extends PlaySpec with MockitoSugar {
       )
 
       Json.fromJson[ReviewDetails](json) mustEqual JsSuccess(model)
+    }
+  }
+
+  "Review details convert method" must {
+    "properly convert valid UK business matching address model to business customer address model" in {
+      val bmAddressModel = BusinessMatchingAddress(
+        "Address line1",
+        "Address line 2",
+        Some("Address line 3"),
+        Some("Address line4"),
+        Some("AA11AA"), "GB")
+
+      val expectedAddressModel = Address(
+        "Address line1",
+        "Address line 2",
+        Some("Address line 3"),
+        Some("Address line4"),
+        Some("AA11AA"),
+        Country("United Kingdom", "GB"))
+
+      ReviewDetails.convert(bmAddressModel) mustBe(expectedAddressModel)
+    }
+
+    "properly convert valid non-UK business matching address model to business customer address model" in {
+      val bmAddressModel = BusinessMatchingAddress(
+        "Address line1",
+        "Address line 2",
+        Some("Address line 3"),
+        Some("Address line4"),
+        None, "US")
+
+      val expectedAddressModel = Address(
+        "Address line1",
+        "Address line 2",
+        Some("Address line 3"),
+        Some("Address line4"),
+        None,
+        Country("United States of America", "US"))
+
+      ReviewDetails.convert(bmAddressModel) mustBe(expectedAddressModel)
+    }
+
+    "properly convert business matching address model with not existing country code to business customer address model" in {
+      val bmAddressModel = BusinessMatchingAddress(
+        "Address line1",
+        "Address line 2",
+        Some("Address line 3"),
+        Some("Address line4"),
+        None, "XYZ")
+
+      val expectedAddressModel = Address(
+        "Address line1",
+        "Address line 2",
+        Some("Address line 3"),
+        Some("Address line4"),
+        None,
+        Country("", "XYZ"))
+
+      ReviewDetails.convert(bmAddressModel) mustBe(expectedAddressModel)
+    }
+
+    "properly convert business matching address model with missing country code to business customer address model" in {
+      val bmAddressModel = BusinessMatchingAddress(
+        "Address line1",
+        "Address line 2",
+        Some("Address line 3"),
+        Some("Address line4"),
+        None, "")
+
+      val expectedAddressModel = Address(
+        "Address line1",
+        "Address line 2",
+        Some("Address line 3"),
+        Some("Address line4"),
+        None,
+        Country("", ""))
+
+      ReviewDetails.convert(bmAddressModel) mustBe(expectedAddressModel)
     }
   }
 }


### PR DESCRIPTION
In this PR there are significant changes to the flow from LandingController depending on the postcode/country code. There are also other changes, so please review carefully :D I've left some comments in this PR in a few places.

Testing:
1. Clone business-customer-stub
2. In EtmpController manipulate address as you like:
    val address = Address("23 High Street", "Park View", Some("Gloucester"), Some("Gloucestershire"), Some("NE98 1ZZ"), "GB")
3. Stop this microservice in service manager
4. Run cloned service on 9926
5. Load empty application with IR-SA/UTR/1111111111 preset
6. You will land on Check this is the business you want to register and it should display adress modified above
7. Continue with testing

## Related / Dependant PRs?

- none

## How Has This Been Tested?

- manually (using business-customer-stub)
- unit tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
