### PR TITLE
DDCYLS-2428 Rollback bootstrap & http-caching, enable encryption

### DIFF
--- a/app/services/cache/CacheOps.scala
+++ b/app/services/cache/CacheOps.scala
@@ -16,9 +16,9 @@
 
 package services.cache
 
-import play.api.libs.json.{JsError, JsResultException, JsString, JsSuccess, Reads}
-import uk.gov.hmrc.crypto.{CompositeSymmetricCrypto, Decrypter, Encrypter, Protected}
+import play.api.libs.json._
 import uk.gov.hmrc.crypto.json.JsonDecryptor
+import uk.gov.hmrc.crypto.{CompositeSymmetricCrypto, Protected}
 
 import scala.util.{Failure, Success, Try}
 
@@ -39,7 +39,7 @@ trait CacheOps {
       }
     }
 
-  def catchDoubleEncryption[T](cache: Cache, key: String)(implicit reads: Reads[T], c: Encrypter with Decrypter, decryptor: JsonDecryptor[T]): Option[T] = {
+  def catchDoubleEncryption[T](cache: Cache, key: String)(implicit reads: Reads[T], c: CompositeSymmetricCrypto, decryptor: JsonDecryptor[T]): Option[T] = {
     Try(decryptValue[T](cache, key)(decryptor)) match {
       case Failure(_: JsResultException) => {
         decryptValue[String](cache, key)(new JsonDecryptor[String]())

--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,19 @@
 import play.sbt.PlayImport.PlayKeys
-import play.sbt.routes.RoutesKeys._
-import sbt.Keys._
+import play.sbt.routes.RoutesKeys.*
+import sbt.Keys.*
 import sbt.Tests.{Group, SubProcess}
-import sbt._
-import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
+import sbt.*
 import com.typesafe.sbt.digest.Import.digest
 import com.typesafe.sbt.web.Import.{Assets, pipelineStages}
-import uk.gov.hmrc._
+import uk.gov.hmrc.*
 import DefaultBuildSettings.{addTestReportOption, defaultSettings, scalaSettings}
 import play.twirl.sbt.Import.TwirlKeys
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
 import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 
-
 val appName: String = "amls-frontend"
 
 lazy val appDependencies: Seq[ModuleID] = AppDependencies()
-lazy val plugins : Seq[Plugins] = Seq(play.sbt.PlayScala)
-lazy val playSettings : Seq[Setting[_]] = Seq.empty
 
 lazy val scoverageSettings = {
   import scoverage.ScoverageKeys
@@ -33,13 +29,13 @@ lazy val scoverageSettings = {
 }
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(Seq(play.sbt.PlayScala, SbtDistributablesPlugin) ++ plugins : _*)
+  .enablePlugins(Seq(play.sbt.PlayScala, SbtDistributablesPlugin) *)
   .settings(libraryDependencySchemes ++= Seq("org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always))
   .settings(majorVersion := 4)
-  .settings(playSettings ++ scoverageSettings : _*)
-  .settings(scalaSettings: _*)
-  .settings(defaultSettings(): _*)
-  .settings(scalaVersion := "2.13.10")
+  .settings(scoverageSettings)
+  .settings(scalaSettings *)
+  .settings(defaultSettings() *)
+  .settings(scalaVersion := "2.13.12")
   .settings(routesImport += "models.notifications.ContactType._")
   .settings(routesImport += "utils.Binders._")
   .settings(Global / lintUnusedKeysOnLoad := false)
@@ -60,7 +56,7 @@ lazy val microservice = Project(appName, file("."))
     )
   )
   .configs(IntegrationTest)
-  .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
+  .settings(inConfig(IntegrationTest)(Defaults.itSettings) *)
   .settings(
     IntegrationTest / Keys.fork := false,
     IntegrationTest / unmanagedSourceDirectories := (IntegrationTest / baseDirectory)(base => Seq(base / "it")).value,
@@ -74,7 +70,7 @@ lazy val microservice = Project(appName, file("."))
       "-feature",
       "-unchecked",
       "-language:implicitConversions",
-      "-P:silencer:pathFilters=views;routes;TestStorage"
+      "-Wconf:cat=unused-imports&src=.*routes.*:s"
     )
   )
   .disablePlugins(JUnitXmlReportPlugin)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -14,6 +14,23 @@
 
 include "frontend.conf"
 
+# An ApplicationLoader that uses Guice to bootstrap the application.
+play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
+
+# Primary entry point for all HTTP requests on Play applications
+play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
+
+# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
+# An audit connector must be provided.
+play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
+
+# Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
+# A metric filter must be provided
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
+
+# Provides an implementation and configures all filters required by a Platform frontend microservice.
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
+
 play.http.filters = "uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters"
 
 # Custom error handler
@@ -65,9 +82,21 @@ timeout.seconds = 1800
 timeout.countdown = 180 // maximum value that can be used for this flag is 1800
 session.timeoutSeconds = 1800
 
+metrics {
+  name = ${appName}
+  rateUnit = SECONDS
+  durationUnit = SECONDS
+  showSamples = true
+  jvm = true
+  enabled = false
+}
+
 microservice {
   metrics {
     graphite {
+      host = graphite
+      port = 2003
+      prefix = play.${appName}.
       enabled = true
     }
   }
@@ -100,7 +129,7 @@ mongodb {
 appCache {
   mongo {
     enabled = true
-    encryptionEnabled = false
+    encryptionEnabled = true
   }
 
   expiryInSeconds = 2419200
@@ -219,4 +248,14 @@ microservice {
 
 accessibility-statement {
   service-path = "/anti-money-laundering"
+}
+
+auditing {
+  enabled = false
+  consumer {
+    baseUri {
+      host = "localhost"
+      port = 8100
+    }
+  }
 }

--- a/it/connectors/cache/DataCacheConnectorISpec.scala
+++ b/it/connectors/cache/DataCacheConnectorISpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.cache
+
+import connectors.DataCacheConnector
+import helpers.IntegrationBaseSpec
+import models.businessmatching.BusinessActivity.BillPaymentServices
+import models.businessmatching.{BusinessActivities, BusinessMatching}
+import play.api.libs.json.Json
+import services.cache.{Cache, MongoCacheClient, MongoCacheClientFactory}
+import uk.gov.hmrc.crypto.ApplicationCrypto
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+class DataCacheConnectorISpec extends IntegrationBaseSpec with DefaultPlayMongoRepositorySupport[Cache] {
+
+  val cacheClientFactory =
+    new MongoCacheClientFactory(appConfig, app.injector.instanceOf[ApplicationCrypto], mongoComponent)
+  override val repository: MongoCacheClient = cacheClientFactory.createClient
+  val cacheConnector = new MongoCacheConnector(cacheClientFactory)
+  val dataCacheConnector: DataCacheConnector = new DataCacheConnector(cacheConnector)
+
+  ".fetch" must {
+
+    "retrieve an item from the cache given a model type" in {
+      val businessMatching = BusinessMatching(activities = Some(BusinessActivities(Set(BillPaymentServices))))
+      val testCache: Cache = Cache("123", Map(BusinessMatching.key -> Json.toJson(businessMatching)))
+      repository.saveAll(testCache, "123")
+      dataCacheConnector.fetch[BusinessMatching]("123", BusinessMatching.key).futureValue mustBe Some(businessMatching)
+    }
+  }
+}

--- a/it/helpers/IntegrationBaseSpec.scala
+++ b/it/helpers/IntegrationBaseSpec.scala
@@ -1,0 +1,24 @@
+package helpers
+
+import config.ApplicationConfig
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import scala.concurrent.ExecutionContext
+
+trait IntegrationBaseSpec extends PlaySpec with Matchers with GuiceOneServerPerSuite {
+
+  def servicesConfig: Map[String, String] = Map(
+    "appCache.mongo.encryptionEnabled" -> "true"
+  )
+
+  override implicit lazy val app: Application = new GuiceApplicationBuilder()
+    .configure(servicesConfig)
+    .build()
+
+  implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+  val appConfig: ApplicationConfig = app.injector.instanceOf[ApplicationConfig]
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,22 +1,22 @@
-import sbt._
+import play.core.PlayVersion
+import play.sbt.PlayImport.ws
+import sbt.*
 
 private object AppDependencies {
 
-  import play.sbt.PlayImport._
-  import play.core.PlayVersion
-
   private val playV = "play-28"
   private val flexmarkVersion = "0.64.8"
-  private val bootstrapV = "7.23.0"
+  private val bootstrapV = "6.0.0"
+  private val hmrcMongoV = "0.71.0"
 
-  val compile = Seq(
+  val compile: Seq[ModuleID] = Seq(
     ws,
     // GOV UK
     "uk.gov.hmrc"           %% "domain"                        % s"8.1.0-$playV",
     "uk.gov.hmrc"           %% "play-partials"                 % s"8.3.0-$playV",
-    "uk.gov.hmrc"           %% s"http-caching-client-$playV"   % "11.2.0",
+    "uk.gov.hmrc"           %% "http-caching-client"           % s"10.0.0-$playV",
     "uk.gov.hmrc"           %% "json-encryption"               % s"5.3.0-$playV",
-    "uk.gov.hmrc.mongo"     %% s"hmrc-mongo-$playV"            % "0.71.0",
+    "uk.gov.hmrc.mongo"     %% s"hmrc-mongo-$playV"            % hmrcMongoV,
     "uk.gov.hmrc"           %% s"bootstrap-frontend-$playV"    % bootstrapV,
     "uk.gov.hmrc"           %% s"play-frontend-hmrc-$playV"    % "8.4.0",
     "uk.gov.hmrc"           %% "play-conditional-form-mapping" % s"1.13.0-$playV",
@@ -28,10 +28,7 @@ private object AppDependencies {
     "commons-codec"          % "commons-codec"                 % "1.15",
     // PLAY
     "com.typesafe.play"     %% "play-json"                     % "2.8.1",
-    "com.typesafe.play"     %% "play-json-joda"                % "2.8.1",
-
-    compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.13" cross CrossVersion.full),
-    "com.github.ghik" % "silencer-lib" % "1.7.13" % Provided cross CrossVersion.full
+    "com.typesafe.play"     %% "play-json-joda"                % "2.8.1"
   )
 
   trait ScopeDependencies {
@@ -40,10 +37,11 @@ private object AppDependencies {
   }
 
   object Test {
-    def apply() = new ScopeDependencies {
-      override val scope = "test"
-      override lazy val dependencies = Seq(
+    def apply(): Seq[sbt.ModuleID] = new ScopeDependencies {
+      override val scope = "test,it"
+      override lazy val dependencies: Seq[sbt.ModuleID] = Seq(
         "uk.gov.hmrc"            %% s"bootstrap-test-$playV"  % bootstrapV          % scope,
+        "uk.gov.hmrc.mongo"      %% s"hmrc-mongo-test-$playV" % hmrcMongoV          % scope,
         "org.scalatestplus.play" %% "scalatestplus-play"      % "7.0.1"             % scope,
         "org.scalatestplus"      %% "scalacheck-1-15"         % "3.2.11.0"          % scope,
         "org.scalacheck"         %% "scalacheck"              % "1.17.0"            % scope,
@@ -55,5 +53,5 @@ private object AppDependencies {
     }.dependencies
   }
 
-  def apply() = compile ++ Test()
+  def apply(): Seq[ModuleID] = compile ++ Test()
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,9 +10,9 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 )
 
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.20.0")
-addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.2.0")
+addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.5.0")
 addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.20" exclude("org.slf4j", "slf4j-simple"))
-addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "2.0.6")
+addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "2.0.9")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"  % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"   %  "sbt-digest"             % "1.1.3")
 addSbtPlugin("net.virtual-void"   %  "sbt-dependency-graph"   % "0.9.2")

--- a/test/connectors/GovernmentGatewayConnectorSpec.scala
+++ b/test/connectors/GovernmentGatewayConnectorSpec.scala
@@ -16,7 +16,6 @@
 
 package connectors
 
-import audit.EnrolEvent
 import exceptions.{DuplicateEnrolmentException, InvalidEnrolmentCredentialsException}
 import generators.{AmlsReferenceNumberGenerator, BaseGenerator, GovernmentGatewayGenerator}
 import models.governmentgateway.EnrolmentRequest
@@ -58,7 +57,6 @@ class GovernmentGatewayConnectorSpec extends AmlsSpec
         implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
         val request: EnrolmentRequest = enrolmentRequestGen.sample.get
         val response: HttpResponse = HttpResponse(OK, "")
-        doNothing().when(audit).sendDataEvent(EnrolEvent(request, response))
         mockHttpCall(Future.successful(response))
 
         whenReady(connector.enrol(request)) { result =>

--- a/test/services/cache/MongoCacheClientSpec.scala
+++ b/test/services/cache/MongoCacheClientSpec.scala
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.cache
+
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import config.ApplicationConfig
+import play.api.Configuration
+import play.api.libs.json.{JsString, Reads}
+import uk.gov.hmrc.crypto.ApplicationCrypto
+import uk.gov.hmrc.http.cache.client.CacheMap
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import utils.AmlsSpec
+
+class MongoCacheClientSpec extends AmlsSpec with DefaultPlayMongoRepositorySupport[Cache] {
+
+  val configNoEncryption: Configuration = Configuration(
+    ConfigFactory.load().withValue("appCache.mongo.encryptionEnabled", ConfigValueFactory.fromAnyRef(false))
+  )
+  val configWithEncryption: Configuration = Configuration(
+    ConfigFactory.load().withValue("appCache.mongo.encryptionEnabled", ConfigValueFactory.fromAnyRef(true))
+  )
+  val appConfigNoEncryption = new ApplicationConfig(configNoEncryption, app.injector.instanceOf[ServicesConfig])
+  val appConfigWithEncryption = new ApplicationConfig(configWithEncryption, app.injector.instanceOf[ServicesConfig])
+  override val repository = new MongoCacheClient(appConfigNoEncryption, app.injector.instanceOf[ApplicationCrypto], mongoComponent)
+  val encryptedRepository =
+    new MongoCacheClient(appConfigWithEncryption, app.injector.instanceOf[ApplicationCrypto], mongoComponent)
+  val testCache: Cache = Cache("123", Map("fieldName" -> JsString("valueName")))
+  val encryptedCacheData: Map[String, JsString] = Map("fieldName" -> JsString("Q2NYiC4W49rMPxfI+soQ2g=="))
+
+  ".saveAll" must {
+
+    "save a cache" in {
+      repository.saveAll(testCache).futureValue
+      repository.collection.countDocuments().head().futureValue mustBe 1
+
+      encryptedRepository.saveAll(testCache).futureValue
+      encryptedRepository.collection.countDocuments().head().futureValue mustBe 1
+    }
+
+    "save a cache when a credId is provided" in {
+      repository.saveAll(testCache, "123").futureValue
+      repository.collection.countDocuments().head().futureValue mustBe 1
+
+      encryptedRepository.saveAll(testCache, "123").futureValue
+      encryptedRepository.collection.countDocuments().head().futureValue mustBe 1
+    }
+  }
+
+  ".fetchAll" must {
+
+    "retrieve a cache that exists" in {
+      repository.saveAll(testCache).futureValue
+      repository.fetchAll("123").futureValue.map(_.data) mustBe Some(testCache.data)
+
+      encryptedRepository.saveAll(testCache).futureValue
+      encryptedRepository.fetchAll("123").futureValue.map(_.data) mustBe Some(encryptedCacheData)
+    }
+
+    "return None when no cache exists" in {
+      repository.fetchAll("123").futureValue.map(_.data) mustBe None
+
+      encryptedRepository.fetchAll("123").futureValue.map(_.data) mustBe None
+    }
+  }
+
+  ".fetchAllWithDefault" must {
+
+    "return a fallback empty cache when no cache exists" in {
+      repository.fetchAllWithDefault("123").futureValue.data mustBe Map.empty
+
+      encryptedRepository.fetchAllWithDefault("123").futureValue.data mustBe Map.empty
+    }
+  }
+
+  ".createOrUpdate" must {
+
+    "create and return a cache when one does not exist" in {
+      repository.createOrUpdate("123", JsString("valueName"), "fieldName").futureValue.data mustBe testCache.data
+
+      encryptedRepository.createOrUpdate("123", JsString("valueName"), "fieldName").futureValue.data mustBe encryptedCacheData
+    }
+
+    "update and return a cache when one already exists" in {
+      repository.saveAll(testCache, "123").futureValue
+      val newData = Map("fieldName" -> JsString("newValueName"))
+      repository.createOrUpdate("123", JsString("newValueName"), "fieldName").futureValue.data mustBe newData
+
+      encryptedRepository.saveAll(testCache, "123").futureValue
+      val newEncryptedData = Map("fieldName" -> JsString("lb6PR82vFARAM8u3kHMtKA=="))
+      encryptedRepository.createOrUpdate("123", JsString("newValueName"), "fieldName").futureValue.data mustBe newEncryptedData
+    }
+  }
+
+  ".removeById" must {
+
+    "remove a cache when one exists" in {
+      repository.saveAll(testCache, "123").futureValue
+      repository.removeById("123").futureValue
+      repository.collection.countDocuments().head().futureValue mustBe 0
+
+      encryptedRepository.saveAll(testCache, "123").futureValue
+      encryptedRepository.removeById("123").futureValue
+      encryptedRepository.collection.countDocuments().head().futureValue mustBe 0
+    }
+
+    "remove nothing when there is no matching cache" in {
+      repository.saveAll(testCache, "123").futureValue
+      repository.removeById("456").futureValue
+      repository.collection.countDocuments().head().futureValue mustBe 1
+
+      encryptedRepository.saveAll(testCache, "123").futureValue
+      encryptedRepository.removeById("456").futureValue
+      encryptedRepository.collection.countDocuments().head().futureValue mustBe 1
+    }
+  }
+
+  ".removeByKey" must {
+
+    "remove a field from a cache item when one exists" in {
+      repository.saveAll(testCache, "123").futureValue
+      repository.removeByKey("123", "fieldName").futureValue.data mustBe Map.empty
+
+      encryptedRepository.saveAll(testCache, "123").futureValue
+      encryptedRepository.removeByKey("123", "fieldName").futureValue.data mustBe Map.empty
+    }
+
+    "return the cache with no updates when the key does not exist" in {
+      repository.saveAll(testCache, "123").futureValue
+      repository.removeByKey("123", "unrecognisedFieldName").futureValue.data mustBe testCache.data
+
+      encryptedRepository.saveAll(testCache, "123").futureValue
+      encryptedRepository.removeByKey("123", "unrecognisedFieldName").futureValue.data mustBe encryptedCacheData
+    }
+  }
+
+  ".upsert" must {
+
+    "create and return a cache when one does not exist" in {
+      repository.upsert(
+        CacheMap("123", testCache.data), JsString("valueName"), "fieldName"
+      ).data mustBe testCache.data
+
+      encryptedRepository.upsert(
+        CacheMap("123", testCache.data), JsString("valueName"), "fieldName"
+      ).data mustBe encryptedCacheData
+    }
+
+    "update and return a cache when one already exists" in {
+      repository.saveAll(testCache, "123").futureValue
+      val newData = Map("fieldName" -> JsString("newValueName"))
+      repository.upsert(
+        CacheMap("123", testCache.data), JsString("newValueName"), "fieldName"
+      ).data mustBe newData
+
+      encryptedRepository.saveAll(testCache, "123").futureValue
+      val newEncryptedData = Map("fieldName" -> JsString("lb6PR82vFARAM8u3kHMtKA=="))
+      encryptedRepository.upsert(
+        CacheMap("123", testCache.data), JsString("newValueName"), "fieldName"
+      ).data mustBe newEncryptedData
+    }
+  }
+
+  ".find" must {
+
+    "return a matching value for the key when one is found" in {
+      repository.saveAll(testCache, "123").futureValue
+      repository.find("123", "fieldName")(implicitly[Reads[String]]).futureValue mustBe Some("valueName")
+
+      encryptedRepository.saveAll(testCache, "123").futureValue
+      encryptedRepository.find("123", "fieldName")(implicitly[Reads[String]]).futureValue mustBe Some("valueName")
+    }
+
+    "return None when a matching value is not found" in {
+      repository.saveAll(testCache, "123").futureValue
+      repository.find("123", "unrecognisedFieldName")(implicitly[Reads[String]]).futureValue mustBe None
+
+      encryptedRepository.saveAll(testCache, "123").futureValue
+      encryptedRepository.find("123", "unrecognisedFieldName")(implicitly[Reads[String]]).futureValue mustBe None
+    }
+
+    "return None when a cache is not found" in {
+      repository.find("123", "fieldName")(implicitly[Reads[String]]).futureValue mustBe None
+
+      encryptedRepository.find("123", "fieldName")(implicitly[Reads[String]]).futureValue mustBe None
+    }
+  }
+}

--- a/test/utils/AmlsSpec.scala
+++ b/test/utils/AmlsSpec.scala
@@ -30,7 +30,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.FakeRequest
 import play.filters.csrf.{CSRFConfigProvider, CSRFFilter}
-import uk.gov.hmrc.crypto.{ApplicationCrypto, Decrypter, Encrypter}
+import uk.gov.hmrc.crypto.{ApplicationCrypto, CompositeSymmetricCrypto}
 import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
 
 import scala.concurrent.ExecutionContext
@@ -64,7 +64,7 @@ trait AmlsSpec extends PlaySpec with GuiceOneAppPerSuite with MockitoSugar with 
 
   // ================================== Encryption/Decryption ==================================
   val applicationCrypto: ApplicationCrypto = app.injector.instanceOf[ApplicationCrypto]
-  implicit val compositeSymmetricCrypto: Encrypter with Decrypter = applicationCrypto.JsonCrypto
+  implicit val compositeSymmetricCrypto: CompositeSymmetricCrypto = applicationCrypto.JsonCrypto
   // ===========================================================================================
 
   implicit val headerCarrier: HeaderCarrier = mock[HeaderCarrier]


### PR DESCRIPTION
Please also merge this build-jobs PR to enable IT tests running: https://github.com/hmrc/build-jobs/pull/17003

Rolled back bootstrap, http-caching and the related config and crypto changes, whilst allowing us to stay on Scala 2.13. I've covered up a few gaps in tests but this is by no means exhaustive. There could be many more IT tests and the one I added was simply to add a bit of groundwork, but ultimately the scope of this ticket could be endless if trying to cover everything.

The issue on main can be reproduced by enabling encryption and going into the renewal journey. Switching on encryption locally as dicussed can also give us another barrier at the acceptance test stage to catch issues.

Also removed the silencer plugin as it is obselete in later Scala versions