### PR TITLE
AMLS Warnings Cleanup - DDCYLS-4074

### DIFF
--- a/app/audit/AddBankAccountEvent.scala
+++ b/app/audit/AddBankAccountEvent.scala
@@ -41,7 +41,7 @@ object AddBankAccountEvent {
 
   object BankAccountAuditDetail {
 
-    implicit val accountTypeWrites = Writes[BankAccountType] {
+    implicit val accountTypeWrites: Writes[BankAccountType] = Writes[BankAccountType] {
       case PersonalAccount => JsString("personal")
       case BelongsToBusiness => JsString("business")
       case BelongsToOtherBusiness => JsString("other business")

--- a/app/audit/AddressAuditing.scala
+++ b/app/audit/AddressAuditing.scala
@@ -32,7 +32,7 @@ import utils.AuditHelper
 case class AuditAddress(addressLine1: String, addressLine2: Option[String], addressLine3: Option[String], country: String, postCode: Option[String])
 
 object AuditAddress {
-  implicit val format = Json.format[AuditAddress]
+  implicit val format: OFormat[AuditAddress] = Json.format[AuditAddress]
 }
 
 object AddressCreatedEvent {
@@ -48,7 +48,7 @@ case class AddressModifiedEvent(currentAddress: AuditAddress, oldAddress: Option
 
 object AddressModifiedEvent {
 
-  implicit val writes = Writes[AddressModifiedEvent] { event =>
+  implicit val writes: Writes[AddressModifiedEvent] = Writes[AddressModifiedEvent] { event =>
     import play.api.libs.json._
 
     val currentAddressObj = Json.obj(

--- a/app/connectors/BusinessMatchingConnector.scala
+++ b/app/connectors/BusinessMatchingConnector.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 
 import javax.inject.Inject
 import play.api.Logging
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.Request
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -36,13 +36,13 @@ case class BusinessMatchingAddress(line_1: String,
 }
 
 object BusinessMatchingAddress {
-  implicit val formats = Json.format[BusinessMatchingAddress]
+  implicit val formats: OFormat[BusinessMatchingAddress] = Json.format[BusinessMatchingAddress]
 }
 
 case class BusinessMatchingIdentification(idNumber: String, issuingInstitution: String, issuingCountryCode: String)
 
 object BusinessMatchingIdentification {
-  implicit val formats = Json.format[BusinessMatchingIdentification]
+  implicit val formats: OFormat[BusinessMatchingIdentification] = Json.format[BusinessMatchingIdentification]
 }
 
 case class BusinessMatchingReviewDetails(businessName: String,
@@ -60,7 +60,7 @@ case class BusinessMatchingReviewDetails(businessName: String,
                                          isBusinessDetailsEditable: Boolean = false)
 
 object BusinessMatchingReviewDetails {
-  implicit val formats = Json.format[BusinessMatchingReviewDetails]
+  implicit val formats: OFormat[BusinessMatchingReviewDetails] = Json.format[BusinessMatchingReviewDetails]
 }
 
 class BusinessMatchingConnector @Inject()(val http: HttpClient,

--- a/app/controllers/AmlsBaseController.scala
+++ b/app/controllers/AmlsBaseController.scala
@@ -31,7 +31,7 @@ abstract class AmlsBaseController(val cpd: CommonPlayDependencies, override val 
 
   implicit val ec: ExecutionContext = controllerComponents.executionContext
 
-  implicit val appConfig = cpd.amlsConfig
+  implicit val appConfig: ApplicationConfig = cpd.amlsConfig
 
   implicit val lang: Lang = Lang.defaultLang
 

--- a/app/models/AmendVariationRenewalResponse.scala
+++ b/app/models/AmendVariationRenewalResponse.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Json, OFormat, Reads}
 
 case class AmendVariationRenewalResponse(
                                     processingDate: String,
@@ -62,8 +62,8 @@ object AmendVariationRenewalResponse {
 
   val key = "AmendVariationResponse"
 
-  implicit val format = Json.format[AmendVariationRenewalResponse]
-  implicit val formatOption = Reads.optionWithNull[AmendVariationRenewalResponse]
+  implicit val format: OFormat[AmendVariationRenewalResponse] = Json.format[AmendVariationRenewalResponse]
+  implicit val formatOption: Reads[Option[AmendVariationRenewalResponse]] = Reads.optionWithNull[AmendVariationRenewalResponse]
 
 
 }

--- a/app/models/Country.scala
+++ b/app/models/Country.scala
@@ -32,11 +32,11 @@ case class Country(name: String, code: String) {
 
 object Country {
 
-  implicit val writes = Writes[Country] {
+  implicit val writes: Writes[Country] = Writes[Country] {
     case Country(_, c) => JsString(c)
   }
 
-  implicit val reads = Reads[Country] {
+  implicit val reads: Reads[Country] = Reads[Country] {
     case JsString("") => JsSuccess(Country("",""))
     case JsString(code) =>
       countries collectFirst {

--- a/app/models/DataImport.scala
+++ b/app/models/DataImport.scala
@@ -16,12 +16,12 @@
 
 package models
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class DataImport(filename: String)
 
 object DataImport {
   val key = "data-import"
 
-  implicit val format = Json.format[DataImport]
+  implicit val format: OFormat[DataImport] = Json.format[DataImport]
 }

--- a/app/models/DateOfChange.scala
+++ b/app/models/DateOfChange.scala
@@ -30,7 +30,7 @@ object DateOfChange {
       DateOfChange(_)
     }
 
-  implicit val writes = Writes[DateOfChange] {
+  implicit val writes: Writes[DateOfChange] = Writes[DateOfChange] {
     case DateOfChange(b) => Json.toJson(b)
   }
 }

--- a/app/models/FeeResponse.scala
+++ b/app/models/FeeResponse.scala
@@ -31,7 +31,7 @@ object ResponseType {
 
   case object AmendOrVariationResponseType extends ResponseType
 
-  implicit val jsonWrites = Writes[ResponseType] {
+  implicit val jsonWrites: Writes[ResponseType] = Writes[ResponseType] {
     case SubscriptionResponseType => JsString("SubscriptionReponse")
     case AmendOrVariationResponseType => JsString("AmendOrVariationResponse")
   }
@@ -86,5 +86,5 @@ object FeeResponse {
   
   implicit val dateTimeWrite: Writes[DateTime] = (dateTime: DateTime) => Json.obj("$date" -> dateTime.getMillis)
 
-  implicit val format = Json.format[FeeResponse]
+  implicit val format: OFormat[FeeResponse] = Json.format[FeeResponse]
 }

--- a/app/models/ReadStatusResponse.scala
+++ b/app/models/ReadStatusResponse.scala
@@ -40,7 +40,7 @@ object ReadStatusResponse {
 
   val dateTimeFormat = ISODateTimeFormat.dateTimeNoMillis().withZoneUTC
 
-  implicit val readsJodaLocalDateTime = Reads[LocalDateTime](js =>
+  implicit val readsJodaLocalDateTime: Reads[LocalDateTime] = Reads[LocalDateTime](js =>
     js.validate[String].map[LocalDateTime](dtString =>
       LocalDateTime.parse(dtString, dateTimeFormat)
     )
@@ -50,6 +50,6 @@ object ReadStatusResponse {
     def writes(dateTime: LocalDateTime): JsValue = JsString(dateTimeFormat.print(dateTime.toDateTime(DateTimeZone.UTC)))
   }
 
-  implicit val format = Json.format[ReadStatusResponse]
+  implicit val format: OFormat[ReadStatusResponse] = Json.format[ReadStatusResponse]
 }
 

--- a/app/models/ReturnLocation.scala
+++ b/app/models/ReturnLocation.scala
@@ -32,7 +32,7 @@ object ReturnLocation {
 
   private def publicRedirectUrl(url: String)(implicit appConfig: ApplicationConfig) = s"${appConfig.frontendBaseUrl}$url"
 
-  implicit val locationWrites = new Writes[ReturnLocation] {
+  implicit val locationWrites: Writes[ReturnLocation] = new Writes[ReturnLocation] {
     override def writes(o: ReturnLocation) = JsString(o.absoluteUrl)
   }
 

--- a/app/models/SubmissionRequestStatus.scala
+++ b/app/models/SubmissionRequestStatus.scala
@@ -16,12 +16,12 @@
 
 package models
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class SubmissionRequestStatus(hasSubmitted: Boolean, isRenewalAmendment: Option[Boolean] = Some(false))
 
 object SubmissionRequestStatus {
   val key = "submission-request-status"
 
-  implicit val format = Json.format[SubmissionRequestStatus]
+  implicit val format: OFormat[SubmissionRequestStatus] = Json.format[SubmissionRequestStatus]
 }

--- a/app/models/SubscriptionErrorResponse.scala
+++ b/app/models/SubscriptionErrorResponse.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.http.UpstreamErrorResponse
 
 import scala.util.Try
@@ -24,7 +24,7 @@ import scala.util.Try
 case class SubscriptionErrorResponse(amlsRegNumber: String, message: String)
 
 object SubscriptionErrorResponse {
-  implicit val format = Json.format[SubscriptionErrorResponse]
+  implicit val format: OFormat[SubscriptionErrorResponse] = Json.format[SubscriptionErrorResponse]
 
   def from(ex: UpstreamErrorResponse): Option[SubscriptionErrorResponse] = {
     Try {

--- a/app/models/SubscriptionFees.scala
+++ b/app/models/SubscriptionFees.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class SubscriptionFees(paymentReference: String,
                             registrationFee: BigDecimal,
@@ -29,5 +29,5 @@ case class SubscriptionFees(paymentReference: String,
                             totalFees: BigDecimal)
 
 object SubscriptionFees {
-  implicit val format = Json.format[SubscriptionFees]
+  implicit val format: OFormat[SubscriptionFees] = Json.format[SubscriptionFees]
 }

--- a/app/models/SubscriptionRequest.scala
+++ b/app/models/SubscriptionRequest.scala
@@ -30,7 +30,7 @@ import models.responsiblepeople.ResponsiblePerson
 import models.supervision.Supervision
 import models.tcsp.Tcsp
 import models.tradingpremises.TradingPremises
-import play.api.libs.json.{JsArray, Json, Writes}
+import play.api.libs.json.{JsArray, Json, OFormat, Writes}
 
 import scala.collection.Seq
 
@@ -65,5 +65,5 @@ object SubscriptionRequest {
     }))
   }
 
-  implicit val format = Json.format[SubscriptionRequest]
+  implicit val format: OFormat[SubscriptionRequest] = Json.format[SubscriptionRequest]
 }

--- a/app/models/SubscriptionResponse.scala
+++ b/app/models/SubscriptionResponse.scala
@@ -59,8 +59,8 @@ object SubscriptionResponse {
 
   val key = "Subscription"
 
-  implicit val format = Json.format[SubscriptionResponse]
-  implicit val formatOption = Reads.optionNoError[SubscriptionResponse]
+  implicit val format: OFormat[SubscriptionResponse] = Json.format[SubscriptionResponse]
+  implicit val formatOption: Reads[Option[SubscriptionResponse]] = Reads.optionNoError[SubscriptionResponse]
 
   val oldFeesStructureTransformer: Reads[JsObject] =
     (

--- a/app/models/UpdateMongoCacheResponse.scala
+++ b/app/models/UpdateMongoCacheResponse.scala
@@ -58,7 +58,7 @@ case class UpdateMongoCacheResponse(dataImport: Option[DataImport],
 object UpdateMongoCacheResponse {
 
   import utils.MappingUtils.constant
-  implicit val writes = Json.writes[UpdateMongoCacheResponse]
+  implicit val writes: OWrites[UpdateMongoCacheResponse] = Json.writes[UpdateMongoCacheResponse]
 
   def readLegacyField[T](key: String, oldKey: String)(implicit r: Reads[T]): Reads[Option[T]] =
     {

--- a/app/models/ViewResponse.scala
+++ b/app/models/ViewResponse.scala
@@ -55,7 +55,7 @@ object ViewResponse {
 
   val key = "View"
 
-  implicit val jsonWrites = Json.writes[ViewResponse]
+  implicit val jsonWrites: OWrites[ViewResponse] = Json.writes[ViewResponse]
 
   def constructReads(
                       etmpFormBundleNumber:String,
@@ -122,6 +122,6 @@ object ViewResponse {
       (__ \ "supervisionSection").readNullable[Supervision]
     }.apply(ViewResponse.constructReads _)
 
-  implicit val formatOption = Reads.optionWithNull[ViewResponse]
+  implicit val formatOption: Reads[Option[ViewResponse]] = Reads.optionWithNull[ViewResponse]
 
 }

--- a/app/models/amp/Amp.scala
+++ b/app/models/amp/Amp.scala
@@ -121,7 +121,7 @@ object Amp {
     }
   }
 
-  implicit val mongoKey = new MongoKey[Amp] {
+  implicit val mongoKey: MongoKey[Amp] = new MongoKey[Amp] {
     override def apply(): String = key
   }
 
@@ -147,7 +147,7 @@ object Amp {
       ) (unlift(Amp.unapply))
   }
 
-  implicit val formatOption = Reads.optionWithNull[Amp]
+  implicit val formatOption: Reads[Option[Amp]] = Reads.optionWithNull[Amp]
 
   def convert(model: Amp): AMPTurnover = {
     model.get[JsValue](model.percentageExpectedTurnover) match {

--- a/app/models/asp/Asp.scala
+++ b/app/models/asp/Asp.scala
@@ -86,11 +86,11 @@ object Asp {
 
   val key = "asp"
 
-  implicit val mongoKey = new MongoKey[Asp] {
+  implicit val mongoKey: MongoKey[Asp] = new MongoKey[Asp] {
     override def apply(): String = "asp"
   }
 
-  implicit val jsonWrites = Json.writes[Asp]
+  implicit val jsonWrites: OWrites[Asp] = Json.writes[Asp]
 
   implicit val jsonReads: Reads[Asp] = {
     (__ \ "services").readNullable[ServicesOfBusiness] and
@@ -99,7 +99,7 @@ object Asp {
       (__ \ "hasAccepted").readNullable[Boolean].map(_.getOrElse(false))
   }.apply(Asp.apply _)
 
-  implicit val formatOption = Reads.optionWithNull[Asp]
+  implicit val formatOption: Reads[Option[Asp]] = Reads.optionWithNull[Asp]
 
   implicit def default(details: Option[Asp]): Asp =
     details.getOrElse(Asp())

--- a/app/models/asp/OtherBusinessTaxMatters.scala
+++ b/app/models/asp/OtherBusinessTaxMatters.scala
@@ -32,7 +32,7 @@ object OtherBusinessTaxMatters {
       case false => Reads(__ => JsSuccess(OtherBusinessTaxMattersNo))
     }
 
-  implicit val jsonWrites = Writes[OtherBusinessTaxMatters] {
+  implicit val jsonWrites: Writes[OtherBusinessTaxMatters] = Writes[OtherBusinessTaxMatters] {
     case OtherBusinessTaxMattersYes => Json.obj("otherBusinessTaxMatters" -> true)
     case OtherBusinessTaxMattersNo => Json.obj("otherBusinessTaxMatters" -> false)
   }

--- a/app/models/asp/ServicesOfBusiness.scala
+++ b/app/models/asp/ServicesOfBusiness.scala
@@ -93,7 +93,7 @@ object Service extends Enumerable.Implicits {
       case _ => JsError((JsPath \ "services") -> JsonValidationError("error.invalid"))
     }
 
-  implicit val jsonServiceWrites = Writes[Service] {
+  implicit val jsonServiceWrites: Writes[Service] = Writes[Service] {
       case Accountancy => JsString("01")
       case PayrollServices => JsString("02")
       case BookKeeping => JsString("03")
@@ -104,6 +104,6 @@ object Service extends Enumerable.Implicits {
 }
 
 object ServicesOfBusiness {
-  implicit val formats = Json.format[ServicesOfBusiness]
+  implicit val formats: OFormat[ServicesOfBusiness] = Json.format[ServicesOfBusiness]
 }
 

--- a/app/models/auth/UserDetails.scala
+++ b/app/models/auth/UserDetails.scala
@@ -16,7 +16,7 @@
 
 package models.auth
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class UserDetails(name: String,
                        email: Option[String],
@@ -26,5 +26,5 @@ case class UserDetails(name: String,
                       )
 
 object UserDetails {
-  implicit val format = Json.format[UserDetails]
+  implicit val format: OFormat[UserDetails] = Json.format[UserDetails]
 }

--- a/app/models/autocomplete/NameValuePair.scala
+++ b/app/models/autocomplete/NameValuePair.scala
@@ -29,7 +29,7 @@ object NameValuePair {
     }
   }
 
-  implicit val jsonWrites = Writes[NameValuePair] { model =>
+  implicit val jsonWrites: Writes[NameValuePair] = Writes[NameValuePair] { model =>
     JsArray(Seq(JsString(model.name), JsString(model.value)))
   }
 }

--- a/app/models/bankdetails/BankAccountRegistered.scala
+++ b/app/models/bankdetails/BankAccountRegistered.scala
@@ -16,11 +16,11 @@
 
 package models.responsiblepeople
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class BankAccountRegistered(registerAnotherBank: Boolean)
 
 object BankAccountRegistered {
-  implicit val formats = Json.format[BankAccountRegistered]
+  implicit val formats: OFormat[BankAccountRegistered] = Json.format[BankAccountRegistered]
 }
 

--- a/app/models/bankdetails/BankAccountSubsteps.scala
+++ b/app/models/bankdetails/BankAccountSubsteps.scala
@@ -46,14 +46,14 @@ object BankAccountIsUk {
 
   implicit val isUkJsonReads: Reads[BankAccountIsUk] = ( __ \ "isUK").read[Boolean] map BankAccountIsUk.apply
 
-  implicit val isUkJsonWrites = Writes[BankAccountIsUk] { data => Json.obj( "isUK" -> data.isUk) }
+  implicit val isUkJsonWrites: Writes[BankAccountIsUk] = Writes[BankAccountIsUk] { data => Json.obj( "isUK" -> data.isUk) }
 }
 
 object BankAccountHasIban {
 
   implicit val hasIbanJsonReads: Reads[BankAccountHasIban] = ( __ \ "isIBAN").read[Boolean] map BankAccountHasIban.apply
 
-  implicit val hasIbanJsonWrites = Writes[BankAccountHasIban] { data => Json.obj("isIBAN" -> data.hasIban ) }
+  implicit val hasIbanJsonWrites: Writes[BankAccountHasIban] = Writes[BankAccountHasIban] { data => Json.obj("isIBAN" -> data.hasIban ) }
 }
 
 object Account {
@@ -83,7 +83,7 @@ object Account {
 
   implicit val accountReads: Reads[Account] = ukJsonReads orElse nonUkIbanJsonReads orElse nonUkAccountJsonReads
 
-  implicit val accountWrites = Writes[Account] {
+  implicit val accountWrites: Writes[Account] = Writes[Account] {
     case account@UKAccount(_, _) => ukJsonWrites.writes(account)
     case account@NonUKIBANNumber(_) => nonUkIbanJsonWrites.writes(account)
     case account@NonUKAccountNumber(_) => nonUkAccountJsonWrites.writes(account)

--- a/app/models/bankdetails/BankAccountType.scala
+++ b/app/models/bankdetails/BankAccountType.scala
@@ -81,7 +81,7 @@ object BankAccountType extends Enumerable.Implicits {
     }
   }
 
-  implicit val jsonWrites = Writes[BankAccountType] {
+  implicit val jsonWrites: Writes[BankAccountType] = Writes[BankAccountType] {
     case PersonalAccount => Json.obj("bankAccountType"->"01")
     case BelongsToBusiness => Json.obj("bankAccountType" -> "02")
     case BelongsToOtherBusiness => Json.obj("bankAccountType" -> "03")

--- a/app/models/bankdetails/BankDetails.scala
+++ b/app/models/bankdetails/BankDetails.scala
@@ -133,7 +133,7 @@ object BankDetails {
 
   val key = "bank-details"
 
-  implicit val mongoKey = new MongoKey[BankDetails] {
+  implicit val mongoKey: MongoKey[BankDetails] = new MongoKey[BankDetails] {
     override def apply(): String = "bank-details"
   }
 

--- a/app/models/businessactivities/AccountantForAMLSRegulations.scala
+++ b/app/models/businessactivities/AccountantForAMLSRegulations.scala
@@ -16,11 +16,11 @@
 
 package models.businessactivities
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class AccountantForAMLSRegulations(accountantForAMLSRegulations: Boolean)
 
 
 object AccountantForAMLSRegulations {
-  implicit val formats = Json.format[AccountantForAMLSRegulations]
+  implicit val formats: OFormat[AccountantForAMLSRegulations] = Json.format[AccountantForAMLSRegulations]
 }

--- a/app/models/businessactivities/BusinessFranchise.scala
+++ b/app/models/businessactivities/BusinessFranchise.scala
@@ -50,7 +50,7 @@ object BusinessFranchise {
       case false => Reads(_ => JsSuccess(BusinessFranchiseNo))
     }
 
-  implicit val jsonWrites = Writes[BusinessFranchise] {
+  implicit val jsonWrites: Writes[BusinessFranchise] = Writes[BusinessFranchise] {
     case BusinessFranchiseYes(value) => Json.obj(
       "businessFranchise" -> true,
       "franchiseName" -> value

--- a/app/models/businessactivities/EmployeeCountAMLSSupervision.scala
+++ b/app/models/businessactivities/EmployeeCountAMLSSupervision.scala
@@ -16,10 +16,10 @@
 
 package models.businessactivities
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class EmployeeCountAMLSSupervision(employeeCountAMLSSupervision: String)
 
 object EmployeeCountAMLSSupervision {
-  implicit val formats = Json.format[EmployeeCountAMLSSupervision]
+  implicit val formats: OFormat[EmployeeCountAMLSSupervision] = Json.format[EmployeeCountAMLSSupervision]
 }

--- a/app/models/businessactivities/ExpectedAMLSTurnover.scala
+++ b/app/models/businessactivities/ExpectedAMLSTurnover.scala
@@ -50,7 +50,7 @@ object ExpectedAMLSTurnover extends Enumerable.Implicits {
 
   import utils.MappingUtils.Implicits._
 
-  implicit val jsonReads = {
+  implicit val jsonReads: Reads[ExpectedAMLSTurnover] = {
     import play.api.libs.json.Reads.StringReads
     (__ \ "expectedAMLSTurnover").read[String].flatMap[ExpectedAMLSTurnover] {
       case "01" => First
@@ -65,7 +65,7 @@ object ExpectedAMLSTurnover extends Enumerable.Implicits {
     }
   }
 
-  implicit val jsonWrites = Writes[ExpectedAMLSTurnover] {
+  implicit val jsonWrites: Writes[ExpectedAMLSTurnover] = Writes[ExpectedAMLSTurnover] {
     case First => Json.obj("expectedAMLSTurnover" -> "01")
     case Second => Json.obj("expectedAMLSTurnover" -> "02")
     case Third => Json.obj("expectedAMLSTurnover" -> "03")

--- a/app/models/businessactivities/ExpectedBusinessTurnover.scala
+++ b/app/models/businessactivities/ExpectedBusinessTurnover.scala
@@ -50,7 +50,7 @@ object ExpectedBusinessTurnover extends Enumerable.Implicits {
 
   import utils.MappingUtils.Implicits._
 
-  implicit val jsonReads = {
+  implicit val jsonReads: Reads[ExpectedBusinessTurnover] = {
     import play.api.libs.json.Reads.StringReads
     (__ \ "expectedBusinessTurnover").read[String].flatMap[ExpectedBusinessTurnover] {
       case "01" => First
@@ -65,7 +65,7 @@ object ExpectedBusinessTurnover extends Enumerable.Implicits {
     }
   }
 
-  implicit val jsonWrites = Writes[ExpectedBusinessTurnover] {
+  implicit val jsonWrites: Writes[ExpectedBusinessTurnover] = Writes[ExpectedBusinessTurnover] {
     case First => Json.obj("expectedBusinessTurnover" -> "01")
     case Second => Json.obj("expectedBusinessTurnover" -> "02")
     case Third => Json.obj("expectedBusinessTurnover" -> "03")

--- a/app/models/businessactivities/HowManyEmployees.scala
+++ b/app/models/businessactivities/HowManyEmployees.scala
@@ -16,11 +16,11 @@
 
 package models.businessactivities
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class HowManyEmployees(employeeCount: Option[String] = None,
                             employeeCountAMLSSupervision: Option[String] = None)
 
 object HowManyEmployees {
-  implicit val formats = Json.format[HowManyEmployees]
+  implicit val formats: OFormat[HowManyEmployees] = Json.format[HowManyEmployees]
 }

--- a/app/models/businessactivities/IdentifySuspiciousActivity.scala
+++ b/app/models/businessactivities/IdentifySuspiciousActivity.scala
@@ -16,10 +16,10 @@
 
 package models.businessactivities
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class IdentifySuspiciousActivity(hasWrittenGuidance: Boolean)
 
 object IdentifySuspiciousActivity {
-  implicit val formats = Json.format[IdentifySuspiciousActivity]
+  implicit val formats: OFormat[IdentifySuspiciousActivity] = Json.format[IdentifySuspiciousActivity]
 }

--- a/app/models/businessactivities/NCARegistered.scala
+++ b/app/models/businessactivities/NCARegistered.scala
@@ -16,10 +16,10 @@
 
 package models.businessactivities
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class NCARegistered(ncaRegistered: Boolean)
 
 object NCARegistered {
-  implicit val formats = Json.format[NCARegistered]
+  implicit val formats: OFormat[NCARegistered] = Json.format[NCARegistered]
 }

--- a/app/models/businessactivities/RiskAssessmentTypes.scala
+++ b/app/models/businessactivities/RiskAssessmentTypes.scala
@@ -42,7 +42,7 @@ object RiskAssessmentType extends Enumerable.Implicits {
       case _ => JsError((JsPath \ "riskassessments") -> play.api.libs.json.JsonValidationError("error.invalid"))
     }
 
-  implicit val jsonRiskAssessmentWrites =
+  implicit val jsonRiskAssessmentWrites: Writes[RiskAssessmentType] =
     Writes[RiskAssessmentType] {
       case PaperBased => JsString("01")
       case Digital => JsString("02")

--- a/app/models/businessactivities/TaxMatters.scala
+++ b/app/models/businessactivities/TaxMatters.scala
@@ -16,10 +16,10 @@
 
 package models.businessactivities
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class TaxMatters(manageYourTaxAffairs: Boolean)
 
 object TaxMatters {
-  implicit val formats = Json.format[TaxMatters]
+  implicit val formats: OFormat[TaxMatters] = Json.format[TaxMatters]
 }

--- a/app/models/businessactivities/TransactionType.scala
+++ b/app/models/businessactivities/TransactionType.scala
@@ -65,7 +65,7 @@ object TransactionTypes extends Enumerable.Implicits {
 
   import utils.MappingUtils.constant
 
-  implicit val jsonReads = new Reads[TransactionTypes] {
+  implicit val jsonReads: Reads[TransactionTypes] = new Reads[TransactionTypes] {
     override def reads(json: JsValue) = {
       val t = (json \ "types").asOpt[Set[String]]
       val n = (json \ "software").asOpt[String]
@@ -110,7 +110,7 @@ object TransactionTypes extends Enumerable.Implicits {
       case false => constant(None)
     }
 
-  implicit val jsonWrites = Writes[TransactionTypes] { t =>
+  implicit val jsonWrites: Writes[TransactionTypes] = Writes[TransactionTypes] { t =>
     Json.obj(
       "types" -> t.types.map(_.value)
     ) ++ (t.types.collectFirst {

--- a/app/models/businesscustomer/Address.scala
+++ b/app/models/businesscustomer/Address.scala
@@ -17,7 +17,7 @@
 package models.businesscustomer
 
 import models.Country
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class Address(
                   line_1: String,
@@ -40,5 +40,5 @@ case class Address(
 }
 
 object Address {
-  implicit val format = Json.format[Address]
+  implicit val format: OFormat[Address] = Json.format[Address]
 }

--- a/app/models/businesscustomer/ReviewDetails.scala
+++ b/app/models/businesscustomer/ReviewDetails.scala
@@ -22,7 +22,7 @@ import connectors.{BusinessMatchingAddress, BusinessMatchingReviewDetails}
 import models.Country
 import models.businessmatching.BusinessType
 import models.businessmatching.BusinessType.{LPrLLP, LimitedCompany, Partnership, SoleProprietor, UnincorporatedBody}
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Json, OWrites, Reads}
 
 case class ReviewDetails(
                           businessName: String,
@@ -58,7 +58,7 @@ object ReviewDetails {
       ) (ReviewDetails.apply _)
   }
 
-  implicit val writes = Json.writes[ReviewDetails]
+  implicit val writes: OWrites[ReviewDetails] = Json.writes[ReviewDetails]
 
   implicit def convert(addr: BusinessMatchingAddress): Address = {
       val country = models.countries collectFirst {

--- a/app/models/businessdetails/ActivityStartDate.scala
+++ b/app/models/businessdetails/ActivityStartDate.scala
@@ -17,12 +17,12 @@
 package models.businessdetails
 
 import org.joda.time.LocalDate
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
 
 case class ActivityStartDate (startDate: LocalDate)
 
 object ActivityStartDate {
-  implicit val format =  Json.format[ActivityStartDate]
+  implicit val format: OFormat[ActivityStartDate] =  Json.format[ActivityStartDate]
 }

--- a/app/models/businessdetails/BusinessDetails.scala
+++ b/app/models/businessdetails/BusinessDetails.scala
@@ -18,7 +18,7 @@ package models.businessdetails
 
 import models.registrationprogress._
 import play.api.i18n.Messages
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Json, OWrites, Reads}
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 case class BusinessDetails(
@@ -123,7 +123,7 @@ object BusinessDetails {
 
   val key = "about-the-business"
 
-  implicit val format = Json.writes[BusinessDetails]
+  implicit val format: OWrites[BusinessDetails] = Json.writes[BusinessDetails]
 
   implicit val jsonReads: Reads[BusinessDetails] = {
     import play.api.libs.functional.syntax._

--- a/app/models/businessdetails/ContactingYou.scala
+++ b/app/models/businessdetails/ContactingYou.scala
@@ -16,7 +16,7 @@
 
 package models.businessdetails
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class ContactingYou(
                           phoneNumber: Option[String] = None,
@@ -24,5 +24,5 @@ case class ContactingYou(
                         )
 
 object ContactingYou {
-  implicit val formats = Json.format[ContactingYou]
+  implicit val formats: OFormat[ContactingYou] = Json.format[ContactingYou]
 }

--- a/app/models/businessdetails/ContactingYouEmail.scala
+++ b/app/models/businessdetails/ContactingYouEmail.scala
@@ -16,10 +16,10 @@
 
 package models.businessdetails
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class ContactingYouEmail(email: String, confirmEmail: String)
 
 object ContactingYouEmail {
-  implicit val formats = Json.format[ContactingYouEmail]
+  implicit val formats: OFormat[ContactingYouEmail] = Json.format[ContactingYouEmail]
 }

--- a/app/models/businessdetails/ContactingYouPhone.scala
+++ b/app/models/businessdetails/ContactingYouPhone.scala
@@ -16,10 +16,10 @@
 
 package models.businessdetails
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class ContactingYouPhone(phoneNumber: String)
 
 object ContactingYouPhone {
-  implicit val formats = Json.format[ContactingYouPhone]
+  implicit val formats: OFormat[ContactingYouPhone] = Json.format[ContactingYouPhone]
 }

--- a/app/models/businessdetails/CorporationTaxRegistered.scala
+++ b/app/models/businessdetails/CorporationTaxRegistered.scala
@@ -31,7 +31,7 @@ object CorporationTaxRegistered {
       case false => Reads(_ => JsSuccess(CorporationTaxRegisteredNo))
     }
 
-  implicit val jsonWrites = Writes[CorporationTaxRegistered] {
+  implicit val jsonWrites: Writes[CorporationTaxRegistered] = Writes[CorporationTaxRegistered] {
     case CorporationTaxRegisteredYes(value) => Json.obj(
       "registeredForCorporationTax" -> true,
       "corporationTaxReference" -> value

--- a/app/models/businessdetails/CorrespondenceAddressIsUk.scala
+++ b/app/models/businessdetails/CorrespondenceAddressIsUk.scala
@@ -16,10 +16,10 @@
 
 package models.businessdetails
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class CorrespondenceAddressIsUk(isUk: Boolean)
 
 object CorrespondenceAddressIsUk {
-  implicit val formats = Json.format[CorrespondenceAddressIsUk]
+  implicit val formats: OFormat[CorrespondenceAddressIsUk] = Json.format[CorrespondenceAddressIsUk]
 }

--- a/app/models/businessdetails/LettersAddress.scala
+++ b/app/models/businessdetails/LettersAddress.scala
@@ -16,10 +16,10 @@
 
 package models.businessdetails
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class LettersAddress(lettersAddress: Boolean)
 
 object LettersAddress {
-  implicit val formats = Json.format[LettersAddress]
+  implicit val formats: OFormat[LettersAddress] = Json.format[LettersAddress]
 }

--- a/app/models/businessdetails/PreviouslyRegistered.scala
+++ b/app/models/businessdetails/PreviouslyRegistered.scala
@@ -31,7 +31,7 @@ object PreviouslyRegistered {
       case false => Reads(_ => JsSuccess(PreviouslyRegisteredNo))
     }
 
-  implicit val jsonWrites = Writes[PreviouslyRegistered] {
+  implicit val jsonWrites: Writes[PreviouslyRegistered] = Writes[PreviouslyRegistered] {
     case PreviouslyRegisteredYes(Some(value)) =>
       Json.obj(
         "previouslyRegistered" -> true,

--- a/app/models/businessdetails/RegisteredOffice.scala
+++ b/app/models/businessdetails/RegisteredOffice.scala
@@ -97,7 +97,7 @@ object RegisteredOffice {
         ) (RegisteredOfficeNonUK.apply _)
   }
 
-  implicit val jsonWrites = Writes[RegisteredOffice] {
+  implicit val jsonWrites: Writes[RegisteredOffice] = Writes[RegisteredOffice] {
 
     case m: RegisteredOfficeUK =>
       Json.obj(

--- a/app/models/businessdetails/VATRegistered.scala
+++ b/app/models/businessdetails/VATRegistered.scala
@@ -49,7 +49,7 @@ object VATRegistered {
     case false => Reads(_ => JsSuccess(VATRegisteredNo))
   }
 
-  implicit val jsonWrites = Writes[VATRegistered] {
+  implicit val jsonWrites: Writes[VATRegistered] = Writes[VATRegistered] {
     case VATRegisteredYes(value) => Json.obj(
       "registeredForVAT" -> true,
       "vrnNumber" -> value

--- a/app/models/businessmatching/BusinessActivities.scala
+++ b/app/models/businessmatching/BusinessActivities.scala
@@ -96,7 +96,7 @@ object BusinessActivity extends Enumerable.Implicits {
     case _ => JsError((JsPath \ "businessActivities") -> play.api.libs.json.JsonValidationError("error.invalid"))
   }
 
-  implicit val jsonActivityWrite = Writes[BusinessActivity] {
+  implicit val jsonActivityWrite: Writes[BusinessActivity] = Writes[BusinessActivity] {
     case AccountancyServices => JsString("01")
     case ArtMarketParticipant => JsString("08")
     case BillPaymentServices => JsString("02")
@@ -153,7 +153,7 @@ object BusinessActivities extends Logging {
     }.sortBy(_.content.mkString)
   }
 
-  implicit val format = Json.writes[BusinessActivities]
+  implicit val format: OWrites[BusinessActivities] = Json.writes[BusinessActivities]
 
   implicit val jsonReads: Reads[BusinessActivities] = {
     import play.api.libs.json.Reads.StringReads

--- a/app/models/businessmatching/BusinessAppliedForPSRNumber.scala
+++ b/app/models/businessmatching/BusinessAppliedForPSRNumber.scala
@@ -48,7 +48,7 @@ object BusinessAppliedForPSRNumber {
       case false => Reads(_ => JsSuccess(BusinessAppliedForPSRNumberNo))
   }
 
-  implicit val jsonWrites = Writes[BusinessAppliedForPSRNumber] {
+  implicit val jsonWrites: Writes[BusinessAppliedForPSRNumber] = Writes[BusinessAppliedForPSRNumber] {
     case BusinessAppliedForPSRNumberYes(value) => Json.obj(
       "appliedFor" -> true,
       "regNumber" -> value

--- a/app/models/businessmatching/BusinessMatchingMsbServices.scala
+++ b/app/models/businessmatching/BusinessMatchingMsbServices.scala
@@ -79,7 +79,7 @@ object BusinessMatchingMsbService extends Enumerable.Implicits {
     case _ => JsError((JsPath \ "services") -> play.api.libs.json.JsonValidationError("error.invalid"))
   }
 
-  implicit val jsonW = Writes[BusinessMatchingMsbService] {
+  implicit val jsonW: Writes[BusinessMatchingMsbService] = Writes[BusinessMatchingMsbService] {
     case TransmittingMoney => JsString("01")
     case CurrencyExchange => JsString("02")
     case ChequeCashingNotScrapMetal => JsString("03")
@@ -118,7 +118,7 @@ object BusinessMatchingMsbServices {
     }.sortBy(_.value)
   }
 
-  implicit val formats = Json.format[BusinessMatchingMsbServices]
+  implicit val formats: OFormat[BusinessMatchingMsbServices] = Json.format[BusinessMatchingMsbServices]
 
   def getValue(ba:BusinessMatchingMsbService): String =
     ba match {

--- a/app/models/businessmatching/BusinessType.scala
+++ b/app/models/businessmatching/BusinessType.scala
@@ -80,5 +80,5 @@ object BusinessType extends Enumerable.Implicits {
     }
   }
 
-  implicit val enumerable = Enumerable(all.map(v => v.toString -> v): _*)
+  implicit val enumerable: Enumerable[BusinessType] = Enumerable(all.map(v => v.toString -> v): _*)
 }

--- a/app/models/businessmatching/CompanyRegistrationNumber.scala
+++ b/app/models/businessmatching/CompanyRegistrationNumber.scala
@@ -16,11 +16,11 @@
 
 package models.businessmatching
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class CompanyRegistrationNumber(companyRegistrationNumber: String)
 
 
 object CompanyRegistrationNumber {
-  implicit val formats = Json.format[CompanyRegistrationNumber]
+  implicit val formats: OFormat[CompanyRegistrationNumber] = Json.format[CompanyRegistrationNumber]
 }

--- a/app/models/businessmatching/ConfirmPostcode.scala
+++ b/app/models/businessmatching/ConfirmPostcode.scala
@@ -16,10 +16,10 @@
 
 package models.businessmatching
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class ConfirmPostcode (postCode: String)
 
 object ConfirmPostcode {
-  implicit val format = Json.format[ConfirmPostcode]
+  implicit val format: OFormat[ConfirmPostcode] = Json.format[ConfirmPostcode]
 }

--- a/app/models/businessmatching/SafeId.scala
+++ b/app/models/businessmatching/SafeId.scala
@@ -16,10 +16,10 @@
 
 package models.businessmatching
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class SafeId(value: String)
 
 object SafeId {
-  implicit val format = Json.format[SafeId]
+  implicit val format: OFormat[SafeId] = Json.format[SafeId]
 }

--- a/app/models/businessmatching/TypeOfBusiness.scala
+++ b/app/models/businessmatching/TypeOfBusiness.scala
@@ -21,5 +21,5 @@ import play.api.libs.json._
 case class TypeOfBusiness(typeOfBusiness: String)
 
 object TypeOfBusiness {
-  implicit val format = Json.format[TypeOfBusiness]
+  implicit val format: OFormat[TypeOfBusiness] = Json.format[TypeOfBusiness]
 }

--- a/app/models/businessmatching/updateservice/AreNewActivitiesAtTradingPremises.scala
+++ b/app/models/businessmatching/updateservice/AreNewActivitiesAtTradingPremises.scala
@@ -32,7 +32,7 @@ object AreNewActivitiesAtTradingPremises {
       case false => Reads(_ => JsSuccess(NewActivitiesAtTradingPremisesNo))
     }
 
-  implicit val jsonWrites = Writes[AreNewActivitiesAtTradingPremises] {
+  implicit val jsonWrites: Writes[AreNewActivitiesAtTradingPremises] = Writes[AreNewActivitiesAtTradingPremises] {
     case NewActivitiesAtTradingPremisesYes(value) => Json.obj(
       "tradingPremisesNewActivities" -> true,
       "businessActivities" -> value

--- a/app/models/businessmatching/updateservice/ServiceChangeRegister.scala
+++ b/app/models/businessmatching/updateservice/ServiceChangeRegister.scala
@@ -17,7 +17,7 @@
 package models.businessmatching.updateservice
 
 import models.businessmatching.{BusinessActivity, BusinessMatchingMsbService}
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class ServiceChangeRegister(addedActivities: Option[Set[BusinessActivity]] = None,
                                  addedSubSectors: Option[Set[BusinessMatchingMsbService]] = None)
@@ -25,5 +25,5 @@ case class ServiceChangeRegister(addedActivities: Option[Set[BusinessActivity]] 
 object ServiceChangeRegister {
   val key = "service-change-register"
 
-  implicit val format = Json.format[ServiceChangeRegister]
+  implicit val format: OFormat[ServiceChangeRegister] = Json.format[ServiceChangeRegister]
 }

--- a/app/models/businessmatching/updateservice/UpdateService.scala
+++ b/app/models/businessmatching/updateservice/UpdateService.scala
@@ -38,7 +38,7 @@ object UpdateService{
 
   val key = "updateservice"
 
-  implicit val jsonWrites = Json.writes[UpdateService]
+  implicit val jsonWrites: OWrites[UpdateService] = Json.writes[UpdateService]
 
   implicit val jsonReads: Reads[UpdateService] = {
     (__ \ "areNewActivitiesAtTradingPremises").readNullable[AreNewActivitiesAtTradingPremises] and
@@ -47,6 +47,6 @@ object UpdateService{
       (__ \ "inNewServiceFlow").readNullable[Boolean].map(_.getOrElse(false))
   }.apply(UpdateService.apply _)
 
-  implicit val formatOption = Reads.optionWithNull[UpdateService]
+  implicit val formatOption: Reads[Option[UpdateService]] = Reads.optionWithNull[UpdateService]
 
 }

--- a/app/models/declaration/BusinessNominatedOfficer.scala
+++ b/app/models/declaration/BusinessNominatedOfficer.scala
@@ -16,7 +16,7 @@
 
 package models.declaration
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class BusinessNominatedOfficer(value: String)
 
@@ -24,5 +24,5 @@ object BusinessNominatedOfficer {
 
   val key = "business-nominated-officer"
 
-  implicit val format = Json.format[BusinessNominatedOfficer]
+  implicit val format: OFormat[BusinessNominatedOfficer] = Json.format[BusinessNominatedOfficer]
 }

--- a/app/models/declaration/BusinessPartners.scala
+++ b/app/models/declaration/BusinessPartners.scala
@@ -16,7 +16,7 @@
 
 package models.declaration
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class BusinessPartners(value: String){
   val indexValue = """([0-9]+)$""".r.findFirstIn(value) map {_.toInt}
@@ -26,5 +26,5 @@ object BusinessPartners {
 
   val key = "business-partners"
 
-  implicit val format = Json.format[BusinessPartners]
+  implicit val format: OFormat[BusinessPartners] = Json.format[BusinessPartners]
 }

--- a/app/models/declaration/RenewRegistration.scala
+++ b/app/models/declaration/RenewRegistration.scala
@@ -33,7 +33,7 @@ object RenewRegistration {
       case false => Reads(_ => JsSuccess(RenewRegistrationNo))
     }
 
-  implicit val jsonWrites = Writes[RenewRegistration] {
+  implicit val jsonWrites: Writes[RenewRegistration] = Writes[RenewRegistration] {
     case RenewRegistrationYes => Json.obj("renewRegistration" -> true)
     case RenewRegistrationNo  => Json.obj("renewRegistration" -> false)
   }

--- a/app/models/declaration/RoleWithinBusiness.scala
+++ b/app/models/declaration/RoleWithinBusiness.scala
@@ -58,7 +58,7 @@ object RoleWithinBusiness {
     }
   }
 
-  implicit val jsonWrites = Writes[RoleWithinBusiness] {
+  implicit val jsonWrites: Writes[RoleWithinBusiness] = Writes[RoleWithinBusiness] {
     case BeneficialShareholder => Json.obj("roleWithinBusiness" -> "01")
     case Director => Json.obj("roleWithinBusiness" -> "02")
     case ExternalAccountant => Json.obj("roleWithinBusiness" -> "03")

--- a/app/models/declaration/RoleWithinBusinessRelease7.scala
+++ b/app/models/declaration/RoleWithinBusinessRelease7.scala
@@ -174,7 +174,7 @@ object RoleWithinBusinessRelease7 extends Enumerable.Implicits {
     }.orElse(preRelease7JsonRead).orElse(fallback)
       .map(RoleWithinBusinessRelease7.apply)
 
-  implicit val jsonWrite = Writes[RoleWithinBusinessRelease7] {
+  implicit val jsonWrite: Writes[RoleWithinBusinessRelease7] = Writes[RoleWithinBusinessRelease7] {
     case RoleWithinBusinessRelease7(roleTypes) =>
       Json.obj(
         businessRolePathName -> (roleTypes map {

--- a/app/models/declaration/WhoIsRegistering.scala
+++ b/app/models/declaration/WhoIsRegistering.scala
@@ -16,7 +16,7 @@
 
 package models.declaration
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class WhoIsRegistering(person: String) {
   val indexValue = """([0-9]+)$""".r.findFirstIn(person) map {_.toInt}
@@ -26,5 +26,5 @@ object WhoIsRegistering {
 
   val key = "who-is-registering"
 
-  implicit val format = Json.format[WhoIsRegistering]
+  implicit val format: OFormat[WhoIsRegistering] = Json.format[WhoIsRegistering]
 }

--- a/app/models/deregister/DeRegisterSubscriptionRequest.scala
+++ b/app/models/deregister/DeRegisterSubscriptionRequest.scala
@@ -17,7 +17,7 @@
 package models.deregister
 
 import org.joda.time.LocalDate
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Json, Reads, Writes}
 import play.api.libs.json.JodaReads._
 
 case class DeRegisterSubscriptionRequest(acknowledgementReference: String,

--- a/app/models/deregister/DeRegisterSubscriptionRequest.scala
+++ b/app/models/deregister/DeRegisterSubscriptionRequest.scala
@@ -28,7 +28,7 @@ case class DeRegisterSubscriptionRequest(acknowledgementReference: String,
 object DeRegisterSubscriptionRequest {
   val DefaultAckReference = "A" * 32
 
-  implicit val reads = Json.reads[DeRegisterSubscriptionRequest]
+  implicit val reads: Reads[DeRegisterSubscriptionRequest] = Json.reads[DeRegisterSubscriptionRequest]
 
   implicit val writes: Writes[DeRegisterSubscriptionRequest] = {
     import play.api.libs.functional.syntax._

--- a/app/models/deregister/DeRegisterSubscriptionResponse.scala
+++ b/app/models/deregister/DeRegisterSubscriptionResponse.scala
@@ -16,12 +16,12 @@
 
 package models.deregister
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class DeRegisterSubscriptionResponse(processingDate: String)
 
 object DeRegisterSubscriptionResponse {
-  implicit val formats = Json.format[DeRegisterSubscriptionResponse]
+  implicit val formats: OFormat[DeRegisterSubscriptionResponse] = Json.format[DeRegisterSubscriptionResponse]
 }
 
 

--- a/app/models/deregister/DeregistrationReason.scala
+++ b/app/models/deregister/DeregistrationReason.scala
@@ -79,7 +79,7 @@ object DeregistrationReason extends Enumerable.Implicits {
     }
   }
 
-  implicit val jsonRedressWrites = Writes[DeregistrationReason] {
+  implicit val jsonRedressWrites: Writes[DeregistrationReason] = Writes[DeregistrationReason] {
     case OutOfScope => Json.obj("deregistrationReason" -> "Out of scope")
     case NotTradingInOwnRight => Json.obj("deregistrationReason" -> "Not trading in own right")
     case UnderAnotherSupervisor => Json.obj("deregistrationReason" -> "Under another supervisor")

--- a/app/models/eab/Eab.scala
+++ b/app/models/eab/Eab.scala
@@ -176,7 +176,7 @@ object Eab {
     }
   }
 
-  implicit val mongoKey = new MongoKey[Eab] {
+  implicit val mongoKey: MongoKey[Eab] = new MongoKey[Eab] {
     override def apply(): String = key
   }
 
@@ -255,5 +255,5 @@ object Eab {
       ) (unlift(Eab.unapply))
   }
 
-  implicit val formatOption = Reads.optionWithNull[Eab]
+  implicit val formatOption: Reads[Option[Eab]] = Reads.optionWithNull[Eab]
 }

--- a/app/models/enrolment/ErrorResponse.scala
+++ b/app/models/enrolment/ErrorResponse.scala
@@ -16,12 +16,12 @@
 
 package models.enrolment
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class ErrorResponse(code: String, message: String) {
   override def toString: String = s"$code: $message"
 }
 
 object ErrorResponse {
-  implicit val format = Json.format[ErrorResponse]
+  implicit val format: OFormat[ErrorResponse] = Json.format[ErrorResponse]
 }

--- a/app/models/enrolment/GovernmentGatewayEnrolment.scala
+++ b/app/models/enrolment/GovernmentGatewayEnrolment.scala
@@ -16,16 +16,16 @@
 
 package models.enrolment
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class EnrolmentIdentifier(key: String, value: String)
 
 object EnrolmentIdentifier {
-  implicit val format = Json.format[EnrolmentIdentifier]
+  implicit val format: OFormat[EnrolmentIdentifier] = Json.format[EnrolmentIdentifier]
 }
 
 case class GovernmentGatewayEnrolment(key: String, identifiers: List[EnrolmentIdentifier], state: String)
 
 object GovernmentGatewayEnrolment {
-  implicit val format = Json.format[GovernmentGatewayEnrolment]
+  implicit val format: OFormat[GovernmentGatewayEnrolment] = Json.format[GovernmentGatewayEnrolment]
 }

--- a/app/models/enrolment/TaxEnrolment.scala
+++ b/app/models/enrolment/TaxEnrolment.scala
@@ -16,12 +16,12 @@
 
 package models.enrolment
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OWrites}
 
 case class TaxEnrolment(userId: String, friendlyName: String, `type`: String, verifiers: Seq[EnrolmentIdentifier])
 
 object TaxEnrolment {
-  implicit val format = Json.writes[TaxEnrolment]
+  implicit val format: OWrites[TaxEnrolment] = Json.writes[TaxEnrolment]
 
   def apply(userId: String, postCode: String): TaxEnrolment =
     TaxEnrolment(userId, "AMLS Enrolment", "principal", Seq(

--- a/app/models/flowmanagement/AddBusinessTypeFlowModel.scala
+++ b/app/models/flowmanagement/AddBusinessTypeFlowModel.scala
@@ -20,7 +20,7 @@ import models.businessmatching._
 import models.businessmatching.BusinessActivity._
 import models.businessmatching.BusinessMatchingMsbService.TransmittingMoney
 import play.api.i18n.Messages
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class AddBusinessTypeFlowModel(activity: Option[BusinessActivity] = None,
                                     addMoreActivities: Option[Boolean] = None,
@@ -79,6 +79,6 @@ object AddBusinessTypeFlowModel {
 
   val key = "add-service-flow"
 
-  implicit val addServiceFlowModelFormat = Json.format[AddBusinessTypeFlowModel]
+  implicit val addServiceFlowModelFormat: OFormat[AddBusinessTypeFlowModel] = Json.format[AddBusinessTypeFlowModel]
 
 }

--- a/app/models/flowmanagement/ChangeSubSectorFlowModel.scala
+++ b/app/models/flowmanagement/ChangeSubSectorFlowModel.scala
@@ -17,7 +17,7 @@
 package models.flowmanagement
 
 import models.businessmatching.{BusinessAppliedForPSRNumber, BusinessMatchingMsbService}
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class ChangeSubSectorFlowModel(subSectors: Option[Set[BusinessMatchingMsbService]] = None,
                                     psrNumber: Option[BusinessAppliedForPSRNumber] = None
@@ -26,7 +26,7 @@ case class ChangeSubSectorFlowModel(subSectors: Option[Set[BusinessMatchingMsbSe
 object ChangeSubSectorFlowModel {
   val key = "change-sub-sector-flow"
 
-  implicit val format = Json.format[ChangeSubSectorFlowModel]
+  implicit val format: OFormat[ChangeSubSectorFlowModel] = Json.format[ChangeSubSectorFlowModel]
 
   val empty = ChangeSubSectorFlowModel()
 }

--- a/app/models/flowmanagement/RemoveBusinessTypeFlowModel.scala
+++ b/app/models/flowmanagement/RemoveBusinessTypeFlowModel.scala
@@ -18,7 +18,7 @@ package models.flowmanagement
 
 import models.DateOfChange
 import models.businessmatching.BusinessActivity
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class RemoveBusinessTypeFlowModel(activitiesToRemove: Option[Set[BusinessActivity]] = None, dateOfChange: Option[DateOfChange] = None)
 
@@ -26,5 +26,5 @@ object RemoveBusinessTypeFlowModel {
 
   val key = "remove-service-flow"
 
-  implicit val RemoveBusinessTypeFlowModelFormat = Json.format[RemoveBusinessTypeFlowModel]
+  implicit val RemoveBusinessTypeFlowModelFormat: OFormat[RemoveBusinessTypeFlowModel] = Json.format[RemoveBusinessTypeFlowModel]
 }

--- a/app/models/governmentgateway/EnrolmentResponse.scala
+++ b/app/models/governmentgateway/EnrolmentResponse.scala
@@ -16,7 +16,7 @@
 
 package models.governmentgateway
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class EnrolmentResponse(
                        serviceName: String,
@@ -26,5 +26,5 @@ case class EnrolmentResponse(
                        )
 
 object EnrolmentResponse {
-  implicit val format = Json.format[EnrolmentResponse]
+  implicit val format: OFormat[EnrolmentResponse] = Json.format[EnrolmentResponse]
 }

--- a/app/models/governmentgateway/Identifier.scala
+++ b/app/models/governmentgateway/Identifier.scala
@@ -16,7 +16,7 @@
 
 package models.governmentgateway
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class Identifier(
                      `type`: String,
@@ -24,5 +24,5 @@ case class Identifier(
                      )
 
 object Identifier {
-  implicit val format = Json.format[Identifier]
+  implicit val format: OFormat[Identifier] = Json.format[Identifier]
 }

--- a/app/models/hvd/ExciseGoods.scala
+++ b/app/models/hvd/ExciseGoods.scala
@@ -16,10 +16,10 @@
 
 package models.hvd
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class ExciseGoods(exciseGoods: Boolean)
 
 object ExciseGoods {
-  implicit val format = Json.format[ExciseGoods]
+  implicit val format: OFormat[ExciseGoods] = Json.format[ExciseGoods]
 }

--- a/app/models/hvd/Hvd.scala
+++ b/app/models/hvd/Hvd.scala
@@ -193,7 +193,7 @@ object Hvd {
 
   implicit val writes: Writes[Hvd] = Json.writes[Hvd]
 
-  implicit val formatOption = Reads.optionWithNull[Hvd]
+  implicit val formatOption: Reads[Option[Hvd]] = Reads.optionWithNull[Hvd]
 
   implicit def default(hvd: Option[Hvd]): Hvd =
     hvd.getOrElse(Hvd())

--- a/app/models/hvd/LinkedCashPayments.scala
+++ b/app/models/hvd/LinkedCashPayments.scala
@@ -16,10 +16,10 @@
 
 package models.hvd
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class LinkedCashPayments(linkedCashPayments: Boolean)
 
 object LinkedCashPayments {
-  implicit val format = Json.format[LinkedCashPayments]
+  implicit val format: OFormat[LinkedCashPayments] = Json.format[LinkedCashPayments]
 }

--- a/app/models/hvd/PercentageOfCashPaymentOver15000.scala
+++ b/app/models/hvd/PercentageOfCashPaymentOver15000.scala
@@ -59,7 +59,7 @@ object PercentageOfCashPaymentOver15000 extends Enumerable.Implicits {
 
   import utils.MappingUtils.Implicits._
 
-  implicit val jsonReads = {
+  implicit val jsonReads: Reads[PercentageOfCashPaymentOver15000] = {
     import play.api.libs.json.Reads.StringReads
     (__ \ "percentage").read[String].flatMap[PercentageOfCashPaymentOver15000] {
       case "01" => First
@@ -72,7 +72,7 @@ object PercentageOfCashPaymentOver15000 extends Enumerable.Implicits {
     }
   }
 
-  implicit val jsonWrites = Writes[PercentageOfCashPaymentOver15000] {
+  implicit val jsonWrites: Writes[PercentageOfCashPaymentOver15000] = Writes[PercentageOfCashPaymentOver15000] {
     case First => Json.obj("percentage" -> "01")
     case Second => Json.obj("percentage" -> "02")
     case Third => Json.obj("percentage" -> "03")

--- a/app/models/hvd/Products.scala
+++ b/app/models/hvd/Products.scala
@@ -178,7 +178,7 @@ object Products extends Enumerable.Implicits {
       }
     } map Products.apply
 
-  implicit val jsonWrite = Writes[Products] {
+  implicit val jsonWrite: Writes[Products] = Writes[Products] {
     case Products(transactions) =>
       Json.obj(
         "products" -> (transactions map {

--- a/app/models/moneyservicebusiness/BusinessUseAnIPSP.scala
+++ b/app/models/moneyservicebusiness/BusinessUseAnIPSP.scala
@@ -49,7 +49,7 @@ object BusinessUseAnIPSP {
     }
   }
 
-  implicit val jsonWrites = Writes[BusinessUseAnIPSP] {
+  implicit val jsonWrites: Writes[BusinessUseAnIPSP] = Writes[BusinessUseAnIPSP] {
     case BusinessUseAnIPSPYes(name ,referenceNumber) => Json.obj(
                                           "useAnIPSP" -> true,
                                            "name" -> name,

--- a/app/models/moneyservicebusiness/CETransactionsInNext12Months.scala
+++ b/app/models/moneyservicebusiness/CETransactionsInNext12Months.scala
@@ -16,10 +16,10 @@
 
 package models.moneyservicebusiness
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class CETransactionsInNext12Months (ceTransaction: String)
 
 object CETransactionsInNext12Months {
-  implicit val format = Json.format[CETransactionsInNext12Months]
+  implicit val format: OFormat[CETransactionsInNext12Months] = Json.format[CETransactionsInNext12Months]
 }

--- a/app/models/moneyservicebusiness/ExpectedThroughput.scala
+++ b/app/models/moneyservicebusiness/ExpectedThroughput.scala
@@ -74,7 +74,7 @@ object ExpectedThroughput extends Enumerable.Implicits {
 
   import utils.MappingUtils.Implicits._
 
-  implicit val jsonReads = {
+  implicit val jsonReads: Reads[ExpectedThroughput] = {
     import play.api.libs.json.Reads.StringReads
     (__ \ "throughput").read[String].flatMap[ExpectedThroughput] {
       case "01" => First
@@ -89,7 +89,7 @@ object ExpectedThroughput extends Enumerable.Implicits {
     }
   }
 
-  implicit val jsonWrites = Writes[ExpectedThroughput] {
+  implicit val jsonWrites: Writes[ExpectedThroughput] = Writes[ExpectedThroughput] {
     case First => Json.obj("throughput" -> "01")
     case Second => Json.obj("throughput" -> "02")
     case Third => Json.obj("throughput" -> "03")

--- a/app/models/moneyservicebusiness/FXTransactionsInNext12Months.scala
+++ b/app/models/moneyservicebusiness/FXTransactionsInNext12Months.scala
@@ -16,10 +16,10 @@
 
 package models.moneyservicebusiness
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class FXTransactionsInNext12Months (fxTransaction: String)
 
 object FXTransactionsInNext12Months {
-    implicit val format = Json.format[FXTransactionsInNext12Months]
+    implicit val format: OFormat[FXTransactionsInNext12Months] = Json.format[FXTransactionsInNext12Months]
 }

--- a/app/models/moneyservicebusiness/FundsTransfer.scala
+++ b/app/models/moneyservicebusiness/FundsTransfer.scala
@@ -16,10 +16,10 @@
 
 package models.moneyservicebusiness
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class FundsTransfer(transferWithoutFormalSystems: Boolean)
 
 object FundsTransfer {
-  implicit val formats = Json.format[FundsTransfer]
+  implicit val formats: OFormat[FundsTransfer] = Json.format[FundsTransfer]
 }

--- a/app/models/moneyservicebusiness/IdentifyLinkedTransactions.scala
+++ b/app/models/moneyservicebusiness/IdentifyLinkedTransactions.scala
@@ -16,10 +16,10 @@
 
 package models.moneyservicebusiness
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class IdentifyLinkedTransactions (linkedTxn: Boolean)
 
 object IdentifyLinkedTransactions {
-  implicit val format =  Json.format[IdentifyLinkedTransactions]
+  implicit val format: OFormat[IdentifyLinkedTransactions] =  Json.format[IdentifyLinkedTransactions]
 }

--- a/app/models/moneyservicebusiness/MoneyServiceBusiness.scala
+++ b/app/models/moneyservicebusiness/MoneyServiceBusiness.scala
@@ -200,7 +200,7 @@ object MoneyServiceBusiness {
 
   implicit val writes: Writes[MoneyServiceBusiness] = Json.writes[MoneyServiceBusiness]
 
-  implicit val formatOption = Reads.optionWithNull[MoneyServiceBusiness]
+  implicit val formatOption: Reads[Option[MoneyServiceBusiness]] = Reads.optionWithNull[MoneyServiceBusiness]
 
   implicit def default(value: Option[MoneyServiceBusiness]): MoneyServiceBusiness = {
     value.getOrElse(MoneyServiceBusiness())

--- a/app/models/moneyservicebusiness/SendMoneyToOtherCountry.scala
+++ b/app/models/moneyservicebusiness/SendMoneyToOtherCountry.scala
@@ -16,12 +16,12 @@
 
 package models.moneyservicebusiness
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class SendMoneyToOtherCountry(money: Boolean)
 
 object SendMoneyToOtherCountry {
-  implicit val format =  Json.format[SendMoneyToOtherCountry]
+  implicit val format: OFormat[SendMoneyToOtherCountry] =  Json.format[SendMoneyToOtherCountry]
 }
 
 

--- a/app/models/moneyservicebusiness/TransactionsInNext12Months.scala
+++ b/app/models/moneyservicebusiness/TransactionsInNext12Months.scala
@@ -16,11 +16,11 @@
 
 package models.moneyservicebusiness
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class TransactionsInNext12Months(txnAmount: String)
 
 object TransactionsInNext12Months {
-  implicit val format = Json.format[TransactionsInNext12Months]
+  implicit val format: OFormat[TransactionsInNext12Months] = Json.format[TransactionsInNext12Months]
 }
 

--- a/app/models/moneyservicebusiness/UsesForeignCurrencies.scala
+++ b/app/models/moneyservicebusiness/UsesForeignCurrencies.scala
@@ -42,7 +42,7 @@ object UsesForeignCurrencies {
     }
   }
 
-  implicit val jsonWrites = Writes[UsesForeignCurrencies] {
+  implicit val jsonWrites: Writes[UsesForeignCurrencies] = Writes[UsesForeignCurrencies] {
     case UsesForeignCurrenciesYes => Json.obj("foreignCurrencies" -> true)
     case UsesForeignCurrenciesNo => Json.obj("foreignCurrencies" -> false)
   }

--- a/app/models/notifications/ContactType.scala
+++ b/app/models/notifications/ContactType.scala
@@ -73,7 +73,7 @@ object ContactType {
       case _ => JsError((JsPath \ "contact_type") -> play.api.libs.json.JsonValidationError("error.invalid"))
     }
 
-  implicit val jsonWrites =
+  implicit val jsonWrites: Writes[ContactType] =
     Writes[ContactType] {
       case RejectionReasons => JsString("REJR")
       case RevocationReasons => JsString("REVR")

--- a/app/models/notifications/DeregisteredReason.scala
+++ b/app/models/notifications/DeregisteredReason.scala
@@ -43,7 +43,7 @@ object DeregisteredReason {
       }
    }
 
-  implicit val jsonWrites = Writes[DeregisteredReason] {
+  implicit val jsonWrites: Writes[DeregisteredReason] = Writes[DeregisteredReason] {
     case CeasedTrading => JsString("01")
     case HVDNoCashPayment => JsString("02")
     case OutOfScope => JsString("03")

--- a/app/models/notifications/NotificationResponse.scala
+++ b/app/models/notifications/NotificationResponse.scala
@@ -27,7 +27,7 @@ object NotificationResponse {
 
   val dateTimeFormat = ISODateTimeFormat.dateTimeNoMillis().withZoneUTC
 
-  implicit val readsJodaLocalDateTime = Reads[LocalDateTime](js =>
+  implicit val readsJodaLocalDateTime: Reads[LocalDateTime] = Reads[LocalDateTime](js =>
     js.validate[String].map[LocalDateTime](dtString =>
       LocalDateTime.parse(dtString, dateTimeFormat)
     )
@@ -37,5 +37,5 @@ object NotificationResponse {
     def writes(dateTime: LocalDateTime): JsValue = JsString(dateTimeFormat.print(dateTime.toDateTime(DateTimeZone.UTC)))
   }
   implicit val dateFormat: Format[DateTime] = MongoJodaFormats.dateTimeFormat
-  implicit val format = Json.format[NotificationResponse]
+  implicit val format: OFormat[NotificationResponse] = Json.format[NotificationResponse]
 }

--- a/app/models/notifications/RejectedReason.scala
+++ b/app/models/notifications/RejectedReason.scala
@@ -40,7 +40,7 @@ object RejectedReason {
     }
   }
 
-  implicit val jsonWrites = Writes[RejectedReason] {
+  implicit val jsonWrites: Writes[RejectedReason] = Writes[RejectedReason] {
     case NonCompliant => JsString("01")
     case FailedToRespond => JsString("02")
     case FailedToPayCharges => JsString("03")

--- a/app/models/notifications/RevokedReason.scala
+++ b/app/models/notifications/RevokedReason.scala
@@ -42,7 +42,7 @@ object RevokedReason {
     }
   }
 
-  implicit val jsonWrites = Writes[RevokedReason] {
+  implicit val jsonWrites: Writes[RevokedReason] = Writes[RevokedReason] {
     case RevokedMissingTrader =>  JsString("01")
     case RevokedCeasedTrading =>  JsString("02")
     case RevokedNonCompliant =>  JsString("03")

--- a/app/models/notifications/StatusType.scala
+++ b/app/models/notifications/StatusType.scala
@@ -38,7 +38,7 @@ object StatusType {
       case _ => JsError(JsPath -> play.api.libs.json.JsonValidationError("error.invalid"))
     }
 
-  implicit val jsonWrites =
+  implicit val jsonWrites: Writes[StatusType] =
     Writes[StatusType] {
       case Approved => JsString("04")
       case Rejected => JsString("06")

--- a/app/models/payments/CreateBacsPaymentRequest.scala
+++ b/app/models/payments/CreateBacsPaymentRequest.scala
@@ -16,10 +16,10 @@
 
 package models.payments
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class CreateBacsPaymentRequest(amlsReference: String, paymentReference: String, safeId: String, amountInPence: Int)
 
 case object CreateBacsPaymentRequest {
-  implicit val format = Json.format[CreateBacsPaymentRequest]
+  implicit val format: OFormat[CreateBacsPaymentRequest] = Json.format[CreateBacsPaymentRequest]
 }

--- a/app/models/payments/CreatePaymentRequest.scala
+++ b/app/models/payments/CreatePaymentRequest.scala
@@ -17,10 +17,10 @@
 package models.payments
 
 import models.ReturnLocation
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OWrites}
 
 case class CreatePaymentRequest(taxType: String, reference: String, description: String, amountInPence: Int, returnUrl: ReturnLocation)
 
 object CreatePaymentRequest {
-  implicit val format = Json.writes[CreatePaymentRequest]
+  implicit val format: OWrites[CreatePaymentRequest] = Json.writes[CreatePaymentRequest]
 }

--- a/app/models/payments/CreatePaymentResponse.scala
+++ b/app/models/payments/CreatePaymentResponse.scala
@@ -16,7 +16,7 @@
 
 package models.payments
 
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json.{Format, Json, OFormat}
 import play.api.libs.functional.syntax._
 
 case class NextUrl(value: String)
@@ -28,5 +28,5 @@ object NextUrl {
 case class CreatePaymentResponse(nextUrl: NextUrl, journeyId: String)
 
 object CreatePaymentResponse {
-  implicit val format = Json.format[CreatePaymentResponse]
+  implicit val format: OFormat[CreatePaymentResponse] = Json.format[CreatePaymentResponse]
 }

--- a/app/models/payments/Payment.scala
+++ b/app/models/payments/Payment.scala
@@ -49,7 +49,7 @@ case class Payment(
                     updatedAt: Option[LocalDateTime] = None)
 
 object Payment {
-  implicit val statusFormat = EnumFormat(PaymentStatuses)
+  implicit val statusFormat: Format[PaymentStatus] = EnumFormat(PaymentStatuses)
 
   implicit val writes: OWrites[Payment] = Json.writes[Payment]
 

--- a/app/models/payments/Payment.scala
+++ b/app/models/payments/Payment.scala
@@ -67,5 +67,5 @@ object Payment {
         (__ \ "updatedAt").readNullable[LocalDateTime]
       ) (Payment(_, _, _, _, _, _, _, _, _, _))
 
-  implicit val format = OFormat(reads,writes)
+  implicit val format: OFormat[Payment] = OFormat(reads,writes)
 }

--- a/app/models/payments/PaymentStatusResult.scala
+++ b/app/models/payments/PaymentStatusResult.scala
@@ -16,11 +16,11 @@
 
 package models.payments
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class PaymentStatusResult(amlsRef: String, paymentId: String, currentStatus: PaymentStatus)
 
 object PaymentStatusResult {
   import Payment._
-  implicit val format = Json.format[PaymentStatusResult]
+  implicit val format: OFormat[PaymentStatusResult] = Json.format[PaymentStatusResult]
 }

--- a/app/models/payments/RefreshPaymentStatusRequest.scala
+++ b/app/models/payments/RefreshPaymentStatusRequest.scala
@@ -16,11 +16,11 @@
 
 package models.payments
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class RefreshPaymentStatusRequest(paymentReference: String)
 
 object RefreshPaymentStatusRequest {
-  implicit val format = Json.format[RefreshPaymentStatusRequest]
+  implicit val format: OFormat[RefreshPaymentStatusRequest] = Json.format[RefreshPaymentStatusRequest]
 }
 

--- a/app/models/payments/UpdateBacsRequest.scala
+++ b/app/models/payments/UpdateBacsRequest.scala
@@ -16,10 +16,10 @@
 
 package models.payments
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class UpdateBacsRequest(isBacs: Boolean)
 
 object UpdateBacsRequest {
-  implicit val format = Json.format[UpdateBacsRequest]
+  implicit val format: OFormat[UpdateBacsRequest] = Json.format[UpdateBacsRequest]
 }

--- a/app/models/registrationdetails/RegistrationDetails.scala
+++ b/app/models/registrationdetails/RegistrationDetails.scala
@@ -16,10 +16,10 @@
 
 package models.registrationdetails
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Reads}
 
 case class RegistrationDetails(companyName: String, isIndividual: Boolean)
 
 object RegistrationDetails {
-  implicit val reads = Json.reads[RegistrationDetails]
+  implicit val reads: Reads[RegistrationDetails] = Json.reads[RegistrationDetails]
 }

--- a/app/models/renewal/AMLSTurnover.scala
+++ b/app/models/renewal/AMLSTurnover.scala
@@ -50,7 +50,7 @@ object AMLSTurnover extends Enumerable.Implicits {
 
   import utils.MappingUtils.Implicits._
 
-  implicit val jsonReads = {
+  implicit val jsonReads: Reads[AMLSTurnover] = {
     import play.api.libs.json.Reads.StringReads
     (__ \ "turnover").read[String].flatMap[AMLSTurnover] {
       case "01" => First
@@ -65,7 +65,7 @@ object AMLSTurnover extends Enumerable.Implicits {
     }
   }
 
-  implicit val jsonWrites = Writes[AMLSTurnover] {
+  implicit val jsonWrites: Writes[AMLSTurnover] = Writes[AMLSTurnover] {
     case First => Json.obj("turnover" -> "01")
     case Second => Json.obj("turnover" -> "02")
     case Third => Json.obj("turnover" -> "03")

--- a/app/models/renewal/AMPTurnover.scala
+++ b/app/models/renewal/AMPTurnover.scala
@@ -44,7 +44,7 @@ object AMPTurnover extends Enumerable.Implicits {
 
   import utils.MappingUtils.Implicits._
 
-  implicit val jsonReads = {
+  implicit val jsonReads: Reads[AMPTurnover] = {
     import play.api.libs.json.Reads.StringReads
     (__ \ "percentageExpectedTurnover").read[String].flatMap[AMPTurnover] {
       case "01" => First
@@ -57,7 +57,7 @@ object AMPTurnover extends Enumerable.Implicits {
     }
   }
 
-  implicit val jsonWrites = Writes[AMPTurnover] {
+  implicit val jsonWrites: Writes[AMPTurnover] = Writes[AMPTurnover] {
     case First => Json.obj("percentageExpectedTurnover" -> "01")
     case Second => Json.obj("percentageExpectedTurnover" -> "02")
     case Third => Json.obj("percentageExpectedTurnover" -> "03")

--- a/app/models/renewal/BusinessTurnover.scala
+++ b/app/models/renewal/BusinessTurnover.scala
@@ -67,7 +67,7 @@ object BusinessTurnover extends Enumerable.Implicits {
     }
   }
 
-  implicit val jsonWrites = Writes[BusinessTurnover] {
+  implicit val jsonWrites: Writes[BusinessTurnover] = Writes[BusinessTurnover] {
     case First => Json.obj("businessTurnover" -> "01")
     case Second => Json.obj("businessTurnover" -> "02")
     case Third => Json.obj("businessTurnover" -> "03")

--- a/app/models/renewal/CETransactionsInLast12Months.scala
+++ b/app/models/renewal/CETransactionsInLast12Months.scala
@@ -16,13 +16,13 @@
 
 package models.renewal
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class CETransactionsInLast12Months(ceTransaction: String)
 
 object CETransactionsInLast12Months {
 
-  implicit val format = Json.format[CETransactionsInLast12Months]
+  implicit val format: OFormat[CETransactionsInLast12Months] = Json.format[CETransactionsInLast12Months]
 
   implicit def convert(model: CETransactionsInLast12Months): models.moneyservicebusiness.CETransactionsInNext12Months = {
     models.moneyservicebusiness.CETransactionsInNext12Months(model.ceTransaction)

--- a/app/models/renewal/CustomersOutsideIsUK.scala
+++ b/app/models/renewal/CustomersOutsideIsUK.scala
@@ -16,10 +16,10 @@
 
 package models.renewal
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class CustomersOutsideIsUK(isOutside: Boolean)
 
 object CustomersOutsideIsUK {
-  implicit val formats = Json.format[CustomersOutsideIsUK]
+  implicit val formats: OFormat[CustomersOutsideIsUK] = Json.format[CustomersOutsideIsUK]
 }

--- a/app/models/renewal/FXTransactionsInLast12Months.scala
+++ b/app/models/renewal/FXTransactionsInLast12Months.scala
@@ -16,13 +16,13 @@
 
 package models.renewal
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class FXTransactionsInLast12Months(fxTransaction: String)
 
 object FXTransactionsInLast12Months {
 
-  implicit val format = Json.format[FXTransactionsInLast12Months]
+  implicit val format: OFormat[FXTransactionsInLast12Months] = Json.format[FXTransactionsInLast12Months]
 
   implicit def convert(model: FXTransactionsInLast12Months): models.moneyservicebusiness.FXTransactionsInNext12Months = {
     models.moneyservicebusiness.FXTransactionsInNext12Months(model.fxTransaction)

--- a/app/models/renewal/InvolvedInOther.scala
+++ b/app/models/renewal/InvolvedInOther.scala
@@ -34,7 +34,7 @@ object InvolvedInOther {
       case false => Reads(_ => JsSuccess(InvolvedInOtherNo))
     }
 
-  implicit val jsonWrites = Writes[InvolvedInOther] {
+  implicit val jsonWrites: Writes[InvolvedInOther] = Writes[InvolvedInOther] {
     case InvolvedInOtherYes(details) => Json.obj(
       "involvedInOther" -> true,
       "details" -> details

--- a/app/models/renewal/PaymentMethods.scala
+++ b/app/models/renewal/PaymentMethods.scala
@@ -86,7 +86,7 @@ object PaymentMethods extends Enumerable.Implicits {
     )
   }
 
-  implicit val jsonW = Writes[PaymentMethods] {x =>
+  implicit val jsonW: Writes[PaymentMethods] = Writes[PaymentMethods] { x =>
     val jsMethods = Json.obj("courier" -> x.courier,
       "direct" -> x.direct,
       "other" -> x.other.isDefined)

--- a/app/models/renewal/PercentageOfCashPaymentOver15000.scala
+++ b/app/models/renewal/PercentageOfCashPaymentOver15000.scala
@@ -43,7 +43,7 @@ object PercentageOfCashPaymentOver15000 extends Enumerable.Implicits {
 
   import utils.MappingUtils.Implicits._
 
-  implicit val jsonReads = {
+  implicit val jsonReads: Reads[PercentageOfCashPaymentOver15000] = {
     import play.api.libs.json.Reads.StringReads
     (__ \ "percentage").read[String].flatMap[PercentageOfCashPaymentOver15000] {
       case "01" => First

--- a/app/models/renewal/Renewal.scala
+++ b/app/models/renewal/Renewal.scala
@@ -17,7 +17,7 @@
 package models.renewal
 
 import models.Country
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Json, OWrites, Reads}
 
 case class Renewal(involvedInOtherActivities: Option[InvolvedInOther] = None,
                    businessTurnover: Option[BusinessTurnover] = None,
@@ -156,7 +156,7 @@ object Renewal {
   val key = "renewal"
   val sectionKey = "renewal"
 
-  implicit val format = Json.writes[Renewal]
+  implicit val format: OWrites[Renewal] = Json.writes[Renewal]
 
   implicit val jsonReads: Reads[Renewal] = {
     import play.api.libs.functional.syntax._

--- a/app/models/renewal/SendMoneyToOtherCountry.scala
+++ b/app/models/renewal/SendMoneyToOtherCountry.scala
@@ -16,13 +16,13 @@
 
 package models.renewal
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class SendMoneyToOtherCountry(money: Boolean)
 
 object SendMoneyToOtherCountry {
 
-  implicit val format =  Json.format[SendMoneyToOtherCountry]
+  implicit val format: OFormat[SendMoneyToOtherCountry] =  Json.format[SendMoneyToOtherCountry]
 
   def convert(model: SendMoneyToOtherCountry): models.moneyservicebusiness.SendMoneyToOtherCountry = {
     model match {

--- a/app/models/renewal/TotalThroughput.scala
+++ b/app/models/renewal/TotalThroughput.scala
@@ -18,7 +18,7 @@ package models.renewal
 
 import models.moneyservicebusiness.ExpectedThroughput
 import play.api.i18n.Messages
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class TotalThroughput(throughput: String)
 
@@ -39,7 +39,7 @@ object TotalThroughput {
     case Mapping(model.throughput, label, _) => messages(label)
   }.getOrElse("")
 
-  implicit val format = Json.format[TotalThroughput]
+  implicit val format: OFormat[TotalThroughput] = Json.format[TotalThroughput]
 
   implicit def convert(model: TotalThroughput): ExpectedThroughput = {
     throughputValues.collectFirst {

--- a/app/models/renewal/TransactionsInLast12Months.scala
+++ b/app/models/renewal/TransactionsInLast12Months.scala
@@ -16,13 +16,13 @@
 
 package models.renewal
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class TransactionsInLast12Months(transfers: String)
 
 object TransactionsInLast12Months {
 
-  implicit val format = Json.format[TransactionsInLast12Months]
+  implicit val format: OFormat[TransactionsInLast12Months] = Json.format[TransactionsInLast12Months]
 
   implicit def convert(model: TransactionsInLast12Months): models.moneyservicebusiness.TransactionsInNext12Months = {
     models.moneyservicebusiness.TransactionsInNext12Months(model.transfers)

--- a/app/models/renewal/UsesForeignCurrencies.scala
+++ b/app/models/renewal/UsesForeignCurrencies.scala
@@ -33,7 +33,7 @@ object UsesForeignCurrencies {
     }
   }
 
-  implicit val jsonWrites = Writes[UsesForeignCurrencies] {
+  implicit val jsonWrites: Writes[UsesForeignCurrencies] = Writes[UsesForeignCurrencies] {
     case UsesForeignCurrenciesYes => Json.obj("foreignCurrencies" -> true)
     case UsesForeignCurrenciesNo => Json.obj("foreignCurrencies" -> false)
   }

--- a/app/models/responsiblepeople/Training.scala
+++ b/app/models/responsiblepeople/Training.scala
@@ -32,7 +32,7 @@ object Training {
       case false => Reads(_ => JsSuccess(TrainingNo))
     }
 
-  implicit val jsonWrites = Writes[Training] {
+  implicit val jsonWrites: Writes[Training] = Writes[Training] {
     case TrainingYes(information) => Json.obj(
       "training" -> true,
       "information" -> information

--- a/app/models/responsiblepeople/UKPassport.scala
+++ b/app/models/responsiblepeople/UKPassport.scala
@@ -32,7 +32,7 @@ object UKPassport {
     }
   }
 
-  implicit val jsonWrites = Writes[UKPassport] {
+  implicit val jsonWrites: Writes[UKPassport] = Writes[UKPassport] {
     case UKPassportYes(value) => Json.obj(
       "ukPassport" -> true,
       "ukPassportNumber" -> value

--- a/app/models/responsiblepeople/VATRegistered.scala
+++ b/app/models/responsiblepeople/VATRegistered.scala
@@ -32,7 +32,7 @@ object VATRegistered {
     case false => Reads(_ => JsSuccess(VATRegisteredNo))
   }
 
-  implicit val jsonWrites = Writes[VATRegistered] {
+  implicit val jsonWrites: Writes[VATRegistered] = Writes[VATRegistered] {
     case VATRegisteredYes(value) => Json.obj(
       "registeredForVAT" -> true,
       "vrnNumber" -> value

--- a/app/models/status/ConfirmationStatus.scala
+++ b/app/models/status/ConfirmationStatus.scala
@@ -16,7 +16,7 @@
 
 package models.status
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class ConfirmationStatus(submissionConfirmed: Option[Boolean])
 
@@ -24,5 +24,5 @@ object ConfirmationStatus {
 
   val key = "Submission_Indicator"
 
-  implicit val format = Json.format[ConfirmationStatus]
+  implicit val format: OFormat[ConfirmationStatus] = Json.format[ConfirmationStatus]
 }

--- a/app/models/supervision/AnotherBody.scala
+++ b/app/models/supervision/AnotherBody.scala
@@ -113,7 +113,7 @@ object AnotherBody {
     }
   }
 
-  implicit val jsonWrites = Writes[AnotherBody] {
+  implicit val jsonWrites: Writes[AnotherBody] = Writes[AnotherBody] {
     case a : AnotherBodyYes => {
      Json.obj("anotherBody" -> true,
         "supervisorName" -> a.supervisorName,

--- a/app/models/supervision/ProfessionalBody.scala
+++ b/app/models/supervision/ProfessionalBody.scala
@@ -32,7 +32,7 @@ object ProfessionalBody {
     case false => Reads(_ => JsSuccess(ProfessionalBodyNo))
   }
 
-  implicit val jsonWrites = Writes[ProfessionalBody] {
+  implicit val jsonWrites: Writes[ProfessionalBody] = Writes[ProfessionalBody] {
     case ProfessionalBodyYes(value) => Json.obj(
       "penalised" -> true,
       "professionalBody" -> value

--- a/app/models/supervision/ProfessionalBodyMember.scala
+++ b/app/models/supervision/ProfessionalBodyMember.scala
@@ -33,7 +33,7 @@ object ProfessionalBodyMember {
     }
   }
 
-  implicit val jsonWrites = Writes[ProfessionalBodyMember] {
+  implicit val jsonWrites: Writes[ProfessionalBodyMember] = Writes[ProfessionalBodyMember] {
     case ProfessionalBodyMemberYes => Json.obj("isAMember" -> true)
     case ProfessionalBodyMemberNo => Json.obj("isAMember" -> false)
   }


### PR DESCRIPTION
Cleaning up compiler warnings for "Implicit definition should have explicit type" on implicit vals. Not all have been removed but they have been reduced.