### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -44,11 +44,6 @@ play.modules.enabled += "modules.Module"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 
-play.filters.csrf.header.bypassHeaders {
-  X-Requested-With = "*"
-  Csrf-Token = "nocheck"
-}
-
 play.http.filters = play.api.http.EnabledFilters
 
 play.filters.enabled = [


### PR DESCRIPTION
A large number of configuration files in production contains code which allows the anti-csrf checks to be bypassed:

The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051
