### PR TITLE
[DLS-5490] - Play 2.8.16 upgrade for amls-frontend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,9 +59,6 @@ lazy val microservice = Project(appName, file("."))
     addTestReportOption(IntegrationTest, "int-test-reports"),
     testGrouping in IntegrationTest := oneForkedJvmPerTest((definedTests in IntegrationTest).value),
     parallelExecution in IntegrationTest := false)
-  .settings(
-    resolvers += Resolver.bintrayRepo("hmrc", "releases")
-  )
  .settings(
     scalacOptions ++= List(
       "-Yrangepos",

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,8 +5,6 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="uk.gov" level="${logger.uk.gov:-WARN}"/>
-
     <logger name="com.ning.http.client" level="WARN"/>
 
     <logger name="org.asynchttpclient.netty.channel.DefaultChannelPool" level="WARN"/>

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,6 +5,8 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
+    <logger name="uk.gov" level="${logger.uk.gov:-WARN}"/>
+
     <logger name="com.ning.http.client" level="WARN"/>
 
     <logger name="org.asynchttpclient.netty.channel.DefaultChannelPool" level="WARN"/>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,7 +22,7 @@ play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
 # Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
 # An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
+play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 
 # Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
 # A metric filter must be provided
@@ -36,7 +36,7 @@ play.http.filters = "uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters
 play.http.errorHandler = "config.AmlsErrorHandler"
 
 appName = "amls-frontend"
-application.router = prod.Routes
+play.http.router = prod.Routes
 
 play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9250 localhost:9032 assets.digital.cabinet-office.gov.uk http://localhost:12345 www.googletagmanager.com https://www.google-analytics.com https://fonts.googleapis.com https://ssl.gstatic.com https://www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com *.optimizely.com optimizely.s3.amazonaws.com data:"
 play.modules.enabled += "modules.Module"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -22,7 +22,7 @@ private object AppDependencies {
     "uk.gov.hmrc"       %% "json-encryption"            % jsonEncryptionVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % hmrcMongoVersion,
     "uk.gov.hmrc"       %% "play-ui"                    % "9.6.0-play-28",
-    "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.12.0",
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "7.12.0",
     "uk.gov.hmrc"       %% "govuk-template"             % "5.69.0-play-28",
     "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "1.31.0-play-28",
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,14 +5,14 @@ private object AppDependencies {
   import play.sbt.PlayImport._
   import play.core.PlayVersion
 
-  private val playPartialsVersion = "8.2.0-play-28"
+  private val playPartialsVersion = "8.3.0-play-28"
   private val httpCachingClientVersion = "9.5.0-play-28"
   private val validationVersion = "2.1.0"
   private val flexmarkVersion = "0.19.1"
   private val okHttpVersion = "3.9.1"
-  private val jsonEncryptionVersion = "4.10.0-play-28"
+  private val jsonEncryptionVersion = "5.1.0-play-28"
   private val hmrcMongoVersion = "0.71.0"
-  private val domain = "6.2.0-play-28"
+  private val domain = "8.1.0-play-28"
 
   val compile = Seq(
     ws,
@@ -21,10 +21,10 @@ private object AppDependencies {
     "uk.gov.hmrc"       %% "http-caching-client"        % httpCachingClientVersion,
     "uk.gov.hmrc"       %% "json-encryption"            % jsonEncryptionVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % hmrcMongoVersion,
-    "uk.gov.hmrc"       %% "play-ui"                    % "9.6.0-play-28",
+    "uk.gov.hmrc"       %% "play-ui"                    % "9.11.0-play-28",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.24.0",
-    "uk.gov.hmrc"       %% "govuk-template"             % "5.69.0-play-28",
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "1.31.0-play-28",
+    "uk.gov.hmrc"       %% "govuk-template"             % "5.78.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "3.34.0-play-28",
 
 
     "io.github.jto" %% "validation-core"      % validationVersion,
@@ -36,7 +36,7 @@ private object AppDependencies {
     "com.squareup.okhttp3" % "mockwebserver" % okHttpVersion,
     "com.typesafe.play" %% "play-json" % "2.8.1",
     "com.typesafe.play" %% "play-json-joda" % "2.8.1",
-    
+
     compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.5" cross CrossVersion.full),
     "com.github.ghik" % "silencer-lib" % "1.7.5" % Provided cross CrossVersion.full
   )

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -22,7 +22,7 @@ private object AppDependencies {
     "uk.gov.hmrc"       %% "json-encryption"            % jsonEncryptionVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % hmrcMongoVersion,
     "uk.gov.hmrc"       %% "play-ui"                    % "9.6.0-play-28",
-    "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "7.12.0",
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.24.0",
     "uk.gov.hmrc"       %% "govuk-template"             % "5.69.0-play-28",
     "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "1.31.0-play-28",
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.4
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 resolvers += Resolver.jcenterRepo
 
 
-addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.5.0")
+addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.8.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.1.0")
 addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.18" exclude("org.slf4j", "slf4j-simple"))
 addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "1.9.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ resolvers += Resolver.jcenterRepo
 
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.5.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.1.0")
-addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.15" exclude("org.slf4j", "slf4j-simple"))
+addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.18" exclude("org.slf4j", "slf4j-simple"))
 addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "1.9.0")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"  % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"   %  "sbt-digest"             % "1.1.3")


### PR DESCRIPTION
### updates:
**required:**

- bootstrap-play : 5.24.0 (any later seems to cause errors)
- sbt-plugin : 2.8.18

**additional:**

- play-partials : 8.3.0-play-28
- json-encryption : 5.1.0-play-28
- domain : 8.1.0-play-28
- play-ui : 9.11.0-play-28
- govuk-template : 5.78.0-play-28
- play-frontend-hmrc : 3.34.0-play-28