### PR TITLE
Upgrade play-frontend-hmrc

### DIFF
--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -73,11 +73,11 @@
 }
 
 @scripts = {
-    <script src='@controllers.routes.Assets.versioned("lib/govuk-frontend/govuk/all.js")'></script>
-    <script src='@controllers.routes.Assets.versioned("lib/hmrc-frontend/hmrc/all.js")'></script>
-    <script>window.GOVUKFrontend.initAll();window.HMRCFrontend.initAll()</script>
+    <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("lib/govuk-frontend/govuk/all.js")'></script>
+    <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("lib/hmrc-frontend/hmrc/all.js")'></script>
+    <script @CSPNonce.attr>window.GOVUKFrontend.initAll();window.HMRCFrontend.initAll()</script>
     @autocompleteJavascript()
-    <script src='@controllers.routes.Assets.versioned("submitButtonDisable.js")'></script>
+    <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("submitButtonDisable.js")'></script>
 }
 
 @mainContentWithGetHelp = {
@@ -105,7 +105,6 @@
             signOutUrl = if(canSignOut) Some(appConfig.logoutUrl) else None,
         )
     ),
-    cspNonce = CSPNonce.get,
     beforeContentBlock = Some(beforeContentBlock),
     scriptsBlock = Some(scripts),
     mainContentLayout = if(fullWidthLayout) None else Some(defaultMainContentLayout(_)),

--- a/app/views/components/Stylesheets.scala.html
+++ b/app/views/components/Stylesheets.scala.html
@@ -18,7 +18,7 @@
 
 @this(autocompleteCss: HmrcAccessibleAutocompleteCss)
 
-@()
+@()(implicit requestHeader: RequestHeader)
 
 @autocompleteCss()
 <link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="all" rel="stylesheet" type="text/css" />

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -21,7 +21,7 @@ private object AppDependencies {
     "uk.gov.hmrc"       %% "json-encryption"               % jsonEncryptionVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % hmrcMongoVersion,
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "5.24.0",
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "6.6.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-28"    % "8.4.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.12.0-play-28",
 
     "com.vladsch.flexmark" % "flexmark-all" % flexmarkVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.9.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.2.0")
-addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.18" exclude("org.slf4j", "slf4j-simple"))
+addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.20" exclude("org.slf4j", "slf4j-simple"))
 addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "2.0.6")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"  % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"   %  "sbt-digest"             % "1.1.3")

--- a/test/views/businessmatching/CheckCompanyIsNotRegisteredViewSpec.scala
+++ b/test/views/businessmatching/CheckCompanyIsNotRegisteredViewSpec.scala
@@ -47,7 +47,7 @@ class CheckCompanyIsNotRegisteredViewSpec extends AmlsViewSpec {
       override def view = checkView()
 
       doc.getElementsByClass("govuk-warning-text__text")
-        .first().text() mustBe messages("businessmatching.checkbusiness.warning")
+        .first().text() mustBe "Warning " + messages("businessmatching.checkbusiness.warning")
     }
 
     "render the correct button" in new Fixture {


### PR DESCRIPTION
The test that was updated was because the GovukWarningText component now has some hidden text for screen readers that says "Warning". I've looked at the page to confirm behaviour (route = `/anti-money-laundering/business-matching/check-company-is-not-registered`)