### PR TITLE
DLS-6149 Make the ID attribute on the "fit and proper" page optional

### DIFF
--- a/app/views/include/forms2/anchor.scala.html
+++ b/app/views/include/forms2/anchor.scala.html
@@ -43,7 +43,7 @@
 
     @if(returnLink) {
         <p class="return-link">
-        @if(returnLocation == Some("renewal")) {
+        @if(returnLocation.contains("renewal")) {
             <a href="@controllers.renewal.routes.RenewalProgressController.get.url">@Messages("link.return.renewal.progress")</a>
         } else {
             <a href="@controllers.routes.RegistrationProgressController.get.url">@Messages("link.return.registration.progress")</a>

--- a/app/views/include/forms2/anchor.scala.html
+++ b/app/views/include/forms2/anchor.scala.html
@@ -26,7 +26,10 @@
 )(implicit m: Messages)
     @* Current use suggests we only use the one class on anchors: button;
     may need refactoring at a later date if more are required *@
-<a href="@attrHref" id="@id.getOrElse("")"
+<a href="@attrHref"
+    @if(id.isDefined) {
+        id="@id.get"
+    }
     @if(!draggable){
         draggable="false"
     }


### PR DESCRIPTION
[Your pull request description here]

## How Has This Been Tested?

 - Go to the [fit and proper test check page](http://localhost:9222/anti-money-laundering/responsible-people/fit-and-proper-notice/1/)
 - Observe (in the dev tools) the green Continue button no longer has an empty "id" tag.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [ ] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
