### PR TITLE
DDCYLS-4086 Adding govuk-link class to anchor tags

### DIFF
--- a/app/views/Start.scala.html
+++ b/app/views/Start.scala.html
@@ -48,7 +48,7 @@
 
     <a class="govuk-link" href="https://www.gov.uk/topic/business-tax/money-laundering-regulations">@messages("")</a>
 
-    <p class="govuk-body">@messages("start.line.9") <a href="https://www.gov.uk/topic/business-tax/money-laundering-regulations">@Messages("start.line.9.middle")</a> @Messages("start.line.9.end")</p>
-    <p class="govuk-body">@messages("start.line.10") <a href="https://www.gov.uk/guidance/money-laundering-regulations-registration-fees">@Messages("start.line.10.middle")</a>@Messages("full.stop")</p>
+    <p class="govuk-body">@messages("start.line.9") <a class="govuk-link" href="https://www.gov.uk/topic/business-tax/money-laundering-regulations">@Messages("start.line.9.middle")</a> @Messages("start.line.9.end")</p>
+    <p class="govuk-body">@messages("start.line.10") <a class="govuk-link" href="https://www.gov.uk/guidance/money-laundering-regulations-registration-fees">@Messages("start.line.10.middle")</a>@Messages("full.stop")</p>
     <p class="govuk-body">@messages("start.line.11")</p>
 }

--- a/app/views/UnauthorisedView.scala.html
+++ b/app/views/UnauthorisedView.scala.html
@@ -31,7 +31,7 @@
 
     <p class="govuk-body">@messages("unauthorised.text1")</p>
     <p class="govuk-body">@messages("unauthorised.text2")
-        <a id="register-link" href="@appConfig.registerNewOrgLink">@messages("unauthorised.register.link.text")</a>
+        <a id="register-link" class="govuk-link" href="@appConfig.registerNewOrgLink">@messages("unauthorised.register.link.text")</a>
     </p>
 
     <!-- This should log you out and then take you back to the sign in page for Gov Gateway -->

--- a/app/views/bankdetails/YourBankAccountsView.scala.html
+++ b/app/views/bankdetails/YourBankAccountsView.scala.html
@@ -95,13 +95,13 @@
                         @bankAccount(bankDetail)
                     </dt>
                     <dd id="incomplete-action-panel-@index" class="hmrc-add-to-a-list__change">
-                        <a id="incomplete-detail-edit-@index" href="@controllers.bankdetails.routes.BankAccountNameController.getIndex(index + 1).url">
+                        <a id="incomplete-detail-edit-@index" class="govuk-link" href="@controllers.bankdetails.routes.BankAccountNameController.getIndex(index + 1).url">
                             <span aria-hidden="true">@messages("bankdetails.yourbankaccount.edit")</span>
                             <span hidden>@messages("bankdetails.yourbankaccount.edit") @bankDetail.accountName</span>
                         </a>
                     </dd>
                     <dd class="hmrc-add-to-a-list__remove">
-                        <a id="incomplete-detail-remove-@index" href="@controllers.bankdetails.routes.RemoveBankDetailsController.get(index + 1).url">
+                        <a id="incomplete-detail-remove-@index" class="govuk-link" href="@controllers.bankdetails.routes.RemoveBankDetailsController.get(index + 1).url">
                             <span aria-hidden="true">@messages("bankdetails.yourbankaccount.remove")</span>
                             <span hidden>@messages("bankdetails.yourbankaccount.remove") @bankDetail.accountName</span>
                         </a>
@@ -125,7 +125,7 @@
                             @bankAccount(bankDetail)
                         </dt>
                         <dd id="completed-action-panel-@index" class="hmrc-add-to-a-list__remove">
-                            <a id="completed-detail-remove-@index" href="@controllers.bankdetails.routes.RemoveBankDetailsController.get(index + 1).url">
+                            <a id="completed-detail-remove-@index" class="govuk-link" href="@controllers.bankdetails.routes.RemoveBankDetailsController.get(index + 1).url">
                                 <span aria-hidden="true">@messages("bankdetails.yourbankaccount.remove")</span>
                                 <span hidden>@messages("bankdetails.yourbankaccount.remove") @bankDetail.accountName</span>
                             </a>

--- a/app/views/components/Anchor.scala.html
+++ b/app/views/components/Anchor.scala.html
@@ -18,4 +18,4 @@
 
 @(text: String, href: String, id: String, attributes: Map[String, String] = Map.empty)(implicit messages: Messages)
 
