### PR TITLE
DLS-5804 Correct lists and fix duplicate IDs

### DIFF
--- a/app/views/businessactivities/summary.scala.html
+++ b/app/views/businessactivities/summary.scala.html
@@ -63,8 +63,7 @@
 
                 @checkYourAnswersRow(
                     question = Messages("businessactivities.confirm-activities.lbl.details"),
-                    editUrl = controllers.businessactivities.routes.InvolvedInOtherController.get(true).toString,
-                    editLinkTag = "involvedinother-edit"
+                    editUrl = controllers.businessactivities.routes.InvolvedInOtherController.get(true).toString
                 ) {
                     @activity
                 }

--- a/app/views/businessactivities/summary.scala.html
+++ b/app/views/businessactivities/summary.scala.html
@@ -112,7 +112,6 @@
         @checkYourAnswersRow(
             question = Messages("businessactivities.businessfranchise.title"),
             editUrl = controllers.businessactivities.routes.BusinessFranchiseController.get(true).toString,
-            editLinkTag = "businessfranchise-edit"
         ) {
             @model.businessFranchise.map {
                 case BusinessFranchiseNo        => { @Messages("lbl.no") }
@@ -126,7 +125,6 @@
                 @checkYourAnswersRow(
                     question = Messages("businessactivities.businessfranchise.lbl.franchisename"),
                     editUrl = controllers.businessactivities.routes.BusinessFranchiseController.get(true).toString,
-                    editLinkTag = "businessfranchise-edit"
                 ) {
                     @name
                 }
@@ -168,7 +166,6 @@
             @checkYourAnswersRow(
                 question = Messages("businessactivities.do.keep.records"),
                 editUrl = controllers.businessactivities.routes.TransactionTypesController.get(true).toString,
-                editLinkTag = "howrecordskept-edit"
             ) {
                     @if(t.types.size > 1) {
                         <ul class="list list-bullet">
@@ -200,7 +197,6 @@
                         @checkYourAnswersRow(
                             question = Messages("businessactivities.name.software.pkg.lbl"),
                             editUrl = controllers.businessactivities.routes.TransactionTypesController.get(true).toString,
-                            editLinkTag = "howrecordskept-edit"
                         ) {
                             @software
                         }

--- a/app/views/businessdetails/summary.scala.html
+++ b/app/views/businessdetails/summary.scala.html
@@ -62,7 +62,6 @@
         @model.vatRegistered.map { vatRegistered =>
             @checkYourAnswersRow(
                 question = Messages("businessdetails.registeredforvat.title"),
-                editLinkTag = "businessdetailsregisteredvat-edit",
                 editUrl = controllers.businessdetails.routes.VATRegisteredController.get(true).toString
             ) {
                 @vatRegistered match {
@@ -78,7 +77,6 @@
                 case VATRegisteredYes(vatNo) => {
                     @checkYourAnswersRow(
                         question = Messages("lbl.vat.reg.number"),
-                        editLinkTag = "businessdetailsregisteredvat-edit",
                         editUrl = controllers.businessdetails.routes.VATRegisteredController.get(true).toString
                     ) {
                           @vatNo

--- a/app/views/businessmatching/summary.scala.html
+++ b/app/views/businessmatching/summary.scala.html
@@ -213,7 +213,6 @@
                     @model.businessAppliedForPSRNumber.map { psr =>
                         @checkYourAnswersRow(
                             question = Messages("businessmatching.psr.number.title"),
-                            editUrl = controllers.businessmatching.routes.PSRNumberController.get(true).toString,
                             editLinkTag = "edit-psr-number"
                         ) {
                             <p id="psr">@psr match {

--- a/app/views/msb/summary.scala.html
+++ b/app/views/msb/summary.scala.html
@@ -272,7 +272,6 @@
             @model.whichCurrencies.map { wc =>
                 @checkYourAnswersRow(
                     question = Messages("msb.which_currencies.title"),
-                    editLinkTag = "msbwhichcurrencies-edit",
                     editUrl = controllers.msb.routes.WhichCurrenciesController.get(true).toString
                 ) {
                     @if(wc.currencies.size == 1){

--- a/app/views/renewal/summary.scala.html
+++ b/app/views/renewal/summary.scala.html
@@ -231,7 +231,6 @@
             @model.whichCurrencies.map { wc =>
                 @checkYourAnswersRow(
                     question = Messages("renewal.msb.whichcurrencies.header"),
-                    editLinkTag = "msbwhichcurrencies-edit",
                     editUrl = controllers.renewal.routes.WhichCurrenciesController.get(edit = true).toString
                 ) {
                     @if(wc.currencies.size > 1) {
@@ -252,7 +251,6 @@
                 @wc.usesForeignCurrencies.map { ufc =>
                     @checkYourAnswersRow(
                         question = Messages("renewal.msb.foreign_currencies.header"),
-                        editLinkTag = "msbwhichcurrencies-edit",
                         editUrl = controllers.renewal.routes.UsesForeignCurrenciesController.get(true).toString
                     ) {
                         @ufc match {
@@ -272,7 +270,6 @@
                     @if(ms.bankMoneySource.isDefined | ms.wholesalerMoneySource.isDefined | ms.customerMoneySource.isDefined) {
                         @checkYourAnswersRow(
                             question = Messages("renewal.msb.money_sources.header"),
-                            editLinkTag = "msbwhichcurrencies-edit",
                             editUrl = controllers.renewal.routes.MoneySourcesController.get(true).toString
                         ) {
 
@@ -308,7 +305,6 @@
                   @if(ms.bankMoneySource.isDefined) {
                       @checkYourAnswersRow(
                           question = Messages("msb.which_currencies.source.which_banks"),
-                          editLinkTag = "msbwhichcurrencies-edit",
                           editUrl = controllers.renewal.routes.MoneySourcesController.get(true).toString
                       ) {
                           @ms.bankMoneySource.map { bms =>
@@ -319,7 +315,6 @@
                     @if(ms.wholesalerMoneySource.isDefined) {
                         @checkYourAnswersRow(
                             question = Messages("msb.which_currencies.source.which_wholesalers"),
-                            editLinkTag = "msbwhichcurrencies-edit",
                             editUrl = controllers.renewal.routes.MoneySourcesController.get(true).toString
                         ) {
                             @ms.wholesalerMoneySource.map { wms =>

--- a/app/views/supervision/summary.scala.html
+++ b/app/views/supervision/summary.scala.html
@@ -59,7 +59,7 @@
 
             @checkYourAnswersRow(
                 question = Messages("supervision.another_body.lbl.supervisor"),
-                editLinkTag = "supervisionanotherbody-edit-name",
+                editLinkTag = "supervisionanotherbody-edit-previous-name",
                 editUrl = controllers.supervision.routes.AnotherBodyController.get(true).toString
             ) {
                 @supervisorName

--- a/app/views/supervision/summary.scala.html
+++ b/app/views/supervision/summary.scala.html
@@ -156,7 +156,6 @@
 
     @checkYourAnswersRow(
         question = Messages("supervision.penalisedbyprofessional.title"),
-        editLinkTag = "supervisionpenalised-edit",
         editUrl = controllers.supervision.routes.PenalisedByProfessionalController.get(true).toString
     ) {
         @model.professionalBody.map {
@@ -170,7 +169,6 @@
         case ProfessionalBodyYes(v) => {
             @checkYourAnswersRow(
                 question = Messages("supervision.penalisedbyprofessional.details.lbl"),
-                editLinkTag = "supervisionpenalised-edit",
                 editUrl = controllers.supervision.routes.PenalisedByProfessionalController.get(true).toString
             ) {
                 @v

--- a/app/views/tcsp/summary.scala.html
+++ b/app/views/tcsp/summary.scala.html
@@ -127,7 +127,6 @@
         @model.servicesOfAnotherTCSP.map { s =>
             @checkYourAnswersRow(
                 question = Messages("tcsp.anothertcspsupervision.title"),
-                editLinkTag = "anothertcspsupervision-edit",
                 editUrl = controllers.tcsp.routes.AnotherTCSPSupervisionController.get(true).toString
             ) {
                 @s match {
@@ -141,7 +140,6 @@
             @if(s != ServicesOfAnotherTCSPNo) {
                     @checkYourAnswersRow(
                         question = Messages("tcsp.anothertcspsupervision.cya.additional.header"),
-                        editLinkTag = "anothertcspsupervision-edit",
                         editUrl = controllers.tcsp.routes.AnotherTCSPSupervisionController.get(true).toString
                     ) {
                         @s match {

--- a/app/views/tradingpremises/what_you_need.scala.html
+++ b/app/views/tradingpremises/what_you_need.scala.html
@@ -14,10 +14,9 @@
  * limitations under the License.
  *@
 
-@import forms.Form2
 @import include._
 @import include.forms2._
-@import config.{ApplicationConfig}
+@import config.ApplicationConfig
 
 @import models.businessmatching.BusinessActivities
 @import models.businessmatching.BusinessMatchingMsbServices

--- a/app/views/tradingpremises/what_you_need.scala.html
+++ b/app/views/tradingpremises/what_you_need.scala.html
@@ -70,17 +70,21 @@
                 <li>@Messages("tradingpremises.whatyouneed.requiredinfo.text.5")</li>
             }
         }
+    }
+    </ul>
 
+    @activities.map { ba =>
         @if(ba.hasBusinessOrAdditionalActivity(MoneyServiceBusiness)) {
             <h3 class="heading-medium">@Messages("tradingpremises.whatyouneed.agents.sub.heading")</h3>
 
             <p>@Messages("tradingpremises.whatyouneed.agents.desc.1")</p>
 
             <p>@Messages("tradingpremises.whatyouneed.agents.desc.2")</p>
-
+            <ul class="list list-bullet">
                 <li>@Messages("tradingpremises.whatyouneed.requiredinfo.text.6")</li>
                 <li>@Messages("tradingpremises.whatyouneed.requiredinfo.text.7")</li>
                 <li>@Messages("tradingpremises.whatyouneed.requiredinfo.text.8")</li>
+            </ul>
         }
 
         @if(ba.hasBusinessOrAdditionalActivity(MoneyServiceBusiness)) {
@@ -93,7 +97,6 @@
                 draggable = false
             )
         } else {
-            </ul>
             @if(index == 1) {
                 @anchor(
                     attrHref = controllers.tradingpremises.routes.ConfirmAddressController.get(index).toString,

--- a/app/views/tradingpremises/what_you_need.scala.html
+++ b/app/views/tradingpremises/what_you_need.scala.html
@@ -93,26 +93,26 @@
                 draggable = false
             )
         } else {
-        </ul>
-        @if(index == 1) {
-            @anchor(
-                attrHref = controllers.tradingpremises.routes.ConfirmAddressController.get(index).toString,
-                attrRole = true,
-                linkText = Messages("button.continue"),
-                returnLink = true,
-                id = Some("tpwhatyouneed-button"),
-                draggable = false
-            )
-        } else {
-            @anchor(
-                attrHref = controllers.tradingpremises.routes.WhereAreTradingPremisesController.get(index).toString,
-                attrRole = true,
-                linkText = Messages("button.continue"),
-                returnLink = true,
-                id = Some("tpwhatyouneed-button"),
-                draggable = false
-            )
+            </ul>
+            @if(index == 1) {
+                @anchor(
+                    attrHref = controllers.tradingpremises.routes.ConfirmAddressController.get(index).toString,
+                    attrRole = true,
+                    linkText = Messages("button.continue"),
+                    returnLink = true,
+                    id = Some("tpwhatyouneed-button"),
+                    draggable = false
+                )
+            } else {
+                @anchor(
+                    attrHref = controllers.tradingpremises.routes.WhereAreTradingPremisesController.get(index).toString,
+                    attrRole = true,
+                    linkText = Messages("button.continue"),
+                    returnLink = true,
+                    id = Some("tpwhatyouneed-button"),
+                    draggable = false
+                )
+            }
         }
     }
-}
 }


### PR DESCRIPTION
Correct lists and fix duplicate IDs.

Some IDs weren't used anywhere, so got removed.

Others - I removed one of the two duplicated IDs, as it was used in tests, but it didn't matter which of the two links was clicked from acceptance tests perspective.

## How Has This Been Tested?

View the page and run Microsoft Accessibility check.
I've extracted the list of duplicated fields from Jenkins (link in the comment in the ticket).

1.	supervisionanotherbody-edit-name
2.	supervisionpenalised-edit
3.	anothertcspsupervision-edit
4.	msbwhichcurrencies-edit
5.	businessdetailsregisteredvat-edit
6.	edit-psr-number
7.	involvedinother-edit
8.	businessfranchise-edit
9.	howrecordskept-edit

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [ ] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
