### PR TITLE
DDCYLS-4095 Fix to status tag logic for TP/RP

### DIFF
--- a/app/models/responsiblepeople/ResponsiblePerson.scala
+++ b/app/models/responsiblepeople/ResponsiblePerson.scala
@@ -239,9 +239,6 @@ object ResponsiblePerson {
   def filter(rp: Seq[ResponsiblePerson]): Seq[ResponsiblePerson] =
     rp.filterNot(_.status.contains(StatusConstants.Deleted)).filterNot(_ == ResponsiblePerson())
 
-  def filterWithIndex(rp: Seq[ResponsiblePerson]): Seq[(ResponsiblePerson, Int)] =
-    rp.zipWithIndex.reverse.filterNot(_._1.status.contains(StatusConstants.Deleted)).filterNot(_._1 == ResponsiblePerson())
-
   def taskRow(implicit cache: CacheMap, messages: Messages): TaskRow = {
 
     val messageKey = "responsiblepeople"
@@ -264,7 +261,7 @@ object ResponsiblePerson {
           TaskRow.notStartedTag
         )
       } else {
-        filter(rp) match {
+        rp match {
           case responsiblePeople if responsiblePeople.nonEmpty && anyChanged(responsiblePeople) && responsiblePeople.forall {
             _.isComplete
           } => TaskRow(

--- a/app/models/tradingpremises/TradingPremises.scala
+++ b/app/models/tradingpremises/TradingPremises.scala
@@ -163,7 +163,7 @@ object TradingPremises {
           TaskRow.notStartedTag
         )
       } else {
-        filter(tp) match {
+        tp match {
           case premises if premises.nonEmpty && anyChanged(premises) && premises.forall {
             _.isComplete
           } => TaskRow(

--- a/app/views/components/TaskRowWithUpdateComponent.scala.html
+++ b/app/views/components/TaskRowWithUpdateComponent.scala.html
@@ -33,7 +33,8 @@
     (taskRow.status == Updated || taskRow.status == Completed, taskRow.hasChanged) match {
         case (true, true) => TaskRow.updatedTag
         case (true, false) => TaskRow.completedTag
-        case (false, _) => taskRow.tag
+        case (false, true) => TaskRow.incompleteTag
+        case (false, false) => taskRow.tag
     }
 }
 

--- a/test/models/tradingpremises/TradingPremisesSpec.scala
+++ b/test/models/tradingpremises/TradingPremisesSpec.scala
@@ -251,9 +251,9 @@ class TradingPremisesSpec extends AmlsSpec {
         val taskRow = TradingPremises.taskRow(mockCacheMap, messages)
 
         taskRow.hasChanged must be(true)
-        taskRow.status must be(Completed)
+        taskRow.status must be(Updated)
         taskRow.href must be(controllers.tradingpremises.routes.YourTradingPremisesController.get().url)
-        taskRow.tag must be(TaskRow.completedTag)
+        taskRow.tag must be(TaskRow.updatedTag)
       }
     }
 

--- a/test/views/components/TaskRowWithUpdateComponentSpec.scala
+++ b/test/views/components/TaskRowWithUpdateComponentSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components
+
+import models.registrationprogress.TaskRow.{completedTag, incompleteTag, notStartedTag, updatedTag}
+import models.registrationprogress.{Completed, NotStarted, Started, TaskRow, Updated}
+import org.jsoup.Jsoup
+import utils.AmlsViewSpec
+import views.html.components.TaskRowWithUpdateComponent
+
+class TaskRowWithUpdateComponentSpec extends AmlsViewSpec {
+
+  lazy val injectedView: TaskRowWithUpdateComponent = inject[TaskRowWithUpdateComponent]
+
+  "The task row status tag text" should {
+
+    "be 'Updated'" when {
+
+      "the status is Updated and existing data has changed" in {
+        val taskRow = TaskRow("", "", hasChanged = true, Updated, updatedTag)
+        val document = Jsoup.parse(injectedView(taskRow).body)
+        document.select("li > strong").text() mustBe "Updated"
+      }
+
+      "the status is Completed and existing data has changed" in {
+        val taskRow = TaskRow("", "", hasChanged = true, Completed, completedTag)
+        val document = Jsoup.parse(injectedView(taskRow).body)
+        document.select("li > strong").text() mustBe "Updated"
+      }
+    }
+
+    "be 'Completed'" when {
+
+      "the status is Updated and there was no existing data" in {
+        val taskRow = TaskRow("", "", hasChanged = false, Updated, updatedTag)
+        val document = Jsoup.parse(injectedView(taskRow).body)
+        document.select("li > strong").text() mustBe "Completed"
+      }
+
+      "the status is Completed and there was no existing data" in {
+        val taskRow = TaskRow("", "", hasChanged = false, Completed, completedTag)
+        val document = Jsoup.parse(injectedView(taskRow).body)
+        document.select("li > strong").text() mustBe "Completed"
+      }
+    }
+
+    "be 'Incomplete'" when {
+
+      "the status is Started and existing data has changed" in {
+        val taskRow = TaskRow("", "", hasChanged = true, Started, incompleteTag)
+        val document = Jsoup.parse(injectedView(taskRow).body)
+        document.select("li > strong").text() mustBe "Incomplete"
+      }
+
+      "the status is Not Started and existing data has changed" in {
+        val taskRow = TaskRow("", "", hasChanged = true, NotStarted, notStartedTag)
+        val document = Jsoup.parse(injectedView(taskRow).body)
+        document.select("li > strong").text() mustBe "Incomplete"
+      }
+    }
+
+    "be 'Not started'" when {
+
+      "the status is Not Started and there was no existing data" in {
+        val taskRow = TaskRow("", "", hasChanged = false, NotStarted, notStartedTag)
+        val document = Jsoup.parse(injectedView(taskRow).body)
+        document.select("li > strong").text() mustBe "Not started"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This should only affect trading premises and responsible people rows as these are the sections which can have multiple sets of data, and therefore had the bugs. I added a new unit test spec for the recent view logic that was also updated here.

This is to address items on rows 22 and 23 of the bug bash spreadsheet.