-<a href="@href" id="@id" @attributes.map(set => s"${set._1}=${set._2}").mkString(" ")>@messages(text)</a>
+<a href="@href" class="govuk-link" id="@id" @attributes.map(set => s"${set._1}=${set._2}").mkString(" ")>@messages(text)</a>

--- a/app/views/components/ReturnLink.scala.html
+++ b/app/views/components/ReturnLink.scala.html
@@ -21,9 +21,9 @@
 @if(returnLink) {
     <p class="govuk-body">
         @if(returnLocation == Some("renewal")) {
-        <a id="return-to-application" href="@controllers.renewal.routes.RenewalProgressController.get.url">@messages("link.return.renewal.progress")</a>
+        <a id="return-to-application" class="govuk-link" href="@controllers.renewal.routes.RenewalProgressController.get.url">@messages("link.return.renewal.progress")</a>
         } else {
-        <a id="return-to-application" href="@controllers.routes.RegistrationProgressController.get.url">@messages("link.return.registration.progress")</a>
+        <a id="return-to-application" class="govuk-link" href="@controllers.routes.RegistrationProgressController.get.url">@messages("link.return.registration.progress")</a>
         }
     </p>
 }

--- a/app/views/components/ServicesSidebar.scala.html
+++ b/app/views/components/ServicesSidebar.scala.html
@@ -54,7 +54,7 @@
 
             @if(displayLink) {
                 <p class="govuk-body sidebar-top-spacing">
-                    <a id="view-details" href="@controllers.businessmatching.routes.SummaryController.get.url" class="edit-preapp">
+                    <a id="view-details" href="@controllers.businessmatching.routes.SummaryController.get.url" class="edit-preapp govuk-link">
                         @(if(canEditPreApplication) messages("progress.preapplication.canedit") else messages("progress.preapplication.readonly"))
                     </a>
                 </p>

--- a/app/views/components/TaskRowComponent.scala.html
+++ b/app/views/components/TaskRowComponent.scala.html
@@ -37,7 +37,7 @@
 
 <li id="@sectionName.replaceAll(" ", "-").toLowerCase.concat("-status")" class="app-task-list__item">
     <span class="app-task-list__task-name">
-        <a href="@taskRow.href">@messageAndTag._1</a>
+        <a class="govuk-link" href="@taskRow.href">@messageAndTag._1</a>
     </span>
     <span hidden class="task-status">
         @messages("status.visuallyhidden.text")

--- a/app/views/components/TaskRowWithUpdateComponent.scala.html
+++ b/app/views/components/TaskRowWithUpdateComponent.scala.html
@@ -40,7 +40,7 @@
 
 <li id="@sectionName.replaceAll(" ", "-").toLowerCase.concat("-status")" class="app-task-list__item">
     <span class="app-task-list__task-name">
-        <a href="@taskRow.href">@message</a>
+        <a class="govuk-link" href="@taskRow.href">@message</a>
     </span>
     <span hidden class="task-status">
     @messages("status.visuallyhidden.text")

--- a/app/views/declaration/DeclareView.scala.html
+++ b/app/views/declaration/DeclareView.scala.html
@@ -50,7 +50,7 @@
         }
         <li>@messages("declaration.declaration.tellhmrc")</li>
         <li>@messages("declaration.declaration.noncompliance")</li>
