### PR TITLE
DDCYLS-4184 Tweak to disable button JS event handler

### DIFF
--- a/app/views/declaration/DeclareView.scala.html
+++ b/app/views/declaration/DeclareView.scala.html
@@ -53,8 +53,8 @@
         <li>@messages("declaration.declaration.confirm") <a href="https://www.gov.uk/government/collections/anti-money-laundering-businesses-supervised-by-hm-revenue-and-customs">@messages("declaration.declaration.guidance")</a></li>
     </ul>
 
-    @formHelper(action = controllers.routes.SubmissionController.post()) {
-        @button(messages("button.acceptandsubmit"), "confirm-continue", attributes = Map("disable-on-submit" -> "true"))
+    @formHelper(action = controllers.routes.SubmissionController.post(), Symbol("disable-on-submit") -> "true") {
+        @button(messages("button.acceptandsubmit"), "confirm-continue")
     }
 
 }

--- a/app/views/deregister/DeregistrationReasonView.scala.html
+++ b/app/views/deregister/DeregistrationReasonView.scala.html
@@ -75,7 +75,7 @@
 
     @subtitle("summary.status")
 
-    @formHelper(controllers.deregister.routes.DeregistrationReasonController.post) {
+    @formHelper(controllers.deregister.routes.DeregistrationReasonController.post, Symbol("disable-on-submit") -> "true") {
 
         @radios(
             Radios(
@@ -92,6 +92,6 @@
             ).withFormField(form("deregistrationReason"))
         )
 
-        @button("status.deregister.button-text", attributes = Map("disable-on-submit" -> "true"))
+        @button("status.deregister.button-text")
     }
 }

--- a/app/views/withdrawal/WithdrawalReasonView.scala.html
+++ b/app/views/withdrawal/WithdrawalReasonView.scala.html
@@ -64,7 +64,7 @@
 
     @subtitle("summary.status")
 
-    @formHelper(controllers.withdrawal.routes.WithdrawalReasonController.post) {
+    @formHelper(controllers.withdrawal.routes.WithdrawalReasonController.post, Symbol("disable-on-submit") -> "true") {
 
         @radios(
             Radios(
@@ -81,6 +81,6 @@
             ).withFormField(form("withdrawalReason"))
         )
 
-        @button("withdrawal.reason.lbl.button", attributes = Map("disable-on-submit" -> "true"))
+        @button("withdrawal.reason.lbl.button")
     }
 }

--- a/public/submitButtonDisable.js
+++ b/public/submitButtonDisable.js
@@ -1,7 +1,10 @@
-let button = document.querySelector('[disable-on-submit="true"]')
-if(button !== null) {
-    button.addEventListener('click', function () {
-        button.setAttribute('disabled', '')
-        button.setAttribute('aria-disabled', 'true')
+let form = document.querySelector('[disable-on-submit="true"]')
+if(form !== null) {
+    form.addEventListener('submit', function () {
+        let button = document.querySelector('form > .govuk-button')
+        if(button != null) {
+            button.setAttribute('disabled', '')
+            button.setAttribute('aria-disabled', 'true')
+        }
     })
 }

--- a/test/views/declaration/DeclareViewSpec.scala
+++ b/test/views/declaration/DeclareViewSpec.scala
@@ -75,10 +75,10 @@ class DeclareViewSpec extends AmlsViewSpec with MustMatchers  {
       doc.select(".govuk-warning-text__text").text() must include(messages("declaration.declaration.fullname", name))
     }
 
-    "have a button with the disable-on-submit attribute" in new ViewFixture {
+    "have a form with the disable-on-submit attribute" in new ViewFixture {
       def view = declare("string1", "string2", "Name", isAmendment = false)
       
-      doc.select("button").attr("disable-on-submit") mustBe "true"
+      doc.select("form").attr("disable-on-submit") mustBe "true"
     }
 
     behave like pageWithBackLink(declare("string1", "string2", "John Smith", isAmendment = false))

--- a/test/views/deregister/DeregistrationReasonViewSpec.scala
+++ b/test/views/deregister/DeregistrationReasonViewSpec.scala
@@ -79,10 +79,10 @@ class DeregistrationReasonViewSpec extends AmlsViewSpec with MustMatchers  {
 
     }
 
-    "have a button with the disable-on-submit attribute" in new TestFixture {
+    "have a form with the disable-on-submit attribute" in new TestFixture {
       def view = deregistration_reason(fp())
 
-      doc.select("button").attr("disable-on-submit") mustBe "true"
+      doc.select("form").attr("disable-on-submit") mustBe "true"
     }
 
     behave like pageWithErrors(

--- a/test/views/withdrawal/WithdrawalReasonViewSpec.scala
+++ b/test/views/withdrawal/WithdrawalReasonViewSpec.scala
@@ -60,10 +60,10 @@ class WithdrawalReasonViewSpec extends AmlsViewSpec with MustMatchers {
       doc.getElementsByAttributeValue("name", "specifyOtherReason") must not be empty
     }
 
-    "have a button with the disable-on-submit attribute" in new TestFixture {
+    "have a form with the disable-on-submit attribute" in new TestFixture {
       def view = withdrawal_reason(fp())
 
-      doc.select("button").attr("disable-on-submit") mustBe "true"
+      doc.select("form").attr("disable-on-submit") mustBe "true"
     }
 
     behave like pageWithErrors(


### PR DESCRIPTION
The attribute is now added to the form instead of the button, and the JS is triggered by the form's submit event.