### PR TITLE
Removing paragraph causing head of empty list error

### DIFF
--- a/app/views/businessactivities/InvolvedInOtherNameView.scala.html
+++ b/app/views/businessactivities/InvolvedInOtherNameView.scala.html
@@ -81,20 +81,6 @@
 
     @heading("businessactivities.involved.other.title")
 
-    @businessTypes.map { types =>
-        @if(types.size > 1) {
-            <p class="govuk-body">@messages("businessactivities.confirm-activities.subtitle_4"):</p>
-
-            <ul class="govuk-list govuk-list--bullet">
-            @types.map { businessType =>
-                <li>@businessType</li>
-            }
-            </ul>
-        } else {
-            <p class="govuk-body">@messages("businessactivities.confirm-activities.subtitle_4") @(types.head)</p>
-        }
-    }
-
     <p class="govuk-body">@messages("businessactivities.involved.other.hint")</p>
     <ul class="govuk-list govuk-list--bullet">
         <li>@messages("businessactivities.involved.listline1")</li>

--- a/test/controllers/businessactivities/InvolvedInOtherControllerSpec.scala
+++ b/test/controllers/businessactivities/InvolvedInOtherControllerSpec.scala
@@ -85,14 +85,6 @@ class InvolvedInOtherControllerSpec extends AmlsSpec with ScalaFutures with Priv
 
         val html = contentAsString(result)
 
-        html must include("an " + messages("businessactivities.registerservices.servicename.lbl.01"))
-        html must include("a " + messages("businessactivities.registerservices.servicename.lbl.03"))
-        html must include("an " + messages("businessactivities.registerservices.servicename.lbl.04"))
-        html must include("a " + messages("businessactivities.registerservices.servicename.lbl.05"))
-        html must include("a " + messages("businessactivities.registerservices.servicename.lbl.06"))
-        html must include("a " + messages("businessactivities.registerservices.servicename.lbl.07"))
-        html must include("a " + messages("businessactivities.registerservices.servicename.lbl.08"))
-
         val page = Jsoup.parse(html)
 
         page.select("input[type=radio][name=involvedInOther][value=true]").hasAttr("checked") must be(false)


### PR DESCRIPTION
PR is to remove a paragraph on the InvolvedInOther page which we believe is causing the head of empty list error. The paragraph uses the .head method which would throw an error if the list is empty. 

## Related / Dependant PRs?

<!--- List any related issues here -->

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [ ] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