-        <li>@messages("declaration.declaration.confirm") <a href="https://www.gov.uk/government/collections/anti-money-laundering-businesses-supervised-by-hm-revenue-and-customs">@messages("declaration.declaration.guidance")</a></li>
+        <li>@messages("declaration.declaration.confirm") <a class="govuk-link" href="https://www.gov.uk/government/collections/anti-money-laundering-businesses-supervised-by-hm-revenue-and-customs">@messages("declaration.declaration.guidance")</a></li>
     </ul>
 
     @formHelper(action = controllers.routes.SubmissionController.post(), Symbol("disable-on-submit") -> "true") {

--- a/app/views/notifications/v1m0/MindedToRejectView.scala.html
+++ b/app/views/notifications/v1m0/MindedToRejectView.scala.html
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-m">Reason for considering refusal</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     <h2 class="govuk-heading-m">If you disagree with this decision</h2>
     <p class="govuk-body">You have 30 days to provide reasons why you disagree with this decision. Write to:</p>

--- a/app/views/notifications/v1m0/MindedToRevokeView.scala.html
+++ b/app/views/notifications/v1m0/MindedToRevokeView.scala.html
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-m">Reason for considering refusal</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     <h2 class="govuk-heading-m">If you disagree with this decision</h2>
     <p class="govuk-body">You have 30 days to provide reasons why you disagree with this decision. Write to:</p>

--- a/app/views/notifications/v1m0/RejectionReasonsView.scala.html
+++ b/app/views/notifications/v1m0/RejectionReasonsView.scala.html
@@ -47,7 +47,7 @@
     <h2 class="govuk-heading-m">Reason for refusal</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     <h2 class="govuk-heading-m">If you disagree with this decision</h2>
     <p class="govuk-body">You can ask for a review of this decision by writing to:</p>

--- a/app/views/notifications/v1m0/RevocationReasonsView.scala.html
+++ b/app/views/notifications/v1m0/RevocationReasonsView.scala.html
@@ -47,7 +47,7 @@
     <h2 class="govuk-heading-m">Reason for revocation</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     <h2 class="govuk-heading-m">If you disagree with this decision</h2>
     <p class="govuk-body">You can ask for a review of this decision by writing to:</p>
@@ -63,7 +63,7 @@
 
     <p class="govuk-body">You should explain why you disagree with the decision, with reference to the regulations.</p>
 
-    <p class="govuk-body">You can also <a href="@appConfig.tribunalLink">appeal to an independent tribunal</a>.</p>
+    <p class="govuk-body">You can also <a class="govuk-link" href="@appConfig.tribunalLink">appeal to an independent tribunal</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v2m0/MindedToRejectView.scala.html
+++ b/app/views/notifications/v2m0/MindedToRejectView.scala.html
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-m">Reason for considering refusal</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     <h2 class="govuk-heading-m">If you disagree with this decision</h2>
     <p class="govuk-body">You have 30 days to provide reasons why you disagree with this decision. Write to:</p>

--- a/app/views/notifications/v2m0/MindedToRevokeView.scala.html
+++ b/app/views/notifications/v2m0/MindedToRevokeView.scala.html
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-m">Reason for considering refusal</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     <h2 class="govuk-heading-m">If you disagree with this decision</h2>
     <p class="govuk-body">You have 30 days to provide reasons why you disagree with this decision. Write to:</p>

--- a/app/views/notifications/v2m0/RejectionReasonsView.scala.html
+++ b/app/views/notifications/v2m0/RejectionReasonsView.scala.html
@@ -48,7 +48,7 @@
     <h2 class="govuk-heading-m">Reason for refusal</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     <h2 class="govuk-heading-m">If you disagree with this decision</h2>
     <p class="govuk-body">You can ask for a review of this decision by writing to:</p>
@@ -64,7 +64,7 @@
 
     <p class="govuk-body">You should explain why you disagree with the decision, with reference to the regulations.</p>
 
-    <p class="govuk-body">You can also <a href="@appConfig.tribunalLink">appeal to an independent tribunal</a>.</p>
+    <p class="govuk-body">You can also <a class="govuk-link" href="@appConfig.tribunalLink">appeal to an independent tribunal</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v2m0/RevocationReasonsView.scala.html
+++ b/app/views/notifications/v2m0/RevocationReasonsView.scala.html
@@ -47,7 +47,7 @@
     <h2 class="govuk-heading-m">Reason for revocation</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     <h2 class="govuk-heading-m">If you disagree with this decision</h2>
     <p class="govuk-body">You can ask for a review of this decision by writing to:</p>
@@ -63,7 +63,7 @@
 
     <p class="govuk-body">You should explain why you disagree with the decision, with reference to the regulations.</p>
 
-    <p class="govuk-body">You can also <a href="@appConfig.tribunalLink">appeal to an independent tribunal</a>.</p>
+    <p class="govuk-body">You can also <a class="govuk-link" href="@appConfig.tribunalLink">appeal to an independent tribunal</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v3m0/MindedToRejectView.scala.html
+++ b/app/views/notifications/v3m0/MindedToRejectView.scala.html
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-m">Reason for considering refusal</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v3m0/MindedToRevokeView.scala.html
+++ b/app/views/notifications/v3m0/MindedToRevokeView.scala.html
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-m">Reason for considering refusal</h2>
     <p class="govuk-body">@Html(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v3m0/RejectionReasonsView.scala.html
+++ b/app/views/notifications/v3m0/RejectionReasonsView.scala.html
@@ -47,7 +47,7 @@
     <h2 class="govuk-heading-m">Reason for refusal</h2>
     <p class="govuk-body">@Html(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v3m0/RevocationReasonsView.scala.html
+++ b/app/views/notifications/v3m0/RevocationReasonsView.scala.html
@@ -47,7 +47,7 @@
     <h2 class="govuk-heading-m">Reason for revocation</h2>
     <p class="govuk-body">@Html(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v4m0/MindedToRejectView.scala.html
+++ b/app/views/notifications/v4m0/MindedToRejectView.scala.html
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-m">Reason for considering refusal</h2>
     <p class="govuk-body">@Html(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v4m0/MindedToRevokeView.scala.html
+++ b/app/views/notifications/v4m0/MindedToRevokeView.scala.html
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-m">Reason for considering refusal</h2>
     <p class="govuk-body">@Html(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v4m0/RejectionReasonsView.scala.html
+++ b/app/views/notifications/v4m0/RejectionReasonsView.scala.html
@@ -47,7 +47,7 @@
     <h2 class="govuk-heading-m">Reason for refusal</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v4m0/RevocationReasonsView.scala.html
+++ b/app/views/notifications/v4m0/RevocationReasonsView.scala.html
@@ -47,7 +47,7 @@
     <h2 class="govuk-heading-m">Reason for revocation</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v5m0/MindedToRejectView.scala.html
+++ b/app/views/notifications/v5m0/MindedToRejectView.scala.html
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-m">Reason for considering refusal</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v5m0/MindedToRevokeView.scala.html
+++ b/app/views/notifications/v5m0/MindedToRevokeView.scala.html
@@ -44,7 +44,7 @@
     <h2 class="govuk-heading-m">Reason for considering refusal</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v5m0/RejectionReasonsView.scala.html
+++ b/app/views/notifications/v5m0/RejectionReasonsView.scala.html
@@ -47,7 +47,7 @@
     <h2 class="govuk-heading-m">Reason for refusal</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/notifications/v5m0/RevocationReasonsView.scala.html
+++ b/app/views/notifications/v5m0/RevocationReasonsView.scala.html
@@ -47,7 +47,7 @@
     <h2 class="govuk-heading-m">Reason for revocation</h2>
     <p class="govuk-body">@HtmlFormat.raw(notificationParams.msgContent)</p>
 
-    <p class="govuk-body">You can view the regulations at <a href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
+    <p class="govuk-body">You can view the regulations at <a class="govuk-link" href="@appConfig.legislationLink">www.legislation.gov.uk</a>.</p>
 
     @backLink()
 }

--- a/app/views/responsiblepeople/CheckYourAnswersView.scala.html
+++ b/app/views/responsiblepeople/CheckYourAnswersView.scala.html
@@ -45,7 +45,7 @@
     @if(showHide) {
         <div class="govuk-inset-text">
             <p class="govuk-body">
-                <a href="@controllers.responsiblepeople.address.routes.NewHomeAddressDateOfChangeController.get(index)">
+                <a class="govuk-link" href="@controllers.responsiblepeople.address.routes.NewHomeAddressDateOfChangeController.get(index)">
                     @messages("responsiblepeople.detailed_answer.tell.us.moved", personName)
                 </a>
             </p>

--- a/app/views/responsiblepeople/YourResponsiblePeopleView.scala.html
+++ b/app/views/responsiblepeople/YourResponsiblePeopleView.scala.html
@@ -50,7 +50,7 @@
         <li>@messages("responsiblepeople.whomustregister.line_5")</li>
     </ul>
 
-    <p class="govuk-body"><a id="addResponsiblePerson" href="@controllers.responsiblepeople.routes.ResponsiblePeopleAddController.get(false)">@messages("responsiblepeople.check_your_answers.add")</a></p>
+    <p class="govuk-body"><a id="addResponsiblePerson" class="govuk-link" href="@controllers.responsiblepeople.routes.ResponsiblePeopleAddController.get(false)">@messages("responsiblepeople.check_your_answers.add")</a></p>
 
     @if(responsiblePeopleIncomplete.nonEmpty) {
         <h2 id="incomplete-header" class="govuk-heading-m">@messages("responsiblepeople.check_your_answers.incomplete")</h2>
@@ -63,14 +63,14 @@
                         @rpDetail(rp)
                     </dt>
                     <dd id="incomplete-action-panel-@index" class="hmrc-add-to-a-list__change">
-                        <a id="detail-edit-@index" href="@controllers.responsiblepeople.routes.PersonNameController.get(index + 1, false, None).url">
+                        <a id="detail-edit-@index" class="govuk-link" href="@controllers.responsiblepeople.routes.PersonNameController.get(index + 1, false, None).url">
                             <span aria-hidden="true">@messages("button.edit")</span>
                             <span hidden>@messages("button.edit") @rpDetail(rp)</span>
                         </a>
                     </dd>
 
                     <dd class="hmrc-add-to-a-list__remove">
-                        <a id="detail-remove-@index" href="@controllers.responsiblepeople.routes.RemoveResponsiblePersonController.get(index + 1).url">
+                        <a id="detail-remove-@index" class="govuk-link" href="@controllers.responsiblepeople.routes.RemoveResponsiblePersonController.get(index + 1).url">
                             <span aria-hidden="true">@messages("button.remove")</span>
                             <span hidden>@messages("button.remove") @rpDetail(rp)</span>
                         </a>
@@ -94,13 +94,13 @@
                         @rpDetail(rp)
                     </dt>
                     <dd id="incomplete-action-panel-@index" class="hmrc-add-to-a-list__change">
-                        <a id="detail-edit-@index" href="@controllers.responsiblepeople.routes.DetailedAnswersController.get(index + 1).url">
+                        <a id="detail-edit-@index" class="govuk-link" href="@controllers.responsiblepeople.routes.DetailedAnswersController.get(index + 1).url">
                             <span aria-hidden="true">@messages("button.edit")</span>
                             <span class=hidden>@messages("button.edit") @rpDetail(rp)</span>
                         </a>
                     </dd>
                     <dd class="hmrc-add-to-a-list__remove">
-                        <a id="detail-remove-@index" href="@controllers.responsiblepeople.routes.RemoveResponsiblePersonController.get(index + 1).url">
+                        <a id="detail-remove-@index" class="govuk-link" href="@controllers.responsiblepeople.routes.RemoveResponsiblePersonController.get(index + 1).url">
                             <span aria-hidden="true">@messages("button.remove")</span>
                             <span hidden>@messages("button.remove") @rpDetail(rp)</span>
                         </a>

--- a/app/views/submission/BadRequestView.scala.html
+++ b/app/views/submission/BadRequestView.scala.html
@@ -38,6 +38,6 @@
     <p class="govuk-body">@messages("error.submission.badrequest.content.line3")</p>
 
     <p class="govuk-body">
-        <a id="report-link" href="@linkHref">@messages("error.submission.duplicate_submission.link.text")</a>
+        <a id="report-link" class="govuk-link" href="@linkHref">@messages("error.submission.duplicate_submission.link.text")</a>
     </p>
 }

--- a/app/views/submission/DuplicateEnrolmentView.scala.html
+++ b/app/views/submission/DuplicateEnrolmentView.scala.html
@@ -37,6 +37,6 @@
     <p class="govuk-body">@messages("error.submission.duplicate_enrolment.content.line2")</p>
 
     <p class="govuk-body">
-        <a id="report-link" href="@linkHref">@messages("error.submission.duplicate_enrolment.link.text")</a>
+        <a id="report-link" class="govuk-link" href="@linkHref">@messages("error.submission.duplicate_enrolment.link.text")</a>
     </p>
 }

--- a/app/views/submission/DuplicateSubmissionView.scala.html
+++ b/app/views/submission/DuplicateSubmissionView.scala.html
@@ -37,6 +37,6 @@
     <p class="govuk-body">@messages("error.submission.duplicate_submission.content.line2")</p>
 
     <p class="govuk-body">
-        <a id="report-link" href="@linkHref">@messages("error.submission.duplicate_submission.link.text")</a>
+        <a id="report-link" class="govuk-link" href="@linkHref">@messages("error.submission.duplicate_submission.link.text")</a>
     </p>
 }

--- a/app/views/submission/WrongCredentialTypeView.scala.html
+++ b/app/views/submission/WrongCredentialTypeView.scala.html
@@ -38,6 +38,6 @@
     <p class="govuk-body">@messages("error.submission.wrong_credentials.content.line3")</p>
 
     <p class="govuk-body">
-        <a id="report-link" href="@linkHref">@messages("error.submission.duplicate_submission.link.text")</a>
+        <a id="report-link" class="govuk-link" href="@linkHref">@messages("error.submission.duplicate_submission.link.text")</a>
     </p>
 }

--- a/app/views/tradingpremises/YourTradingPremisesView.scala.html
+++ b/app/views/tradingpremises/YourTradingPremisesView.scala.html
@@ -51,7 +51,7 @@
 
     <p class="govuk-body">@messages("tradingpremises.yourpremises.line_2")</p>
 
-    <p class="govuk-body"><a id="addTradingPremises" href="@controllers.tradingpremises.routes.TradingPremisesAddController.get(true)">@messages("tradingpremises.summary.addanother")</a></p>
+    <p class="govuk-body"><a id="addTradingPremises" class="govuk-link" href="@controllers.tradingpremises.routes.TradingPremisesAddController.get(true)">@messages("tradingpremises.summary.addanother")</a></p>
 
     @if(completeTp.isEmpty & incompleteTp.isEmpty) {
         <p class="govuk-body">@messages("tradingpremises.yourpremises.line_3")</p>
@@ -68,13 +68,13 @@
                     @tpDetail(tp)
                     </dt>
                     <dd id="incomplete-action-panel-@index" class="hmrc-add-to-a-list__change">
-                        <a id="detail-edit-@index" href="@controllers.tradingpremises.routes.YourTradingPremisesController.getIndividual(index + 1, true).url">
+                        <a id="detail-edit-@index" class="govuk-link" href="@controllers.tradingpremises.routes.YourTradingPremisesController.getIndividual(index + 1, true).url">
                             <span aria-hidden="true">@messages("button.edit")</span>
                             <span hidden>@messages("button.edit") @tpDetail(tp)</span>
                         </a>
                     </dd>
                     <dd class="hmrc-add-to-a-list__remove">
-                        <a id="detail-remove-@index" href="@tp.removeUrl(index + 1, add, status)">
+                        <a id="detail-remove-@index" class="govuk-link" href="@tp.removeUrl(index + 1, add, status)">
                             <span aria-hidden="true">@messages("button.remove")</span>
                             <span hidden>@messages("button.remove") @tpDetail(tp)</span>
                         </a>
@@ -98,13 +98,13 @@
                     @tpDetail(tp)
                     </dt>
                     <dd id="incomplete-action-panel-@index" class="hmrc-add-to-a-list__change">
-                        <a id="detail-edit-@index" href="@controllers.tradingpremises.routes.CheckYourAnswersController.get(index + 1).url">
+                        <a id="detail-edit-@index" class="govuk-link" href="@controllers.tradingpremises.routes.CheckYourAnswersController.get(index + 1).url">
                             <span aria-hidden="true">@messages("button.edit")</span>
                             <span hidden>@messages("button.edit") @tpDetail(tp)</span>
                         </a>
                     </dd>
                     <dd class="hmrc-add-to-a-list__remove">
-                        <a id="detail-remove-@index" href="@tp.removeUrl(index + 1, add, status)">
+                        <a id="detail-remove-@index" class="govuk-link" href="@tp.removeUrl(index + 1, add, status)">
                             <span aria-hidden="true">@messages("button.remove")</span>
                             <span hidden>@messages("button.remove") @tpDetail(tp)</span>
                         </a>

--- a/test/views/StartViewSpec.scala
+++ b/test/views/StartViewSpec.scala
@@ -55,8 +55,8 @@ class StartViewSpec extends AmlsViewSpec with MustMatchers {
       doc.getElementById("button").text() mustBe "Sign in"
       doc.getElementsByClass("govuk-heading-m").text() mustBe "Before you start"
 
-      html must include("Check our <a href=\"https://www.gov.uk/topic/business-tax/money-laundering-regulations\">Money Laundering Regulations guidance</a> before applying to register.")
-      html must include("Check <a href=\"https://www.gov.uk/guidance/money-laundering-regulations-registration-fees\">fees for anti-money laundering supervision</a>.")
+      html must include("Check our <a class=\"govuk-link\" href=\"https://www.gov.uk/topic/business-tax/money-laundering-regulations\">Money Laundering Regulations guidance</a> before applying to register.")
+      html must include("Check <a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/money-laundering-regulations-registration-fees\">fees for anti-money laundering supervision</a>.")
       html must include("You should sign out when leaving the service.")
     }
 


### PR DESCRIPTION
Adding the `govuk-link` class to anchor tags in the code which previously were displaying a link in a different shade of blue due to this class not being present

## Related / Dependant PRs?

<!--- List any related issues here -->

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [ ] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
