### PR TITLE
DDCYLS-3059

### DIFF
--- a/app/controllers/tradingpremises/TradingPremisesAddController.scala
+++ b/app/controllers/tradingpremises/TradingPremisesAddController.scala
@@ -18,10 +18,12 @@ package controllers.tradingpremises
 
 import connectors.DataCacheConnector
 import controllers.{AmlsBaseController, CommonPlayDependencies}
+
 import javax.inject.{Inject, Singleton}
 import models.businessmatching.BusinessMatching
 import models.tradingpremises.TradingPremises
 import play.api.mvc.{AnyContent, MessagesControllerComponents, Request}
+import services.TradingPremisesService
 import uk.gov.hmrc.http.cache.client.CacheMap
 import utils.{AuthAction, ControllerHelper, RepeatingSection}
 
@@ -32,6 +34,7 @@ class TradingPremisesAddController @Inject()(val dataCacheConnector: DataCacheCo
                                              val authAction: AuthAction,
                                              val ds: CommonPlayDependencies,
                                              val cc: MessagesControllerComponents,
+                                             val tradingPremisesService: TradingPremisesService,
                                              implicit val error: views.html.ErrorView) extends AmlsBaseController(ds, cc) with RepeatingSection {
 
   private def isMSBSelected(cacheMap: Option[CacheMap]): Boolean = {
@@ -53,7 +56,7 @@ class TradingPremisesAddController @Inject()(val dataCacheConnector: DataCacheCo
 
   def get(displayGuidance: Boolean = true) = authAction.async {
     implicit request =>
-          addData[TradingPremises](request.credId, TradingPremises.default(None)) flatMap { idx =>
+          tradingPremisesService.addTradingPremises(request.credId, TradingPremises.default(None)) flatMap { idx =>
             displayGuidance match {
               case true => Future.successful(Redirect(controllers.tradingpremises.routes.WhatYouNeedController.get(idx)))
               case false => redirectToNextPage(request.credId, idx)

--- a/app/models/tradingpremises/TradingPremises.scala
+++ b/app/models/tradingpremises/TradingPremises.scala
@@ -112,6 +112,13 @@ case class TradingPremises(
     }
   }
 
+  def notEmpty: Boolean = {
+    this match {
+      case TradingPremises(None, None, None, None, None, None, None, None, _, _, _, None, _, None, _) => false
+      case _ => true
+    }
+  }
+
   def label: Option[String] = {
     this.yourTradingPremises.map { tradingpremises =>
       (Seq(tradingpremises.tradingName) ++ tradingpremises.tradingPremisesAddress.toLines).mkString(", ")

--- a/app/services/TradingPremisesService.scala
+++ b/app/services/TradingPremisesService.scala
@@ -16,14 +16,21 @@
 
 package services
 
-import javax.inject.Singleton
+import connectors.DataCacheConnector
+
+import javax.inject.{Inject, Singleton}
 import models.businessmatching.{BusinessActivity, BusinessMatchingMsbServices}
 import models.businessmatching.BusinessActivity.MoneyServiceBusiness
 import models.tradingpremises
 import models.tradingpremises.{TradingPremises, WhatDoesYourBusinessDo}
+import play.api.libs.json.Format
+import typeclasses.MongoKey
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class TradingPremisesService {
+class TradingPremisesService @Inject()(val cacheConnector: DataCacheConnector) {
 
   def updateTradingPremises(
                              indices: Seq[Int],
@@ -64,7 +71,7 @@ class TradingPremisesService {
   def removeBusinessActivitiesFromTradingPremises(
                                                    tradingPremises: Seq[TradingPremises],
                                                    existingActivities: Set[BusinessActivity],
-                                                   removeActivities: Set[BusinessActivity]): Seq[TradingPremises] =
+                                                   removeActivities: Set[BusinessActivity]): Seq[TradingPremises] = {
     patchTradingPremisesBusinessActivities(tradingPremises) { (wdybd, index) =>
       wdybd.copy({
         wdybd.activities diff removeActivities match {
@@ -79,6 +86,26 @@ class TradingPremisesService {
         tp
       }
     }
+  }
+
+  def addTradingPremises(credId: String, newTradingPremises: TradingPremises)(implicit hc: HeaderCarrier, formats: Format[TradingPremises],
+                                                                              key: MongoKey[TradingPremises], ec: ExecutionContext): Future[Int] = {
+
+    val futureFetchedTradingPremises =
+      cacheConnector
+        .fetch[Seq[TradingPremises]](credId, key())
+        .map(_.fold(Seq.empty[TradingPremises])(identity))
+
+    futureFetchedTradingPremises.flatMap { fetchedTradingPremises =>
+      if (!fetchedTradingPremises.lastOption.contains(newTradingPremises) && !fetchedTradingPremises.lastOption.exists(_.notEmpty)) {
+        cacheConnector
+          .save[Seq[TradingPremises]](credId, key(), fetchedTradingPremises :+ newTradingPremises)
+          .map(_ => fetchedTradingPremises.size + 1)
+      } else {
+        Future.successful(fetchedTradingPremises.size)
+      }
+    }
+  }
 
   private def patchTradingPremisesBusinessActivities(tradingPremises: Seq[TradingPremises])
                                                     (fn: (WhatDoesYourBusinessDo, Int) => WhatDoesYourBusinessDo): Seq[TradingPremises] = {

--- a/app/utils/RepeatingSection.scala
+++ b/app/utils/RepeatingSection.scala
@@ -17,10 +17,12 @@
 package utils
 
 import connectors.DataCacheConnector
+import models.tradingpremises.TradingPremises
 import play.api.libs.json.Format
 import typeclasses.MongoKey
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.cache.client.CacheMap
+
 import scala.concurrent.{ExecutionContext, Future}
 
 // $COVERAGE-OFF$

--- a/test/controllers/tradingpremises/TradingPremisesAddControllerSpec.scala
+++ b/test/controllers/tradingpremises/TradingPremisesAddControllerSpec.scala
@@ -26,6 +26,7 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.test.Helpers._
+import services.TradingPremisesService
 import uk.gov.hmrc.http.cache.client.CacheMap
 import utils.AmlsSpec
 
@@ -41,6 +42,7 @@ class TradingPremisesAddControllerSpec extends AmlsSpec with ScalaCheckPropertyC
       SuccessfulAuthAction,
       ds = commonDependencies,
       cc = mockMcc,
+      tradingPremisesService = mock[TradingPremisesService],
       error = errorView)
   }
 
@@ -48,23 +50,11 @@ class TradingPremisesAddControllerSpec extends AmlsSpec with ScalaCheckPropertyC
     val emptyCache = CacheMap("", Map.empty)
 
     "load What You Need successfully when displayGuidance is true" in new Fixture {
-
-      val BusinessActivitiesModel = BusinessActivities(Set(MoneyServiceBusiness, TrustAndCompanyServices, TelephonePaymentService))
-      val mockCacheMap = mock[CacheMap]
-
-      when(mockCacheMap.getEntry[BusinessMatching](BusinessMatching.key))
-        .thenReturn(Some(BusinessMatching(None, Some(BusinessActivitiesModel))))
-
-      when(controller.dataCacheConnector.fetchAll(any())(any()))
-        .thenReturn(Future.successful(Some(mockCacheMap)))
-
-      when(controller.dataCacheConnector.fetch[Seq[TradingPremises]](any(), any())(any(), any()))
-        .thenReturn(Future.successful(None))
-
-      when(controller.dataCacheConnector.save[Seq[TradingPremises]](any(),any(), any())( any(), any()))
-        .thenReturn(Future.successful(emptyCache))
+      when(controller.tradingPremisesService.addTradingPremises(any(), any())(any(), any(), any(), any()))
+        .thenReturn(Future.successful(1))
 
       val result = controller.get(true)(request)
+
       status(result) must be(SEE_OTHER)
       redirectLocation(result) must be(Some(routes.WhatYouNeedController.get(1).url))
     }
@@ -73,7 +63,6 @@ class TradingPremisesAddControllerSpec extends AmlsSpec with ScalaCheckPropertyC
 
       val BusinessActivitiesModel = BusinessActivities(Set(TrustAndCompanyServices, TelephonePaymentService))
       val mockCacheMap = mock[CacheMap]
-
 
       when(mockCacheMap.getEntry[Seq[TradingPremises]](any())(any()))
         .thenReturn(Some(Seq(TradingPremises(), TradingPremises())))
@@ -89,6 +78,9 @@ class TradingPremisesAddControllerSpec extends AmlsSpec with ScalaCheckPropertyC
 
       when(controller.dataCacheConnector.save[Seq[TradingPremises]](any(), any(), any())(any(), any()))
         .thenReturn(Future.successful(emptyCache))
+
+      when(controller.tradingPremisesService.addTradingPremises(any(), any())(any(), any(), any(), any()))
+        .thenReturn(Future.successful(1))
 
       val result = controller.get(false)(request)
       status(result) must be(SEE_OTHER)
@@ -116,6 +108,9 @@ class TradingPremisesAddControllerSpec extends AmlsSpec with ScalaCheckPropertyC
       when(controller.dataCacheConnector.save[Seq[TradingPremises]](any(), any(), any())(any(), any()))
         .thenReturn(Future.successful(emptyCache))
 
+      when(controller.tradingPremisesService.addTradingPremises(any(), any())(any(), any(), any(), any()))
+        .thenReturn(Future.successful(1))
+
       val result = controller.get(false)(request)
       status(result) must be(SEE_OTHER)
       redirectLocation(result) must be(Some(routes.ConfirmAddressController.get(1).url))
@@ -137,6 +132,9 @@ class TradingPremisesAddControllerSpec extends AmlsSpec with ScalaCheckPropertyC
 
       when(controller.dataCacheConnector.save[Seq[TradingPremises]](any(), any(), any())(any(), any()))
         .thenReturn(Future.successful(emptyCache))
+
+      when(controller.tradingPremisesService.addTradingPremises(any(), any())(any(), any(), any(), any()))
+        .thenReturn(Future.successful(1))
 
       val result = controller.get(false)(request)
       status(result) must be(SEE_OTHER)

--- a/test/generators/tradingpremises/TradingPremisesGenerator.scala
+++ b/test/generators/tradingpremises/TradingPremisesGenerator.scala
@@ -97,4 +97,5 @@ trait TradingPremisesGenerator extends BaseGenerator with BusinessActivitiesGene
     tp <- tradingPremisesGen
   } yield tp.copy(whatDoesYourBusinessDoAtThisAddress = Some(WhatDoesYourBusinessDo(activities.toSet)))
 
+  val emptyTradingPremises = TradingPremises(None, None, None, None, None, None, None, None, false, None, None, None, None, None, false)
 }

--- a/test/models/tradingpremises/TradingPremisesSpec.scala
+++ b/test/models/tradingpremises/TradingPremisesSpec.scala
@@ -16,6 +16,7 @@
 
 package models.tradingpremises
 
+import generators.tradingpremises.TradingPremisesGenerator
 import models.businessmatching.BusinessActivity._
 import models.registrationprogress._
 import models.tradingpremises.BusinessStructure._
@@ -23,11 +24,12 @@ import models.tradingpremises.TradingPremisesMsbService._
 import org.joda.time.LocalDate
 import org.mockito.Matchers.{eq => meq, _}
 import org.mockito.Mockito._
+import org.scalacheck.Gen
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.cache.client.CacheMap
 import utils.{AmlsSpec, StatusConstants}
 
-class TradingPremisesSpec extends AmlsSpec {
+class TradingPremisesSpec extends AmlsSpec with TradingPremisesGenerator {
 
   val ytp = YourTradingPremises(
     "foo",
@@ -229,7 +231,7 @@ class TradingPremisesSpec extends AmlsSpec {
             completeModel.copy(status = Some(StatusConstants.Deleted), hasChanged = true, hasAccepted = true),
             TradingPremises(Some(RegisteringAgentPremises(true)), None, hasAccepted = true)
           )))
-        
+
         val taskRow = TradingPremises.taskRow(mockCacheMap, messages)
 
         taskRow.hasChanged must be(true)
@@ -357,6 +359,23 @@ class TradingPremisesSpec extends AmlsSpec {
       "at least one BankDetails within the sequence has changed" in {
         val res = TradingPremises.anyChanged(originalBankDetailsChanged)
         res must be(true)
+      }
+    }
+  }
+
+  "notEmpty" must {
+    "return false" when {
+      "Trading premises only contains a Line ID, Removal Reason & Status" in {
+        val tradingPremises = TradingPremises(None, None, None, None, None, None, None, None, false, Some(1),
+          Some("status"), None, Some("removal reason"), None, false)
+
+        tradingPremises.notEmpty mustBe false
+      }
+    }
+
+    "return true" when {
+      "Trading premises contains data" in {
+        Gen.listOfN(1000, fullTradingPremisesGen).sample.filter(_.nonEmpty)
       }
     }
   }

--- a/test/services/businessmatching/TradingPremisesServiceSpec.scala
+++ b/test/services/businessmatching/TradingPremisesServiceSpec.scala
@@ -22,13 +22,18 @@ import models.businessmatching.BusinessActivity._
 import models.businessmatching.BusinessMatchingMsbService.{ChequeCashingNotScrapMetal, ChequeCashingScrapMetal}
 import models.tradingpremises.TradingPremisesMsbServices._
 import models.businessmatching.{BusinessMatchingMsbServices => BMMsbServices}
-import models.tradingpremises.{WhatDoesYourBusinessDo, TradingPremisesMsbServices => TPMsbServices}
+import models.tradingpremises.{TradingPremises, WhatDoesYourBusinessDo, TradingPremisesMsbServices => TPMsbServices}
 import org.joda.time.LocalDate
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import services.TradingPremisesService
+import uk.gov.hmrc.http.cache.client.CacheMap
 import utils.{AmlsSpec, DependencyMocks, FutureAssertions, StatusConstants}
+
+import scala.concurrent.Future
 
 class TradingPremisesServiceSpec extends PlaySpec
   with AmlsSpec
@@ -38,9 +43,7 @@ class TradingPremisesServiceSpec extends PlaySpec
   with TradingPremisesGenerator {
 
   trait Fixture extends DependencyMocks {
-
-    val service = new TradingPremisesService()
-
+    val service = new TradingPremisesService(mockCacheConnector)
   }
 
   "addBusinessActivitiesToTradingPremises" must {
@@ -189,4 +192,25 @@ class TradingPremisesServiceSpec extends PlaySpec
     }
   }
 
+  "Add Trading Premises" must {
+    "Add a non-empty trading premises" in new Fixture {
+      val tradingPremises = fullTradingPremisesGen.sample.get
+      when(mockCacheConnector.fetch[Seq[TradingPremises]](any(), any())(any(), any())).thenReturn(Future.successful(Some(Seq.empty[TradingPremises])))
+      when(mockCacheConnector.save(any(), any(), any())(any(), any())).thenReturn(Future.successful(mockCacheMap))
+
+      val index = service.addTradingPremises("123546", tradingPremises)
+
+      index.futureValue mustBe 1
+    }
+
+    "Not add a newly started empty trading premises" in new Fixture {
+      val tradingPremises = fullTradingPremisesGen.sample.get
+      when(mockCacheConnector.fetch[Seq[TradingPremises]](any(), any())(any(), any())).thenReturn(Future.successful(Some(Seq(tradingPremises))))
+      when(mockCacheConnector.save(any(), any(), any())(any(), any())).thenReturn(Future.successful(mockCacheMap))
+
+      val index = service.addTradingPremises("123456", emptyTradingPremises)
+
+      index.futureValue mustBe 1
+    }
+  }
 }


### PR DESCRIPTION
Added addTradingPremisesFunction in TradingPremisesService that doesn't allow empty trading premises to be added to the database.

Added notEmpty function in TradingPremises that determines whether a trading premises is empty or not

TradingPremisesAddController now uses the service rather than RepeatingSection to add a trading premises

Added tests for the above.