### PR TITLE
DDCYLS-2315

### DIFF
--- a/app/models/FeeResponse.scala
+++ b/app/models/FeeResponse.scala
@@ -20,7 +20,6 @@ import models.ResponseType.AmendOrVariationResponseType
 import models.status.{ReadyForRenewal, RenewalSubmitted, SubmissionReadyForReview, SubmissionStatus}
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.json._
-import uk.gov.hmrc.mongo.play.json.formats.MongoJodaFormats
 
 sealed trait ResponseType
 
@@ -71,9 +70,14 @@ case class FeeResponse(responseType: ResponseType,
 
 object FeeResponse {
 
+
   implicit val dateTimeRead: Reads[DateTime] =
     (__ \ "$date").read[Long].map { dateTime =>
       new DateTime(dateTime, DateTimeZone.UTC)
+    }.orElse {
+      (__ \ "$date" \ "$numberLong").read[Long].map { dateTime =>
+        new DateTime(dateTime, DateTimeZone.UTC)
+      }
     }
 
 


### PR DESCRIPTION
date & time will come back under a new path using the HMRC Mongo Library. So this path is now being used to read the date & time