### PR TITLE
DDCYLS-3042 Update various depedencies, removal of some unused

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,5 @@
-$govuk-assets-path: "/agent/assets/lib/govuk-frontend/govuk/assets/";
-@import "lib/govuk-frontend/govuk/base";
+$govuk-assets-path: "/agent/assets/lib/govuk-frontend/dist/govuk/assets/";
+@import "lib/govuk-frontend/dist/govuk/base";
 
 .registration-status-tag {
   float: right;

--- a/app/controllers/businessmatching/updateservice/ChangeBusinessTypesController.scala
+++ b/app/controllers/businessmatching/updateservice/ChangeBusinessTypesController.scala
@@ -21,10 +21,8 @@ import cats.implicits._
 import connectors.DataCacheConnector
 import controllers.{AmlsBaseController, CommonPlayDependencies}
 import forms.businessmatching.updateservice.ChangeBusinessTypesFormProvider
-import models.businessmatching._
 import models.businessmatching.updateservice.ChangeBusinessType
 import models.flowmanagement.ChangeBusinessTypesPageId
-import play.api.i18n.Messages
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.businessmatching.BusinessMatchingService
 import services.flowmanagement.Router
@@ -34,7 +32,6 @@ import views.html.businessmatching.updateservice.ChangeServicesView
 
 import javax.inject.Inject
 import scala.collection.immutable.SortedSet
-import scala.concurrent.Future
 
 class ChangeBusinessTypesController @Inject()(authAction: AuthAction,
                                               val ds: CommonPlayDependencies,
@@ -71,18 +68,11 @@ class ChangeBusinessTypesController @Inject()(authAction: AuthAction,
       )
   }
 
-  private def getFormData(credId: String)(implicit dataCacheConnector: DataCacheConnector, hc: HeaderCarrier, messages: Messages) = for {
-    cache <- OptionT(dataCacheConnector.fetchAll(credId))
-    businessMatching <- OptionT.fromOption[Future](cache.getEntry[BusinessMatching](BusinessMatching.key))
+  private def getFormData(credId: String)(implicit hc: HeaderCarrier) = for {
     activities <- businessMatchingService.getRemainingBusinessActivities(credId)
     remainingActivities = activities.map(_.toString)
   } yield {
-    val existing = addHelper.prefixedActivities(businessMatching)
-
-    val existingSorted = SortedSet[String]() ++ existing
     val remainingActivitiesSorted = SortedSet[String]() ++ remainingActivities
-
     remainingActivitiesSorted
   }
-
 }

--- a/app/controllers/businessmatching/updateservice/remove/WhatDateRemovedController.scala
+++ b/app/controllers/businessmatching/updateservice/remove/WhatDateRemovedController.scala
@@ -24,7 +24,6 @@ import forms.DateOfChangeFormProvider
 import models.flowmanagement._
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.flowmanagement.Router
-import uk.gov.hmrc.http.HeaderCarrier
 import utils.AuthAction
 import views.html.DateOfChangeView
 
@@ -63,7 +62,7 @@ class WhatDateRemovedController @Inject()(authAction: AuthAction,
       )
   }
 
-  private def getFormData(credId: String)(implicit hc: HeaderCarrier): OptionT[Future, RemoveBusinessTypeFlowModel] = for {
+  private def getFormData(credId: String): OptionT[Future, RemoveBusinessTypeFlowModel] = for {
     model <- OptionT(dataCacheConnector.fetch[RemoveBusinessTypeFlowModel](credId, RemoveBusinessTypeFlowModel.key))
   } yield model
 

--- a/app/controllers/responsiblepeople/DetailedAnswersController.scala
+++ b/app/controllers/responsiblepeople/DetailedAnswersController.scala
@@ -91,7 +91,7 @@ class DetailedAnswersController @Inject () (
       case Some(x) if x.copy(hasAccepted = true).isComplete => showHideAddressMove(amlsRegistrationNo, accountTypeId, credId, x.lineId) flatMap { showHide =>
         isMsbOrTcsp(credId).map {
           msbOrTcsp: Option[Boolean] =>
-            val shouldShowApprovalSection = !(msbOrTcsp.contains(true)) && x.approvalFlags.hasAlreadyPassedFitAndProper.contains(false)
+            val shouldShowApprovalSection = !msbOrTcsp.contains(true) && x.approvalFlags.hasAlreadyPassedFitAndProper.contains(false)
             val personName = ControllerHelper.rpTitleName(Some(x))
             val summaryList = cyaHelper.getSummaryList(x, businessMatching, personName, index, flow, showHide, shouldShowApprovalSection)
             Ok(view(summaryList, index, showHide, personName, flow))
@@ -113,11 +113,10 @@ class DetailedAnswersController @Inject () (
       }
   }
 
-  private def isMsbOrTcsp(credId: String)(implicit hc: HeaderCarrier): Future[Option[Boolean]] = {
+  private def isMsbOrTcsp(credId: String): Future[Option[Boolean]] =
     for {
       businessmatching <- dataCacheConnector.fetch[BusinessMatching](credId, BusinessMatching.key)
     } yield businessmatching.map(_.msbOrTcsp)
-  }
 
   private def redirectFromDeclarationFlow(amlsRegistrationNo: Option[String], accountTypeId: (String, String), credId: String)(implicit hc: HeaderCarrier) =
     (for {
@@ -135,7 +134,7 @@ class DetailedAnswersController @Inject () (
         Redirect(DeclarationHelper.routeDependingOnNominatedOfficer(hasNominatedOfficer, status))
     }) getOrElse InternalServerError("Cannot determine redirect")
 
-  private def fetchModel(credId: String)(implicit hc: HeaderCarrier) =
+  private def fetchModel(credId: String) =
     dataCacheConnector.fetch[Seq[ResponsiblePerson]](credId, ResponsiblePerson.key)
 
 }

--- a/app/controllers/responsiblepeople/RemoveResponsiblePersonController.scala
+++ b/app/controllers/responsiblepeople/RemoveResponsiblePersonController.scala
@@ -27,7 +27,6 @@ import services.StatusService
 import utils.{AuthAction, RepeatingSection, StatusConstants}
 import views.html.responsiblepeople.RemoveResponsiblePersonView
 
-import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatter.ofPattern
 import scala.concurrent.Future
 

--- a/app/controllers/tcsp/SummaryController.scala
+++ b/app/controllers/tcsp/SummaryController.scala
@@ -20,17 +20,16 @@ import cats.data.OptionT
 import cats.implicits._
 import connectors.DataCacheConnector
 import controllers.{AmlsBaseController, CommonPlayDependencies}
-import javax.inject.Inject
 import models.tcsp._
-import services.StatusService
-import services.businessmatching.ServiceFlow
-import uk.gov.hmrc.http.HeaderCarrier
-import views.html.tcsp.CheckYourAnswersView
 import play.api.Logging
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.StatusService
+import services.businessmatching.ServiceFlow
 import utils.AuthAction
 import utils.tcsp.CheckYourAnswersHelper
+import views.html.tcsp.CheckYourAnswersView
 
+import javax.inject.Inject
 import scala.concurrent.Future
 
 class SummaryController @Inject()(
@@ -61,5 +60,5 @@ class SummaryController @Inject()(
         } yield Redirect(controllers.routes.RegistrationProgressController.get)) getOrElse InternalServerError("Cannot update Tcsp")
   }
 
-  private def fetchModel(credId: String)(implicit hc: HeaderCarrier): Future[Option[Tcsp]] = dataCache.fetch[Tcsp](credId, Tcsp.key)
+  private def fetchModel(credId: String): Future[Option[Tcsp]] = dataCache.fetch[Tcsp](credId, Tcsp.key)
 }

--- a/app/controllers/tradingpremises/RemoveTradingPremisesController.scala
+++ b/app/controllers/tradingpremises/RemoveTradingPremisesController.scala
@@ -92,7 +92,7 @@ class RemoveTradingPremisesController @Inject () (
                   }
                 } yield Redirect(routes.YourTradingPremisesController.get(complete))
               }
-              case _ => removeWithoutDate
+              case _ => removeWithoutDate()
             }
           }
         }
@@ -149,7 +149,7 @@ class RemoveTradingPremisesController @Inject () (
                       }
                     )
                 }.getOrElse(throw new RuntimeException("Could not access trading premises"))
-              case _ => removeWithoutDate
+              case _ => removeWithoutDate()
             }
           }
         }

--- a/app/models/ReadStatusResponse.scala
+++ b/app/models/ReadStatusResponse.scala
@@ -19,7 +19,7 @@ package models
 import play.api.libs.json._
 
 import java.time.format.DateTimeFormatter
-import java.time.{LocalDate, LocalDateTime, ZoneId}
+import java.time.{LocalDate, LocalDateTime}
 
 case class ReadStatusResponse(
                                processingDate: LocalDateTime,

--- a/app/models/notifications/NotificationDetails.scala
+++ b/app/models/notifications/NotificationDetails.scala
@@ -20,7 +20,7 @@ import cats.implicits._
 import models.confirmation.Currency
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+import play.custom.JsPathSupport.{localDateTimeReads, localDateTimeWrites}
 import utils.ContactTypeHelper
 
 import java.time.format.DateTimeFormatter
@@ -53,7 +53,7 @@ object NotificationDetails {
         (JsPath \ "status").readNullable[Status] and
         (JsPath \ "messageText").readNullable[String] and
         (JsPath \ "variation").read[Boolean] and
-        (JsPath \ "receivedAt").read[LocalDateTime]((MongoJavatimeFormats.localDateTimeFormat))
+        (JsPath \ "receivedAt").read[LocalDateTime](localDateTimeReads)
       )(NotificationDetails.apply _)
 
   val writes : OWrites[NotificationDetails ] =
@@ -62,7 +62,7 @@ object NotificationDetails {
         (JsPath \ "status").writeNullable[Status] and
         (JsPath \ "messageText").writeNullable[String] and
         (JsPath \ "variation").write[Boolean] and
-        (JsPath \ "receivedAt").write[LocalDateTime]((MongoJavatimeFormats.localDateTimeFormat))
+        (JsPath \ "receivedAt").write[LocalDateTime](localDateTimeWrites)
       )(unlift(NotificationDetails.unapply))
 
   implicit val format: OFormat[NotificationDetails] = OFormat(reads, writes)

--- a/app/models/notifications/NotificationRow.scala
+++ b/app/models/notifications/NotificationRow.scala
@@ -21,10 +21,10 @@ import models.notifications.RejectedReason._
 import play.api.i18n.Messages
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import play.custom.JsPathSupport.{localDateTimeReads, localDateTimeWrites}
 import uk.gov.hmrc.govukfrontend.views.Aliases.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.table.TableRow
-import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 import utils.ContactTypeHelper
 
 import java.time.LocalDateTime
@@ -129,7 +129,7 @@ case class NotificationRow(
 }
 
 object NotificationRow {
-  implicit val dateTimeFormat: Format[LocalDateTime] = MongoJavatimeFormats.localDateTimeFormat
+  implicit val dateTimeFormat: Format[LocalDateTime] = Format(localDateTimeReads, localDateTimeWrites)
 
   val reads: Reads[NotificationRow] =
     (
@@ -137,7 +137,7 @@ object NotificationRow {
         (JsPath \ "contactType").readNullable[ContactType] and
         (JsPath \ "contactNumber").readNullable[String] and
         (JsPath \ "variation").read[Boolean] and
-        (JsPath \ "receivedAt").read[LocalDateTime](MongoJavatimeFormats.localDateTimeReads) and
+        (JsPath \ "receivedAt").read[LocalDateTime](localDateTimeReads) and
         (JsPath \ "isRead").read[Boolean] and
         (JsPath \ "amlsRegistrationNumber").read[String] and
         (JsPath \ "templatePackageVersion").read[String] and
@@ -150,7 +150,7 @@ object NotificationRow {
         (JsPath \ "contactType").writeNullable[ContactType] and
         (JsPath \ "contactNumber").writeNullable[String] and
         (JsPath \ "variation").write[Boolean] and
-        (JsPath \ "receivedAt").write[LocalDateTime](MongoJavatimeFormats.localDateTimeWrites) and
+        (JsPath \ "receivedAt").write[LocalDateTime](localDateTimeWrites) and
         (JsPath \ "isRead").write[Boolean] and
         (JsPath \ "amlsRegistrationNumber").write[String] and
         (JsPath \ "templatePackageVersion").write[String] and

--- a/app/services/cache/MongoCacheClient.scala
+++ b/app/services/cache/MongoCacheClient.scala
@@ -22,17 +22,17 @@ import org.mongodb.scala.bson.BsonDocument
 import org.mongodb.scala.model._
 import play.api.libs.json.OFormat.oFormatFromReadsAndOWrites
 import play.api.libs.json._
+import play.custom.JsPathSupport.{localDateTimeReads, localDateTimeWrites}
 import uk.gov.hmrc.crypto.json.{JsonDecryptor, JsonEncryptor}
 import uk.gov.hmrc.crypto.{ApplicationCrypto, _}
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.mongo.MongoComponent
-import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
 
 import java.time.{LocalDateTime, ZoneOffset}
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.SECONDS
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 // $COVERAGE-OFF$
@@ -60,12 +60,12 @@ case class Cache(id: String, data: Map[String, JsValue], lastUpdated: LocalDateT
 }
 
 object Cache {
-  implicit val dateFormat = MongoJavatimeFormats.localDateTimeFormat
-  implicit val format = Json.format[Cache]
+  implicit val dateFormat: Format[LocalDateTime] = Format(localDateTimeReads, localDateTimeWrites)
+  implicit val format: OFormat[Cache] = Json.format[Cache]
 
   def apply(cacheMap: CacheMap): Cache = Cache(cacheMap.id, cacheMap.data)
 
-  val empty = Cache("", Map())
+  val empty: Cache = Cache("", Map())
 }
 
 /**

--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -73,9 +73,12 @@
 }
 
 @scripts = {
-    <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("lib/govuk-frontend/govuk/all.js")'></script>
     <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("lib/hmrc-frontend/hmrc/all.js")'></script>
-    <script @CSPNonce.attr>window.GOVUKFrontend.initAll();window.HMRCFrontend.initAll()</script>
+    <script @CSPNonce.attr type="module">
+        import { initAll } from '@routes.Assets.versioned("lib/govuk-frontend/dist/govuk/govuk-frontend.min.js")'
+        initAll()
+    </script>
+    <script @CSPNonce.attr>window.HMRCFrontend.initAll()</script>
     @autocompleteJavascript()
     <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("submitButtonDisable.js")'></script>
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,4 +1,3 @@
-import play.core.PlayVersion
 import play.sbt.PlayImport.ws
 import sbt.*
 
@@ -7,27 +6,24 @@ private object AppDependencies {
   private val playV = "play-28"
   private val flexmarkVersion = "0.64.8"
   private val bootstrapV = "6.0.0"
-  private val hmrcMongoV = "0.71.0"
+  private val hmrcMongoV = "1.8.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,
     // GOV UK
-    "uk.gov.hmrc"           %% "domain"                        % s"8.1.0-$playV",
+    "uk.gov.hmrc"           %% "domain"                        % s"8.3.0-$playV",
     "uk.gov.hmrc"           %% "play-partials"                 % s"8.3.0-$playV",
     "uk.gov.hmrc"           %% "http-caching-client"           % s"10.0.0-$playV",
     "uk.gov.hmrc"           %% "json-encryption"               % s"5.3.0-$playV",
     "uk.gov.hmrc.mongo"     %% s"hmrc-mongo-$playV"            % hmrcMongoV,
     "uk.gov.hmrc"           %% s"bootstrap-frontend-$playV"    % bootstrapV,
-    "uk.gov.hmrc"           %% s"play-frontend-hmrc-$playV"    % "8.5.0",
+    "uk.gov.hmrc"           %% s"play-frontend-hmrc-$playV"    % "9.7.0",
     "uk.gov.hmrc"           %% "play-conditional-form-mapping" % s"1.13.0-$playV",
     // OTHER
     "com.vladsch.flexmark"   % "flexmark-all"                  % flexmarkVersion,
     "com.beachape"          %% "enumeratum-play"               % "1.6.3",
-    "com.squareup.okhttp3"   % "mockwebserver"                 % "4.12.0",
     "org.typelevel"         %% "cats-core"                     % "2.10.0",
-    "commons-codec"          % "commons-codec"                 % "1.15",
-    // PLAY
-    "com.typesafe.play"     %% "play-json"                     % "2.8.1",
+    "commons-codec"          % "commons-codec"                 % "1.15"
   )
 
   trait ScopeDependencies {
@@ -42,12 +38,7 @@ private object AppDependencies {
         "uk.gov.hmrc"            %% s"bootstrap-test-$playV"  % bootstrapV          % scope,
         "uk.gov.hmrc.mongo"      %% s"hmrc-mongo-test-$playV" % hmrcMongoV          % scope,
         "org.scalatestplus.play" %% "scalatestplus-play"      % "7.0.1"             % scope,
-        "org.scalatestplus"      %% "scalacheck-1-15"         % "3.2.11.0"          % scope,
-        "org.scalacheck"         %% "scalacheck"              % "1.17.0"            % scope,
-        "org.jsoup"               % "jsoup"                   % "1.17.2"            % scope,
-        "com.typesafe.play"      %% "play-test"               % PlayVersion.current % scope,
-        "org.mockito"             % "mockito-all"             % "1.10.19"           % scope,
-        "com.vladsch.flexmark"    % "flexmark-all"            % "0.64.8"            % scope
+        "org.scalatestplus"      %% "scalacheck-1-17"         % "3.2.17.0"          % scope
       )
     }.dependencies
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.21.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.5.0")
-addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.20" exclude("org.slf4j", "slf4j-simple"))
+addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.21" exclude("org.slf4j", "slf4j-simple"))
 addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "2.0.9")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"  % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"   %  "sbt-digest"             % "1.1.3")

--- a/test/connectors/AmlsConnectorSpec.scala
+++ b/test/connectors/AmlsConnectorSpec.scala
@@ -25,8 +25,7 @@ import models.payments._
 import models.registrationdetails.RegistrationDetails
 import models.withdrawal._
 import models.{AmendVariationRenewalResponse, _}
-import org.mockito.Matchers
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatestplus.mockito.MockitoSugar
@@ -39,7 +38,8 @@ import java.time.{LocalDate, LocalDateTime}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class AmlsConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures with IntegrationPatience with AmlsReferenceNumberGenerator with PaymentGenerator {
+class AmlsConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures with IntegrationPatience with
+  AmlsReferenceNumberGenerator with PaymentGenerator {
 
   val amlsConnector = new AmlsConnector(http = mock[HttpClient],
                                         appConfig = mock[ApplicationConfig])
@@ -262,7 +262,7 @@ class AmlsConnectorSpec extends PlaySpec with MockitoSugar with ScalaFutures wit
       val id = "fcguhio"
 
       when {
-        amlsConnector.http.POSTString[HttpResponse](Matchers.any(), eqTo(id), Matchers.any())(Matchers.any(), Matchers.any(), Matchers.any())
+        amlsConnector.http.POSTString[HttpResponse](any(), eqTo(id), any())(any(), any(), any())
       } thenReturn Future.successful(HttpResponse(CREATED, ""))
 
       whenReady(amlsConnector.savePayment(id, amlsRegistrationNumber, safeId, accountTypeId)) {

--- a/test/connectors/AmlsNotificationConnectorSpec.scala
+++ b/test/connectors/AmlsNotificationConnectorSpec.scala
@@ -18,7 +18,7 @@ package connectors
 
 import config.ApplicationConfig
 import models.notifications._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/connectors/AuthenticatorConnectorSpec.scala
+++ b/test/connectors/AuthenticatorConnectorSpec.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import config.ApplicationConfig
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import uk.gov.hmrc.http.HttpResponse

--- a/test/connectors/BusinessMatchingConnectorSpec.scala
+++ b/test/connectors/BusinessMatchingConnectorSpec.scala
@@ -16,7 +16,7 @@
 
 package connectors
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import play.api.libs.json.Json

--- a/test/connectors/EnrolmentStubConnectorSpec.scala
+++ b/test/connectors/EnrolmentStubConnectorSpec.scala
@@ -19,7 +19,7 @@ package connectors
 import config.ApplicationConfig
 import generators.BaseGenerator
 import models.enrolment.{EnrolmentIdentifier, GovernmentGatewayEnrolment}
-import org.mockito.Matchers.{any}
+import org.mockito.ArgumentMatchers.{any}
 import org.mockito.Mockito.{verify, when}
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HttpClient

--- a/test/connectors/FeeConnectorSpec.scala
+++ b/test/connectors/FeeConnectorSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import generators.AmlsReferenceNumberGenerator
 import models.ResponseType.SubscriptionResponseType
 import models._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/connectors/GovernmentGatewayConnectorSpec.scala
+++ b/test/connectors/GovernmentGatewayConnectorSpec.scala
@@ -19,7 +19,7 @@ package connectors
 import exceptions.{DuplicateEnrolmentException, InvalidEnrolmentCredentialsException}
 import generators.{AmlsReferenceNumberGenerator, BaseGenerator, GovernmentGatewayGenerator}
 import models.governmentgateway.EnrolmentRequest
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}

--- a/test/connectors/KeystoreConnectorSpec.scala
+++ b/test/connectors/KeystoreConnectorSpec.scala
@@ -18,7 +18,7 @@ package connectors
 
 import config.AmlsSessionCache
 import models.status.ConfirmationStatus
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.ScalaFutures

--- a/test/connectors/PayApiConnectorSpec.scala
+++ b/test/connectors/PayApiConnectorSpec.scala
@@ -18,7 +18,7 @@ package connectors
 
 import models.ReturnLocation
 import models.payments.{CreatePaymentRequest, CreatePaymentResponse, NextUrl}
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent._
 import play.api.libs.json.{JsNull, Json}

--- a/test/connectors/TaxEnrolmentsConnectorSpec.scala
+++ b/test/connectors/TaxEnrolmentsConnectorSpec.scala
@@ -21,7 +21,7 @@ import exceptions.{DuplicateEnrolmentException, InvalidEnrolmentCredentialsExcep
 import generators.auth.UserDetailsGenerator
 import generators.{AmlsReferenceNumberGenerator, BaseGenerator}
 import models.enrolment.{AmlsEnrolmentKey, ErrorResponse, TaxEnrolment}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}

--- a/test/connectors/TestOnlyStubConnectorSpec.scala
+++ b/test/connectors/TestOnlyStubConnectorSpec.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import config.ApplicationConfig
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers

--- a/test/connectors/cache/MongoCacheConnectorSpec.scala
+++ b/test/connectors/cache/MongoCacheConnectorSpec.scala
@@ -16,7 +16,7 @@
 
 package connectors.cache
 
-import org.mockito.Matchers.{any, eq => meq}
+import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.{reset, when}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}

--- a/test/controllers/AssetsControllerSpec.scala
+++ b/test/controllers/AssetsControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import models.autocomplete.LocationGraphTransformer
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec

--- a/test/controllers/BacsConfirmationControllerSpec.scala
+++ b/test/controllers/BacsConfirmationControllerSpec.scala
@@ -29,7 +29,7 @@ import models.registrationdetails.RegistrationDetails
 import models.status._
 import models.{status => _, _}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import services._

--- a/test/controllers/ConfirmationControllerSpec.scala
+++ b/test/controllers/ConfirmationControllerSpec.scala
@@ -31,7 +31,7 @@ import models.registrationdetails.RegistrationDetails
 import models.status.{SubmissionDecisionApproved, _}
 import models.{status => _, _}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.Injecting

--- a/test/controllers/LandingControllerWithAmendmentsSpec.scala
+++ b/test/controllers/LandingControllerWithAmendmentsSpec.scala
@@ -38,7 +38,7 @@ import models.supervision.Supervision
 import models.tcsp.Tcsp
 import models.tradingpremises.TradingPremises
 import models.{status => _, _}
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito
 import org.mockito.Mockito._
 import org.scalatest.matchers.must.Matchers

--- a/test/controllers/LandingControllerWithoutAmendmentsSpec.scala
+++ b/test/controllers/LandingControllerWithoutAmendmentsSpec.scala
@@ -29,7 +29,7 @@ import models.responsiblepeople.TimeAtAddress.OneToThreeYears
 import models.responsiblepeople._
 import models.status._
 import models.{status => _, _}
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import play.api.mvc.{BodyParsers, Result}
 import play.api.test.Helpers._

--- a/test/controllers/NotificationControllerSpec.scala
+++ b/test/controllers/NotificationControllerSpec.scala
@@ -28,7 +28,7 @@ import models.notifications.{ContactType, IDType, NotificationDetails, Notificat
 import models.registrationdetails.RegistrationDetails
 import models.status.{SubmissionDecisionRejected, SubmissionReadyForReview}
 import models.{Country, ReadStatusResponse}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/PaymentConfirmationControllerSpec.scala
+++ b/test/controllers/PaymentConfirmationControllerSpec.scala
@@ -32,7 +32,7 @@ import models.renewal.{InvolvedInOtherNo, Renewal}
 import models.status._
 import models.{status => _, _}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/RegistrationProgressControllerSpec.scala
+++ b/test/controllers/RegistrationProgressControllerSpec.scala
@@ -29,7 +29,7 @@ import models.renewal.{Renewal, _}
 import models.responsiblepeople.{ResponsiblePeopleValues, ResponsiblePerson}
 import models.status._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{any, eq => meq}
+import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito._
 import play.api.http.Status.OK
 import play.api.test.Helpers._

--- a/test/controllers/RetryPaymentControllerSpec.scala
+++ b/test/controllers/RetryPaymentControllerSpec.scala
@@ -28,7 +28,7 @@ import models.payments._
 import models.registrationdetails.RegistrationDetails
 import models.status._
 import models.{status => _, _}
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import services._

--- a/test/controllers/StatusControllerSpec.scala
+++ b/test/controllers/StatusControllerSpec.scala
@@ -32,8 +32,7 @@ import models.responsiblepeople._
 import models.status._
 import models.{status => _, _}
 import org.jsoup.Jsoup
-import org.mockito.Matchers
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.http.Status.OK
 import play.api.i18n.Messages
@@ -275,7 +274,7 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with Injecting
         when(controllerNoAmlsNumber.landingService.cacheMap(any[String])(any(), any()))
           .thenReturn(Future.successful(Some(cacheMap)))
 
-        when(cacheMap.getEntry[BusinessMatching](Matchers.contains(BusinessMatching.key))(any()))
+        when(cacheMap.getEntry[BusinessMatching](contains(BusinessMatching.key))(any()))
           .thenReturn(Some(BusinessMatching(Some(reviewDetails), None)))
 
         when(controllerNoAmlsNumber.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any(), any()))
@@ -336,7 +335,7 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with Injecting
         when(controller.dataCache.fetch[BusinessMatching](any(), any())(any()))
           .thenReturn(Future.successful(Some(BusinessMatching(Some(reviewDetails), Some(BusinessActivities(Set(TelephonePaymentService)))))))
 
-        when(cacheMap.getEntry[SubscriptionResponse](Matchers.contains(SubscriptionResponse.key))(any()))
+        when(cacheMap.getEntry[SubscriptionResponse](contains(SubscriptionResponse.key))(any()))
           .thenReturn(Some(SubscriptionResponse("", "", Some(SubscriptionFees("", 0, None, None, None, None, 0, None, 0)))))
 
         val readStatusResponse = ReadStatusResponse(LocalDateTime.now(), "Approved", None, None, None,
@@ -359,10 +358,10 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with Injecting
         when(controller.landingService.cacheMap(any[String])(any(), any()))
           .thenReturn(Future.successful(Some(cacheMap)))
 
-        when(cacheMap.getEntry[BusinessMatching](Matchers.contains(BusinessMatching.key))(any()))
+        when(cacheMap.getEntry[BusinessMatching](contains(BusinessMatching.key))(any()))
           .thenReturn(Some(BusinessMatching(Some(reviewDetails), None)))
 
-        when(cacheMap.getEntry[SubscriptionResponse](Matchers.contains(SubscriptionResponse.key))(any()))
+        when(cacheMap.getEntry[SubscriptionResponse](contains(SubscriptionResponse.key))(any()))
           .thenReturn(Some(SubscriptionResponse("", "", Some(SubscriptionFees("", 0, None, None, None, None, 0, None, 0)))))
 
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any(), any()))
@@ -384,10 +383,10 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with Injecting
         when(controller.landingService.cacheMap(any[String])(any(), any()))
           .thenReturn(Future.successful(Some(cacheMap)))
 
-        when(cacheMap.getEntry[BusinessMatching](Matchers.contains(BusinessMatching.key))(any()))
+        when(cacheMap.getEntry[BusinessMatching](contains(BusinessMatching.key))(any()))
           .thenReturn(Some(BusinessMatching(Some(reviewDetails), None)))
 
-        when(cacheMap.getEntry[SubscriptionResponse](Matchers.contains(SubscriptionResponse.key))(any()))
+        when(cacheMap.getEntry[SubscriptionResponse](contains(SubscriptionResponse.key))(any()))
           .thenReturn(Some(SubscriptionResponse("", "", Some(SubscriptionFees("", 0, None, None, None, None, 0, None, 0)))))
 
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any(), any()))
@@ -410,10 +409,10 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with Injecting
         when(controller.landingService.cacheMap(any[String])(any(), any()))
           .thenReturn(Future.successful(Some(cacheMap)))
 
-        when(cacheMap.getEntry[BusinessMatching](Matchers.contains(BusinessMatching.key))(any()))
+        when(cacheMap.getEntry[BusinessMatching](contains(BusinessMatching.key))(any()))
           .thenReturn(Some(BusinessMatching(Some(reviewDetails), None)))
 
-        when(cacheMap.getEntry[SubscriptionResponse](Matchers.contains(SubscriptionResponse.key))(any()))
+        when(cacheMap.getEntry[SubscriptionResponse](contains(SubscriptionResponse.key))(any()))
           .thenReturn(Some(SubscriptionResponse("", "", Some(SubscriptionFees("", 0, None, None, None, None, 0, None, 0)))))
 
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any(), any()))
@@ -432,10 +431,10 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with Injecting
         when(controller.landingService.cacheMap(any[String])(any(), any()))
           .thenReturn(Future.successful(Some(cacheMap)))
 
-        when(cacheMap.getEntry[BusinessMatching](Matchers.contains(BusinessMatching.key))(any()))
+        when(cacheMap.getEntry[BusinessMatching](contains(BusinessMatching.key))(any()))
           .thenReturn(Some(BusinessMatching(Some(reviewDetails), None)))
 
-        when(cacheMap.getEntry[SubscriptionResponse](Matchers.contains(SubscriptionResponse.key))(any()))
+        when(cacheMap.getEntry[SubscriptionResponse](contains(SubscriptionResponse.key))(any()))
           .thenReturn(Some(SubscriptionResponse("", "", Some(SubscriptionFees("", 0, None, None, None, None, 0, None, 0)))))
 
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any(), any()))
@@ -458,10 +457,10 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with Injecting
         when(controller.landingService.cacheMap(any[String])(any(), any()))
           .thenReturn(Future.successful(Some(cacheMap)))
 
-        when(cacheMap.getEntry[BusinessMatching](Matchers.contains(BusinessMatching.key))(any()))
+        when(cacheMap.getEntry[BusinessMatching](contains(BusinessMatching.key))(any()))
           .thenReturn(Some(BusinessMatching(Some(reviewDetails), None)))
 
-        when(cacheMap.getEntry[SubscriptionResponse](Matchers.contains(SubscriptionResponse.key))(any()))
+        when(cacheMap.getEntry[SubscriptionResponse](contains(SubscriptionResponse.key))(any()))
           .thenReturn(Some(SubscriptionResponse("", "", Some(SubscriptionFees("", 0, None, None, None, None, 0, None, 0)))))
 
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any(), any()))
@@ -484,10 +483,10 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with Injecting
         when(controller.landingService.cacheMap(any[String])(any(), any()))
           .thenReturn(Future.successful(Some(cacheMap)))
 
-        when(cacheMap.getEntry[BusinessMatching](Matchers.contains(BusinessMatching.key))(any()))
+        when(cacheMap.getEntry[BusinessMatching](contains(BusinessMatching.key))(any()))
           .thenReturn(Some(BusinessMatching(Some(reviewDetails), None)))
 
-        when(cacheMap.getEntry[SubscriptionResponse](Matchers.contains(SubscriptionResponse.key))(any()))
+        when(cacheMap.getEntry[SubscriptionResponse](contains(SubscriptionResponse.key))(any()))
           .thenReturn(Some(SubscriptionResponse("", "", Some(SubscriptionFees("", 0, None, None, None, None, 0, None, 0)))))
 
         when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any(), any()))
@@ -507,10 +506,10 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with Injecting
         when(controller.landingService.cacheMap(any[String])(any(), any()))
           .thenReturn(Future.successful(Some(cacheMap)))
 
-        when(cacheMap.getEntry[BusinessMatching](Matchers.contains(BusinessMatching.key))(any()))
+        when(cacheMap.getEntry[BusinessMatching](contains(BusinessMatching.key))(any()))
           .thenReturn(Some(BusinessMatching(Some(reviewDetails), None)))
 
-        when(cacheMap.getEntry[SubscriptionResponse](Matchers.contains(SubscriptionResponse.key))(any()))
+        when(cacheMap.getEntry[SubscriptionResponse](contains(SubscriptionResponse.key))(any()))
           .thenReturn(Some(SubscriptionResponse("", "", Some(SubscriptionFees("", 0, None, None, None, None, 0, None, 0)))))
 
         when(controller.renewalService.isCachePresent(any())(any(), any())).thenReturn(Future.successful(true))
@@ -538,10 +537,10 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with Injecting
         when(controller.landingService.cacheMap(any[String])(any(), any()))
           .thenReturn(Future.successful(Some(cacheMap)))
 
-        when(cacheMap.getEntry[BusinessMatching](Matchers.contains(BusinessMatching.key))(any()))
+        when(cacheMap.getEntry[BusinessMatching](contains(BusinessMatching.key))(any()))
           .thenReturn(Some(BusinessMatching(Some(reviewDetails), None)))
 
-        when(cacheMap.getEntry[SubscriptionResponse](Matchers.contains(SubscriptionResponse.key))(any()))
+        when(cacheMap.getEntry[SubscriptionResponse](contains(SubscriptionResponse.key))(any()))
           .thenReturn(Some(SubscriptionResponse("", "", Some(SubscriptionFees("", 0, None, None, None, None, 0, None, 0)))))
 
         when(controller.renewalService.isRenewalComplete(any(), any[String]())(any(), any()))
@@ -582,7 +581,7 @@ class StatusControllerSpec extends AmlsSpec with PaymentGenerator with Injecting
             reviewDetails = Some(ReviewDetails("BusinessName", None, mock[Address], "safeId", None))
           )))
 
-        when(cacheMap.getEntry[SubscriptionResponse](Matchers.contains(SubscriptionResponse.key))(any()))
+        when(cacheMap.getEntry[SubscriptionResponse](contains(SubscriptionResponse.key))(any()))
           .thenReturn(Some(SubscriptionResponse("", "", Some(SubscriptionFees("", 0, None, None, None, None, 0, None, 0)))))
 
         val dataCache = mock[DataCacheConnector]

--- a/test/controllers/SubmissionControllerSpec.scala
+++ b/test/controllers/SubmissionControllerSpec.scala
@@ -24,7 +24,7 @@ import models.registrationprogress.{Completed, Started, TaskRow}
 import models.renewal.Renewal
 import models.status._
 import models.{AmendVariationRenewalResponse, SubmissionResponse, SubscriptionFees, SubscriptionResponse}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import play.api.test.Helpers._

--- a/test/controllers/amp/AmpControllerSpec.scala
+++ b/test/controllers/amp/AmpControllerSpec.scala
@@ -26,7 +26,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
 import utils.{AmlsSpec, AuthAction, AuthorisedFixture, CacheMocks}
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import play.api.test.FakeRequest
 import services.ProxyCacheService
 

--- a/test/controllers/applicationstatus/HowToPayControllerSpec.scala
+++ b/test/controllers/applicationstatus/HowToPayControllerSpec.scala
@@ -21,7 +21,7 @@ import generators.submission.SubscriptionResponseGenerator
 import models.ResponseType.SubscriptionResponseType
 import models.{FeeResponse, ResponseType}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import utils.{AmlsSpec, AuthorisedFixture, DependencyMocks, FeeHelper}

--- a/test/controllers/asp/OtherBusinessTaxMattersControllerSpec.scala
+++ b/test/controllers/asp/OtherBusinessTaxMattersControllerSpec.scala
@@ -21,7 +21,7 @@ import forms.asp.OtherBusinessTaxMattersFormProvider
 import models.asp.{Asp, OtherBusinessTaxMattersYes}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/asp/ServicesOfBusinessDateOfChangeControllerSpec.scala
+++ b/test/controllers/asp/ServicesOfBusinessDateOfChangeControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.DateOfChangeFormProvider
 import models.asp._
 import models.businessdetails.ActivityStartDate
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/asp/SummaryControllerSpec.scala
+++ b/test/controllers/asp/SummaryControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers.asp
 
 import controllers.actions.SuccessfulAuthAction
 import models.asp.Asp
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest

--- a/test/controllers/bankdetails/BankAccountHasIbanControllerSpec.scala
+++ b/test/controllers/bankdetails/BankAccountHasIbanControllerSpec.scala
@@ -21,8 +21,8 @@ import forms.bankdetails.BankAccountHasIBANFormProvider
 import models.bankdetails.BankAccountType.PersonalAccount
 import models.bankdetails._
 import models.status.{SubmissionDecisionApproved, SubmissionReady, SubmissionReadyForReview}
-import org.mockito.Matchers
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
@@ -133,7 +133,7 @@ class BankAccountHasIbanControllerSpec extends AmlsSpec with Injecting {
             "hasIBAN" -> "true"
           )
 
-          when(controller.auditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any()))
+          when(controller.auditConnector.sendEvent(any())(any(), any()))
             .thenReturn(Future.successful(AuditResult.Success))
 
           mockCacheFetch[Seq[BankDetails]](Some(Seq(BankDetails(Some(PersonalAccount), None))), Some(BankDetails.key))

--- a/test/controllers/bankdetails/BankAccountIbanControllerSpec.scala
+++ b/test/controllers/bankdetails/BankAccountIbanControllerSpec.scala
@@ -23,9 +23,9 @@ import models.bankdetails._
 import models.status.{SubmissionDecisionApproved, SubmissionReady, SubmissionReadyForReview}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.mockito.{ArgumentCaptor, Matchers}
+import org.mockito.ArgumentCaptor
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
 import uk.gov.hmrc.play.audit.http.connector.AuditResult.Success
@@ -168,7 +168,7 @@ class BankAccountIbanControllerSpec extends AmlsSpec with Injecting {
             "IBANNumber" -> "12345"
           )
 
-          when(controller.auditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any()))
+          when(controller.auditConnector.sendEvent(any())(any(), any()))
             .thenReturn(Future.successful(AuditResult.Success))
 
           mockCacheFetch[Seq[BankDetails]](Some(Seq(BankDetails(Some(PersonalAccount), None))), Some(BankDetails.key))

--- a/test/controllers/bankdetails/BankAccountIsUKControllerSpec.scala
+++ b/test/controllers/bankdetails/BankAccountIsUKControllerSpec.scala
@@ -21,8 +21,8 @@ import forms.bankdetails.BankAccountIsUKFormProvider
 import models.bankdetails.BankAccountType.PersonalAccount
 import models.bankdetails._
 import models.status.{SubmissionDecisionApproved, SubmissionReady, SubmissionReadyForReview}
-import org.mockito.Matchers
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
@@ -133,7 +133,7 @@ class BankAccountIsUKControllerSpec extends AmlsSpec with Injecting {
             "isUK" -> "false"
           )
 
-          when(controller.auditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any()))
+          when(controller.auditConnector.sendEvent(any())(any(), any()))
             .thenReturn(Future.successful(AuditResult.Success))
 
           mockCacheFetch[Seq[BankDetails]](Some(Seq(BankDetails(Some(PersonalAccount), None))), Some(BankDetails.key))

--- a/test/controllers/bankdetails/BankAccountNonUKControllerSpec.scala
+++ b/test/controllers/bankdetails/BankAccountNonUKControllerSpec.scala
@@ -23,9 +23,9 @@ import models.bankdetails._
 import models.status.{SubmissionDecisionApproved, SubmissionReady, SubmissionReadyForReview}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.mockito.{ArgumentCaptor, Matchers}
+import org.mockito.ArgumentCaptor
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
 import uk.gov.hmrc.play.audit.http.connector.AuditResult.Success
@@ -167,7 +167,7 @@ class BankAccountNonUKControllerSpec extends AmlsSpec with Injecting {
             "nonUKAccountNumber" -> "1234567890123456789012345678901234567890"
           )
 
-          when(controller.auditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any()))
+          when(controller.auditConnector.sendEvent(any())(any(), any()))
             .thenReturn(Future.successful(AuditResult.Success))
 
           mockCacheFetch[Seq[BankDetails]](Some(Seq(BankDetails(Some(PersonalAccount), None))), Some(BankDetails.key))

--- a/test/controllers/bankdetails/BankAccountTypeControllerSpec.scala
+++ b/test/controllers/bankdetails/BankAccountTypeControllerSpec.scala
@@ -22,7 +22,7 @@ import models.bankdetails.BankAccountType.{BelongsToBusiness, BelongsToOtherBusi
 import models.bankdetails._
 import models.status.{SubmissionDecisionApproved, SubmissionReady, SubmissionReadyForReview}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages

--- a/test/controllers/bankdetails/BankAccountUKControllerSpec.scala
+++ b/test/controllers/bankdetails/BankAccountUKControllerSpec.scala
@@ -23,9 +23,9 @@ import models.bankdetails._
 import models.status.{SubmissionDecisionApproved, SubmissionReady, SubmissionReadyForReview}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.mockito.{ArgumentCaptor, Matchers}
+import org.mockito.ArgumentCaptor
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}
@@ -170,7 +170,7 @@ class BankAccountUKControllerSpec extends AmlsSpec with MockitoSugar with Inject
             "sortCode" -> "123456"
           )
 
-          when(controller.auditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any()))
+          when(controller.auditConnector.sendEvent(any())(any(), any()))
             .thenReturn(Future.successful(AuditResult.Success))
 
           mockCacheFetch[Seq[BankDetails]](Some(Seq(BankDetails(Some(PersonalAccount), None))), Some(BankDetails.key))

--- a/test/controllers/bankdetails/RemoveBankDetailsControllerSpec.scala
+++ b/test/controllers/bankdetails/RemoveBankDetailsControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import models.bankdetails.BankAccountType.PersonalAccount
 import models.bankdetails._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import utils.{AmlsSpec, DependencyMocks, StatusConstants}

--- a/test/controllers/bankdetails/SummaryControllerSpec.scala
+++ b/test/controllers/bankdetails/SummaryControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import models.bankdetails.BankAccountType._
 import models.bankdetails._
 import models.status.SubmissionReady
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/businessactivities/AccountantForAMLSRegulationsControllerSpec.scala
+++ b/test/controllers/businessactivities/AccountantForAMLSRegulationsControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.businessactivities.AccountantForAMLSRegulationsFormProvider
 import models.businessactivities.{AccountantForAMLSRegulations, BusinessActivities, TaxMatters, WhoIsYourAccountant}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/businessactivities/BusinessFranchiseControllerSpec.scala
+++ b/test/controllers/businessactivities/BusinessFranchiseControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.businessactivities.BusinessFranchiseFormProvider
 import models.businessactivities.BusinessFranchiseYes
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
@@ -132,7 +132,7 @@ class BusinessFranchiseControllerSpec extends AmlsSpec with MockitoSugar with Sc
           val result = controller.post()(newRequest)
           status(result) must be(BAD_REQUEST)
 
-          verifyZeroInteractions(mockService)
+          verifyNoInteractions(mockService)
         }
       }
     }

--- a/test/controllers/businessactivities/DocumentRiskAssessmentPolicyControllerSpec.scala
+++ b/test/controllers/businessactivities/DocumentRiskAssessmentPolicyControllerSpec.scala
@@ -22,7 +22,7 @@ import models.businessactivities._
 import models.businessmatching.BusinessActivity.{AccountancyServices, MoneyServiceBusiness}
 import models.businessmatching.{BusinessMatching, BusinessActivities => BMBusinessActivities}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
@@ -136,7 +136,7 @@ class DocumentRiskAssessmentPolicyControllerSpec extends AmlsSpec with MockitoSu
             val result = controller.post()(newRequest)
             status(result) must be(BAD_REQUEST)
 
-            verifyZeroInteractions(mockService)
+            verifyNoInteractions(mockService)
           }
 
           "riskassessments fields are missing, represented by an empty string" in new Fixture {
@@ -150,7 +150,7 @@ class DocumentRiskAssessmentPolicyControllerSpec extends AmlsSpec with MockitoSu
             val result = controller.post()(newRequest)
             status(result) must be(BAD_REQUEST)
 
-            verifyZeroInteractions(mockService)
+            verifyNoInteractions(mockService)
           }
         }
       }

--- a/test/controllers/businessactivities/EmployeeCountAMLSSupervisionControllerSpec.scala
+++ b/test/controllers/businessactivities/EmployeeCountAMLSSupervisionControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.businessactivities.EmployeeCountAMLSSupervisionFormProvider
 import models.businessactivities.EmployeeCountAMLSSupervision
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessactivities/ExpectedAMLSTurnoverControllerSpec.scala
+++ b/test/controllers/businessactivities/ExpectedAMLSTurnoverControllerSpec.scala
@@ -25,7 +25,7 @@ import models.businessmatching.BusinessActivity._
 import models.businessmatching.{BusinessMatching, BusinessActivities => Activities}
 import models.status.NotCompleted
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures

--- a/test/controllers/businessactivities/ExpectedBusinessTurnoverControllerSpec.scala
+++ b/test/controllers/businessactivities/ExpectedBusinessTurnoverControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.businessactivities.ExpectedBusinessTurnoverFormProvider
 import models.businessactivities.{BusinessActivities, ExpectedBusinessTurnover}
 import models.status.NotCompleted
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessactivities/HowManyEmployeesControllerSpec.scala
+++ b/test/controllers/businessactivities/HowManyEmployeesControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.businessactivities
 import controllers.actions.SuccessfulAuthAction
 import forms.businessactivities.EmployeeCountFormProvider
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessactivities/IdentifiySuspiciousActivityControllerSpec.scala
+++ b/test/controllers/businessactivities/IdentifiySuspiciousActivityControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.businessactivities.IdentifySuspiciousActivityFormProvider
 import models.businessactivities.{BusinessActivities, IdentifySuspiciousActivity}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessactivities/InvolvedInOtherControllerSpec.scala
+++ b/test/controllers/businessactivities/InvolvedInOtherControllerSpec.scala
@@ -25,7 +25,7 @@ import models.businessmatching.BusinessActivity._
 import models.businessmatching.{BusinessMatching, BusinessActivities => BMActivities}
 import models.status.NotCompleted
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import play.api.mvc.Result

--- a/test/controllers/businessactivities/NCARegisteredControllerSpec.scala
+++ b/test/controllers/businessactivities/NCARegisteredControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.businessactivities.NCARegisteredFormProvider
 import models.businessactivities.{BusinessActivities, NCARegistered}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test

--- a/test/controllers/businessactivities/RiskAssessmentPolicyControllerSpec.scala
+++ b/test/controllers/businessactivities/RiskAssessmentPolicyControllerSpec.scala
@@ -23,7 +23,7 @@ import models.businessactivities._
 import models.businessmatching.BusinessActivity.{AccountancyServices, MoneyServiceBusiness}
 import models.businessmatching.{BusinessMatching, BusinessActivities => BMBusinessActivities}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/businessactivities/SummaryControllerSpec.scala
+++ b/test/controllers/businessactivities/SummaryControllerSpec.scala
@@ -25,7 +25,7 @@ import models.businessmatching.BusinessActivity.{MoneyServiceBusiness, Telephone
 import models.businessmatching.{BusinessMatching, BusinessActivities => BMBusinessActivities}
 import models.status.{NotCompleted, SubmissionDecisionApproved}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages

--- a/test/controllers/businessactivities/TaxMattersControllerSpec.scala
+++ b/test/controllers/businessactivities/TaxMattersControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.businessactivities.TaxMattersFormProvider
 import models.businessactivities._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessactivities/TransactionRecordControllerSpec.scala
+++ b/test/controllers/businessactivities/TransactionRecordControllerSpec.scala
@@ -21,7 +21,7 @@ import forms.businessactivities.TransactionRecordFormProvider
 import models.businessactivities.TransactionTypes.Paper
 import models.businessactivities._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/businessactivities/TransactionTypesControllerSpec.scala
+++ b/test/controllers/businessactivities/TransactionTypesControllerSpec.scala
@@ -26,7 +26,7 @@ import play.api.test.Helpers._
 import utils.{AmlsSpec, DependencyMocks}
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.{never, verify}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.scalatest.matchers.must.Matchers
 import play.api.test.{FakeRequest, Injecting}
 import views.html.businessactivities.TransactionTypesView

--- a/test/controllers/businessactivities/WhatYouNeedControllerSpec.scala
+++ b/test/controllers/businessactivities/WhatYouNeedControllerSpec.scala
@@ -21,7 +21,7 @@ import models.businessmatching.{BusinessActivities, BusinessMatching}
 import models.businessmatching.BusinessActivity.AccountancyServices
 import models.status.{ReadyForRenewal, RenewalSubmitted, SubmissionDecisionApproved, SubmissionReadyForReview}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessactivities/WhoIsYourAccountantIsUkControllerSpec.scala
+++ b/test/controllers/businessactivities/WhoIsYourAccountantIsUkControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.businessactivities.AccountantIsUKAddressFormProvider
 import models.Country
 import models.businessactivities._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/businessactivities/WhoIsYourAccountantNameControllerSpec.scala
+++ b/test/controllers/businessactivities/WhoIsYourAccountantNameControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.businessactivities.WhoIsYourAccountantNameFormProvider
 import models.businessactivities.{BusinessActivities, WhoIsYourAccountant, WhoIsYourAccountantName}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.PrivateMethodTester
 import org.scalatest.concurrent.ScalaFutures

--- a/test/controllers/businessactivities/WhoIsYourAccountantNonUkAddressControllerSpec.scala
+++ b/test/controllers/businessactivities/WhoIsYourAccountantNonUkAddressControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.businessactivities.AccountantNonUKAddressFormProvider
 import models.Country
 import models.businessactivities._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessactivities/WhoIsYourAccountantUkAddressControllerSpec.scala
+++ b/test/controllers/businessactivities/WhoIsYourAccountantUkAddressControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.businessactivities.AccountantUKAddressFormProvider
 import models.businessactivities._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessdetails/ActivityStartDateControllerSpec.scala
+++ b/test/controllers/businessdetails/ActivityStartDateControllerSpec.scala
@@ -24,7 +24,7 @@ import models.businesscustomer.{Address, ReviewDetails}
 import models.businessdetails._
 import models.businessmatching.{BusinessMatching, BusinessType}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest

--- a/test/controllers/businessdetails/BusinessEmailAddressControllerSpec.scala
+++ b/test/controllers/businessdetails/BusinessEmailAddressControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers.businessdetails
 
 import controllers.actions.SuccessfulAuthAction
 import forms.businessdetails.BusinessEmailAddressFormProvider
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures

--- a/test/controllers/businessdetails/ConfirmRegisteredOfficeControllerSpec.scala
+++ b/test/controllers/businessdetails/ConfirmRegisteredOfficeControllerSpec.scala
@@ -22,7 +22,7 @@ import models.Country
 import models.businesscustomer.{Address, ReviewDetails}
 import models.businessdetails._
 import models.businessmatching.{BusinessMatching, BusinessType}
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessdetails/ContactingYouPhoneControllerSpec.scala
+++ b/test/controllers/businessdetails/ContactingYouPhoneControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.DataCacheConnector
 import controllers.actions.SuccessfulAuthAction
 import forms.businessdetails.BusinessTelephoneFormProvider
 import models.businessdetails.{BusinessDetails, ContactingYou}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures

--- a/test/controllers/businessdetails/CorporationTaxRegisteredControllerSpec.scala
+++ b/test/controllers/businessdetails/CorporationTaxRegisteredControllerSpec.scala
@@ -23,14 +23,14 @@ import models.businessdetails.{BusinessDetails, CorporationTaxRegisteredYes}
 import models.businesscustomer.{Address, ReviewDetails}
 import models.businessmatching.{BusinessMatching, BusinessType}
 import models.businessmatching.BusinessType.{LimitedCompany, UnincorporatedBody}
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import utils.DependencyMocks
 import utils.AmlsSpec
-import org.mockito.Matchers.{eq => eqTo}
+import org.mockito.ArgumentMatchers.{eq => eqTo}
 
 class CorporationTaxRegisteredControllerSpec extends AmlsSpec with MockitoSugar with ScalaFutures with DependencyMocks {
 

--- a/test/controllers/businessdetails/CorrespondenceAddressIsUkControllerSpec.scala
+++ b/test/controllers/businessdetails/CorrespondenceAddressIsUkControllerSpec.scala
@@ -24,7 +24,7 @@ import models.businessdetails._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessdetails/CorrespondenceAddressNonUkControllerSpec.scala
+++ b/test/controllers/businessdetails/CorrespondenceAddressNonUkControllerSpec.scala
@@ -25,7 +25,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessdetails/CorrespondenceAddressUkControllerSpec.scala
+++ b/test/controllers/businessdetails/CorrespondenceAddressUkControllerSpec.scala
@@ -24,7 +24,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessdetails/LettersAddressControllerSpec.scala
+++ b/test/controllers/businessdetails/LettersAddressControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.businessdetails.LettersAddressFormProvider
 import models.businessdetails._
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.ScalaFutures

--- a/test/controllers/businessdetails/PreviouslyRegisteredControllerSpec.scala
+++ b/test/controllers/businessdetails/PreviouslyRegisteredControllerSpec.scala
@@ -23,7 +23,7 @@ import models.businesscustomer.{Address, ReviewDetails}
 import models.businessdetails._
 import models.businessmatching.{BusinessMatching, BusinessType}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures

--- a/test/controllers/businessdetails/RegisteredOfficeDateOfChangeControllerSpec.scala
+++ b/test/controllers/businessdetails/RegisteredOfficeDateOfChangeControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.DateOfChangeFormProvider
 import models.businessdetails._
 import models.{Country, DateOfChange}
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/businessdetails/RegisteredOfficeIsUKControllerSpec.scala
+++ b/test/controllers/businessdetails/RegisteredOfficeIsUKControllerSpec.scala
@@ -23,7 +23,7 @@ import models.Country
 import models.businessdetails._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest

--- a/test/controllers/businessdetails/RegisteredOfficeNonUKControllerSpec.scala
+++ b/test/controllers/businessdetails/RegisteredOfficeNonUKControllerSpec.scala
@@ -25,7 +25,7 @@ import models.status.{ReadyForRenewal, SubmissionDecisionApproved, SubmissionDec
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest

--- a/test/controllers/businessdetails/RegisteredOfficeUKControllerSpec.scala
+++ b/test/controllers/businessdetails/RegisteredOfficeUKControllerSpec.scala
@@ -25,7 +25,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest

--- a/test/controllers/businessdetails/SummaryControllerSpec.scala
+++ b/test/controllers/businessdetails/SummaryControllerSpec.scala
@@ -23,7 +23,7 @@ import models.businesscustomer.{Address, ReviewDetails}
 import models.businessdetails.BusinessDetails
 import models.businessmatching.{BusinessMatching, BusinessType}
 import models.status.SubmissionReady
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/businessdetails/VATRegisteredControllerSpec.scala
+++ b/test/controllers/businessdetails/VATRegisteredControllerSpec.scala
@@ -24,7 +24,7 @@ import models.businessdetails._
 import models.businessmatching.BusinessMatching
 import models.businessmatching.BusinessType.{LPrLLP, LimitedCompany, Partnership}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessmatching/BusinessTypeControllerSpec.scala
+++ b/test/controllers/businessmatching/BusinessTypeControllerSpec.scala
@@ -19,8 +19,7 @@ package controllers.businessmatching
 import controllers.actions.SuccessfulAuthAction
 import forms.businessmatching.BusinessTypeFormProvider
 import models.businessmatching.BusinessType
-import org.mockito.Matchers
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers.{eq => eqTo, any}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
@@ -117,7 +116,7 @@ class BusinessTypeControllerSpec extends AmlsSpec with ScalaFutures with Injecti
       val newRequest = FakeRequest(POST, routes.BusinessTypeController.post().url)
         .withFormUrlEncodedBody("businessType" -> BusinessType.LimitedCompany.toString)
 
-      when(mockService.updateBusinessType(any(), Matchers.eq(BusinessType.LimitedCompany))(any(), any()))
+      when(mockService.updateBusinessType(any(), eqTo(BusinessType.LimitedCompany))(any(), any()))
         .thenReturn(Future.successful(Some(BusinessType.LimitedCompany)))
 
       val result = controller.post()(newRequest)
@@ -130,7 +129,7 @@ class BusinessTypeControllerSpec extends AmlsSpec with ScalaFutures with Injecti
       val newRequest = test.FakeRequest(POST, routes.BusinessTypeController.post().url)
         .withFormUrlEncodedBody("businessType" -> BusinessType.LimitedCompany.toString)
 
-      when(mockService.updateBusinessType(any(), Matchers.eq(BusinessType.LimitedCompany))(any(), any()))
+      when(mockService.updateBusinessType(any(), eqTo(BusinessType.LimitedCompany))(any(), any()))
         .thenReturn(Future.successful(None))
 
       val result = controller.post()(newRequest)

--- a/test/controllers/businessmatching/CompanyRegistrationNumberControllerSpec.scala
+++ b/test/controllers/businessmatching/CompanyRegistrationNumberControllerSpec.scala
@@ -23,7 +23,7 @@ import forms.businessmatching.CompanyRegistrationNumberFormProvider
 import models.businessmatching.{BusinessMatching, CompanyRegistrationNumber}
 import models.status.NotCompleted
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessmatching/ConfirmPostCodeControllerSpec.scala
+++ b/test/controllers/businessmatching/ConfirmPostCodeControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import models.Country
 import models.businessmatching.{BusinessMatching, BusinessType}
 import org.mockito.Mockito._
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import models.businesscustomer.{ReviewDetails, Address => BusinessCustomerAddress}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessmatching/MsbSubSectorsControllerSpec.scala
+++ b/test/controllers/businessmatching/MsbSubSectorsControllerSpec.scala
@@ -28,7 +28,7 @@ import models.flowmanagement.{ChangeSubSectorFlowModel, SubSectorsPageId}
 import models.moneyservicebusiness.{MoneyServiceBusiness, MoneyServiceBusinessTestData}
 import models.status.NotCompleted
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import play.api.test.FakeRequest
@@ -68,7 +68,7 @@ class MsbSubSectorsControllerSpec extends AmlsSpec with ScalaFutures with MoneyS
     } thenReturn cacheMapT
 
     when {
-      controller.helper.updateSubSectors(any(), any())(any(), any())
+      controller.helper.updateSubSectors(any(), any())(any())
     } thenReturn Future.successful((mock[MoneyServiceBusiness], mock[BusinessMatching], Seq.empty))
 
     def setupModel(model: Option[BusinessMatching]): Unit = when {

--- a/test/controllers/businessmatching/PSRNumberControllerSpec.scala
+++ b/test/controllers/businessmatching/PSRNumberControllerSpec.scala
@@ -30,7 +30,7 @@ import models.moneyservicebusiness.MoneyServiceBusiness
 import models.status.NotCompleted
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
@@ -128,11 +128,11 @@ class PSRNumberControllerSpec extends AmlsSpec
         val flowModel = ChangeSubSectorFlowModel(Some(Set(TransmittingMoney)))
 
         when {
-          controller.helper.getOrCreateFlowModel(any())(any(), any())
+          controller.helper.getOrCreateFlowModel(any())(any())
         } thenReturn Future.successful(flowModel)
 
         when {
-          controller.helper.updateSubSectors(any(), any())(any(), any())
+          controller.helper.updateSubSectors(any(), any())(any())
         } thenReturn Future.successful((mock[MoneyServiceBusiness], mock[BusinessMatching], Seq.empty))
 
         val newRequest = FakeRequest(POST, routes.PSRNumberController.post().url)
@@ -156,7 +156,7 @@ class PSRNumberControllerSpec extends AmlsSpec
         val flowModel = ChangeSubSectorFlowModel(Some(Set(TransmittingMoney)))
 
         when {
-          controller.helper.getOrCreateFlowModel(any())(any(), any())
+          controller.helper.getOrCreateFlowModel(any())(any())
         } thenReturn Future.successful(flowModel)
 
         mockCacheUpdate[ChangeSubSectorFlowModel](Some(ChangeSubSectorFlowModel.key), ChangeSubSectorFlowModel.empty)

--- a/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
+++ b/test/controllers/businessmatching/RegisterServicesControllerSpec.scala
@@ -27,7 +27,7 @@ import models.responsiblepeople.{ApprovalFlags, ResponsiblePerson}
 import models.supervision.Supervision
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessmatching/SummaryControllerSpec.scala
+++ b/test/controllers/businessmatching/SummaryControllerSpec.scala
@@ -26,7 +26,7 @@ import models.flowmanagement.AddBusinessTypeFlowModel
 import models.status.NotCompleted
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import services.businessmatching.BusinessMatchingService

--- a/test/controllers/businessmatching/TypeOfBusinessControllerSpec.scala
+++ b/test/controllers/businessmatching/TypeOfBusinessControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.businessmatching.TypeOfBusinessFormProvider
 import models.businessmatching.{BusinessMatching, TypeOfBusiness}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/businessmatching/updateservice/AddBusinessTypeHelperSpec.scala
+++ b/test/controllers/businessmatching/updateservice/AddBusinessTypeHelperSpec.scala
@@ -28,7 +28,7 @@ import models.businessmatching.BusinessMatchingMsbService._
 import models.businessmatching.BusinessActivity._
 import models.flowmanagement.AddBusinessTypeFlowModel
 import models.supervision._
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{never, verify}
 import play.api.test.Helpers._
 import services.{ResponsiblePeopleService, TradingPremisesService}
@@ -49,8 +49,7 @@ class AddBusinessTypeHelperSpec extends AmlsSpec
     val responsiblePeopleService = mock[ResponsiblePeopleService]
     val mockApplicationConfig = mock[ApplicationConfig]
 
-    val SUT = new AddBusinessTypeHelper(
-      SuccessfulAuthAction,
+    val SUT = new AddBusinessTypeHelper()(
       mockCacheConnector,
       tradingPremisesService,
       responsiblePeopleService,

--- a/test/controllers/businessmatching/updateservice/ChangeBusinessTypeControllerSpec.scala
+++ b/test/controllers/businessmatching/updateservice/ChangeBusinessTypeControllerSpec.scala
@@ -25,7 +25,7 @@ import models.businessmatching.updateservice.Remove
 import models.businessmatching.updateservice.{Add, ChangeBusinessType}
 import models.flowmanagement.{ChangeBusinessTypesPageId, RemoveBusinessTypeFlowModel}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages
@@ -64,14 +64,12 @@ class ChangeBusinessTypeControllerSpec extends AmlsSpec with MockitoSugar with I
     val businessMatching = BusinessMatching(activities = Some(businessActivitiesModel))
     val emptyBusinessMatching = BusinessMatching()
 
-    mockCacheGetEntry[BusinessMatching](Some(businessMatching), BusinessMatching.key)
-
     when {
       bmService.getRemainingBusinessActivities(any())(any(), any())
     } thenReturn OptionT.liftF[Future, Set[BusinessActivity]](Future.successful(Set(HighValueDealing)))
 
     when {
-      controller.helper.removeFlowData(any())(any(), any())
+      controller.helper.removeFlowData(any())(any())
     } thenReturn OptionT.liftF[Future, RemoveBusinessTypeFlowModel](Future.successful(RemoveBusinessTypeFlowModel()))
   }
 
@@ -143,18 +141,6 @@ class ChangeBusinessTypeControllerSpec extends AmlsSpec with MockitoSugar with I
           val result = controller.post()(request)
           status(result) must be(BAD_REQUEST)
         }
-      }
-
-      "return Internal Server Error if the business matching model can't be obtained" in new Fixture {
-
-        val postRequest = FakeRequest(POST, routes.ChangeBusinessTypesController.post().url)
-        .withFormUrlEncodedBody("" -> "")
-
-        mockCacheGetEntry[BusinessMatching](None, BusinessMatching.key)
-
-        val result = controller.post()(postRequest)
-
-        status(result) mustBe INTERNAL_SERVER_ERROR
       }
     }
   }

--- a/test/controllers/businessmatching/updateservice/ChangeSubSectorHelperSpec.scala
+++ b/test/controllers/businessmatching/updateservice/ChangeSubSectorHelperSpec.scala
@@ -24,7 +24,7 @@ import models.businessmatching.updateservice.ServiceChangeRegister
 import models.flowmanagement.ChangeSubSectorFlowModel
 import models.moneyservicebusiness.{MoneyServiceBusiness => MSB, _}
 import org.mockito.Mockito.{never, verify}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import models.tradingpremises.{TradingPremises, TradingPremisesMsbServices, WhatDoesYourBusinessDo}
 import models.tradingpremises.TradingPremisesMsbService.{
   ChequeCashingScrapMetal => TPChequeCashingScrapMetal,
@@ -40,9 +40,7 @@ class ChangeSubSectorHelperSpec extends AmlsSpec with ScalaFutures {
 
   trait Fixture extends DependencyMocks {
     self =>
-    val helper = new ChangeSubSectorHelper(
-      SuccessfulAuthAction,
-      mockCacheConnector)
+    val helper = new ChangeSubSectorHelper()(mockCacheConnector)
   }
 
   "requires a PSR Number" when {

--- a/test/controllers/businessmatching/updateservice/RemoveBusinessTypeHelperSpec.scala
+++ b/test/controllers/businessmatching/updateservice/RemoveBusinessTypeHelperSpec.scala
@@ -45,11 +45,7 @@ class RemoveBusinessTypeHelperSpec extends AmlsSpec with FutureAssertions with M
 
     val mockApplicationConfig = mock[ApplicationConfig]
 
-    val helper = new RemoveBusinessTypeHelper(
-      SuccessfulAuthAction,
-      mockApplicationConfig,
-      mockCacheConnector
-    )
+    val helper = new RemoveBusinessTypeHelper()(mockCacheConnector)
   }
 
   "RemoveBusinessTypeHelper" must {

--- a/test/controllers/businessmatching/updateservice/add/AddBusinessTypeSummaryControllerSpec.scala
+++ b/test/controllers/businessmatching/updateservice/add/AddBusinessTypeSummaryControllerSpec.scala
@@ -30,7 +30,7 @@ import models.flowmanagement.{AddBusinessTypeFlowModel, AddBusinessTypeSummaryPa
 import models.status.SubmissionDecisionApproved
 import models.supervision.Supervision
 import models.tradingpremises.{TradingPremises, WhatDoesYourBusinessDo}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import org.scalacheck.Gen
 import org.scalatestplus.mockito.MockitoSugar
@@ -119,11 +119,11 @@ class AddBusinessTypeSummaryControllerSpec extends AmlsSpec
         )
 
         when {
-          controller.helper.updateBusinessMatching(any(), any())(any(), any())
+          controller.helper.updateBusinessMatching(any(), any())(any())
         } thenReturn OptionT.fromOption[Future](Some(businessMatchingModel))
 
         when {
-          controller.helper.updateServicesRegister(any(), any())(any(), any())
+          controller.helper.updateServicesRegister(any(), any())(any())
         } thenReturn OptionT.liftF(Future.successful(serviceChangeRegister))
 
         when {
@@ -131,19 +131,19 @@ class AddBusinessTypeSummaryControllerSpec extends AmlsSpec
         } thenReturn modifiedTradingPremises
 
         when {
-          controller.helper.updateHasAcceptedFlag(any(), eqTo(flowModel))(any(), any())
+          controller.helper.updateHasAcceptedFlag(any(), eqTo(flowModel))(any())
         } thenReturn OptionT.fromOption[Future](Some(mockCacheMap))
 
         when {
-          controller.helper.updateBusinessActivities(any(), any())(any())
+          controller.helper.updateBusinessActivities(any(), any())
         } thenReturn OptionT.liftF(Future.successful(mock[models.businessactivities.BusinessActivities]))
 
         when {
-          controller.helper.updateSupervision(any())(any(), any())
+          controller.helper.updateSupervision(any())(any())
         } thenReturn OptionT.liftF(Future.successful(Supervision()))
 
         when {
-          controller.helper.clearFlowModel(any())(any())
+          controller.helper.clearFlowModel(any())
         } thenReturn OptionT.liftF(Future.successful(AddBusinessTypeFlowModel()))
 
         val result = controller.post()(request)

--- a/test/controllers/businessmatching/updateservice/add/AddMoreBusinessTypesControllerSpec.scala
+++ b/test/controllers/businessmatching/updateservice/add/AddMoreBusinessTypesControllerSpec.scala
@@ -24,7 +24,7 @@ import models.businessmatching._
 import models.businessmatching.BusinessActivity.{BillPaymentServices, HighValueDealing, TelephonePaymentService}
 import models.flowmanagement.{AddBusinessTypeFlowModel, AddMoreBusinessTypesPageId}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/businessmatching/updateservice/add/NoPsrControllerSpec.scala
+++ b/test/controllers/businessmatching/updateservice/add/NoPsrControllerSpec.scala
@@ -20,7 +20,7 @@ import cats.data.OptionT
 import controllers.actions.SuccessfulAuthAction
 import controllers.businessmatching.updateservice.AddBusinessTypeHelper
 import models.flowmanagement.{AddBusinessTypeFlowModel, NoPSRPageId}
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import play.api.test.Helpers._
@@ -66,7 +66,7 @@ class NoPsrControllerSpec extends AmlsSpec with ScalaFutures {
 
     "clear the flow model" in new Fixture {
       when {
-        mockUpdateServiceHelper.clearFlowModel(any())(any())
+        mockUpdateServiceHelper.clearFlowModel(any())
       } thenReturn OptionT[Future, AddBusinessTypeFlowModel](Future.successful(Some(AddBusinessTypeFlowModel())))
 
       val result = controller.post()(requestWithUrlEncodedBody("" -> ""))

--- a/test/controllers/businessmatching/updateservice/add/SelectBusinessTypeControllerSpec.scala
+++ b/test/controllers/businessmatching/updateservice/add/SelectBusinessTypeControllerSpec.scala
@@ -27,7 +27,7 @@ import models.businessmatching.BusinessActivity.{AccountancyServices, BillPaymen
 import models.flowmanagement.AddBusinessTypeFlowModel
 import models.responsiblepeople.ResponsiblePerson
 import org.jsoup.Jsoup
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/businessmatching/updateservice/add/SubSectorsControllerSpec.scala
+++ b/test/controllers/businessmatching/updateservice/add/SubSectorsControllerSpec.scala
@@ -28,7 +28,7 @@ import models.businessmatching._
 import models.flowmanagement.{AddBusinessTypeFlowModel, SubSectorsPageId}
 import models.moneyservicebusiness.MoneyServiceBusinessTestData
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.i18n.Messages
 import play.api.test.FakeRequest

--- a/test/controllers/businessmatching/updateservice/remove/RemoveBusinessTypesControllerSpec.scala
+++ b/test/controllers/businessmatching/updateservice/remove/RemoveBusinessTypesControllerSpec.scala
@@ -26,7 +26,7 @@ import models.businessmatching._
 import models.flowmanagement.{RemoveBusinessTypeFlowModel, WhatBusinessTypesToRemovePageId}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -107,7 +107,7 @@ class RemoveBusinessTypesControllerSpec extends AmlsSpec {
 
         mockCacheFetch(Some(RemoveBusinessTypeFlowModel()), Some(RemoveBusinessTypeFlowModel.key))
 
-        when(mockRemoveBusinessTypeHelper.dateOfChangeApplicable(any(), any())(any(), any()))
+        when(mockRemoveBusinessTypeHelper.dateOfChangeApplicable(any(), any())(any()))
           .thenReturn(OptionT.liftF[Future, Boolean](Future.successful(true)))
 
         mockCacheSave[RemoveBusinessTypeFlowModel]
@@ -135,7 +135,7 @@ class RemoveBusinessTypesControllerSpec extends AmlsSpec {
 
         mockCacheFetch(Some(flowModel), Some(RemoveBusinessTypeFlowModel.key))
 
-        when(mockRemoveBusinessTypeHelper.dateOfChangeApplicable(any(), any())(any(), any()))
+        when(mockRemoveBusinessTypeHelper.dateOfChangeApplicable(any(), any())(any()))
           .thenReturn(OptionT.liftF[Future, Boolean](Future.successful(true)))
 
         mockCacheSave[RemoveBusinessTypeFlowModel]
@@ -159,7 +159,7 @@ class RemoveBusinessTypesControllerSpec extends AmlsSpec {
 
         mockCacheFetch(Some(RemoveBusinessTypeFlowModel(dateOfChange = Some(DateOfChange(LocalDate.now)))), Some(RemoveBusinessTypeFlowModel.key))
 
-        when(mockRemoveBusinessTypeHelper.dateOfChangeApplicable(any(), any())(any(), any()))
+        when(mockRemoveBusinessTypeHelper.dateOfChangeApplicable(any(), any())(any()))
           .thenReturn(OptionT.liftF[Future, Boolean](Future.successful(false)))
 
         mockCacheSave[RemoveBusinessTypeFlowModel]
@@ -183,7 +183,7 @@ class RemoveBusinessTypesControllerSpec extends AmlsSpec {
 
         mockCacheFetch(Some(RemoveBusinessTypeFlowModel(activitiesToRemove = Some(Set(MoneyServiceBusiness)), dateOfChange = Some(DateOfChange(LocalDate.now)))), Some(RemoveBusinessTypeFlowModel.key))
 
-        when(mockRemoveBusinessTypeHelper.dateOfChangeApplicable(any(), any())(any(), any()))
+        when(mockRemoveBusinessTypeHelper.dateOfChangeApplicable(any(), any())(any()))
           .thenReturn(OptionT.liftF[Future, Boolean](Future.successful(true)))
 
         mockCacheSave[RemoveBusinessTypeFlowModel]
@@ -207,7 +207,7 @@ class RemoveBusinessTypesControllerSpec extends AmlsSpec {
 
         mockCacheFetch(Some(RemoveBusinessTypeFlowModel(activitiesToRemove = Some(Set(HighValueDealing)), dateOfChange = Some(DateOfChange(LocalDate.now)))), Some(RemoveBusinessTypeFlowModel.key))
 
-        when(mockRemoveBusinessTypeHelper.dateOfChangeApplicable(any(), any())(any(), any()))
+        when(mockRemoveBusinessTypeHelper.dateOfChangeApplicable(any(), any())(any()))
           .thenReturn(OptionT.liftF[Future, Boolean](Future.successful(true)))
 
         mockCacheSave[RemoveBusinessTypeFlowModel]

--- a/test/controllers/businessmatching/updateservice/remove/RemoveBusinessTypesSummaryControllerSpec.scala
+++ b/test/controllers/businessmatching/updateservice/remove/RemoveBusinessTypesSummaryControllerSpec.scala
@@ -26,7 +26,7 @@ import models.flowmanagement.{RemoveBusinessTypeFlowModel, RemoveBusinessTypesSu
 import models.responsiblepeople.ResponsiblePerson
 import models.tradingpremises.TradingPremises
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
@@ -84,19 +84,19 @@ class RemoveBusinessTypesSummaryControllerSpec extends AmlsSpec with TitleValida
 
         mockCacheFetch(Some(flowModel), Some(RemoveBusinessTypeFlowModel.key))
 
-        when(removeServiceHelper.removeBusinessMatchingBusinessTypes(any(), eqTo(flowModel))(any(), any()))
+        when(removeServiceHelper.removeBusinessMatchingBusinessTypes(any(), eqTo(flowModel))(any()))
           .thenReturn(OptionT.liftF(Future.successful(mock[BusinessMatching])))
 
-        when(removeServiceHelper.removeFitAndProper(any(), eqTo(flowModel))(any(), any()))
+        when(removeServiceHelper.removeFitAndProper(any(), eqTo(flowModel))(any()))
           .thenReturn(OptionT.liftF[Future, Seq[ResponsiblePerson]](Future.successful(Seq.empty)))
 
-        when(removeServiceHelper.removeTradingPremisesBusinessTypes(any(), eqTo(flowModel))(any(), any()))
+        when(removeServiceHelper.removeTradingPremisesBusinessTypes(any(), eqTo(flowModel))(any()))
           .thenReturn(OptionT.liftF[Future, Seq[TradingPremises]](Future.successful(Seq.empty)))
 
         when(removeServiceHelper.removeSectionData(any(), eqTo(flowModel))(any(), any()))
           .thenReturn(OptionT.liftF[Future, Seq[CacheMap]](Future.successful(Seq.empty)))
 
-        when(removeServiceHelper.removeFlowData(any())(any(), any()))
+        when(removeServiceHelper.removeFlowData(any())(any()))
           .thenReturn(OptionT.liftF[Future, RemoveBusinessTypeFlowModel](Future.successful(RemoveBusinessTypeFlowModel())))
 
         val result = controller.post()(requestWithUrlEncodedBody("" -> ""))

--- a/test/controllers/declaration/AddPersonControllerSpec.scala
+++ b/test/controllers/declaration/AddPersonControllerSpec.scala
@@ -28,7 +28,7 @@ import models.declaration.release7.{Director, ExternalAccountant}
 import models.status.{ReadyForRenewal, SubmissionReady, SubmissionReadyForReview}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/declaration/DeclarationControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationControllerSpec.scala
@@ -24,7 +24,7 @@ import models.registrationprogress.{Completed, Started, TaskRow}
 import models.renewal._
 import models.status.{NotCompleted, ReadyForRenewal, SubmissionReadyForReview}
 import models.{Country, ReadStatusResponse, SubscriptionFees, SubscriptionResponse}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/declaration/RegisterPartnersControllerSpec.scala
+++ b/test/controllers/declaration/RegisterPartnersControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.declaration.BusinessPartnersFormProvider
 import models.registrationprogress.{Completed, Started, TaskRow}
 import models.responsiblepeople._
 import models.status._
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/declaration/RenewRegistrationControllerSpec.scala
+++ b/test/controllers/declaration/RenewRegistrationControllerSpec.scala
@@ -21,7 +21,7 @@ import forms.declaration.RenewRegistrationFormProvider
 import models.declaration.{RenewRegistration, RenewRegistrationNo, RenewRegistrationYes}
 import models.status.ReadyForRenewal
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/declaration/WhoIsRegisteringControllerSpec.scala
+++ b/test/controllers/declaration/WhoIsRegisteringControllerSpec.scala
@@ -28,7 +28,7 @@ import models.renewal.Renewal
 import models.responsiblepeople._
 import models.status._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/declaration/WhoIsTheBusinessNominatedOfficerControllerSpec.scala
+++ b/test/controllers/declaration/WhoIsTheBusinessNominatedOfficerControllerSpec.scala
@@ -23,7 +23,7 @@ import models.registrationprogress.{Completed, Started, TaskRow}
 import models.responsiblepeople.ResponsiblePerson.flowFromDeclaration
 import models.responsiblepeople._
 import models.status.{ReadyForRenewal, SubmissionDecisionApproved, SubmissionReady, SubmissionReadyForReview}
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/deregister/DeRegisterApplicationControllerSpec.scala
+++ b/test/controllers/deregister/DeRegisterApplicationControllerSpec.scala
@@ -24,7 +24,7 @@ import models.businessmatching.{BusinessActivities, BusinessActivity, BusinessMa
 import models.businessmatching.BusinessActivity.AccountancyServices
 import models.deregister.DeRegisterSubscriptionResponse
 import models.registrationdetails.RegistrationDetails
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import services.{AuthEnrolmentsService, StatusService}

--- a/test/controllers/deregister/DeregistrationReasonControllerSpec.scala
+++ b/test/controllers/deregister/DeregistrationReasonControllerSpec.scala
@@ -26,7 +26,7 @@ import models.deregister.DeregistrationReason.{HVDPolicyOfNotAcceptingHighValueC
 import models.deregister.{DeRegisterSubscriptionRequest, DeRegisterSubscriptionResponse, DeregistrationReason}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/eab/EabControllerSpec.scala
+++ b/test/controllers/eab/EabControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.eab
 import connectors.DataCacheConnector
 import controllers.actions.SuccessfulAuthAction
 import models.eab.Eab
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder

--- a/test/controllers/hvd/CashPaymentControllerSpec.scala
+++ b/test/controllers/hvd/CashPaymentControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.hvd.CashPaymentFormProvider
 import models.hvd._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/hvd/CashPaymentFirstDateControllerSpec.scala
+++ b/test/controllers/hvd/CashPaymentFirstDateControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.hvd.CashPaymentFirstDateFormProvider
 import models.hvd._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/hvd/HvdDateOfChangeControllerSpec.scala
+++ b/test/controllers/hvd/HvdDateOfChangeControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.DateOfChangeFormProvider
 import models.DateOfChange
 import models.businessdetails.{ActivityStartDate, BusinessDetails}
 import models.hvd.Hvd
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/hvd/LinkedCashPaymentsControllerSpec.scala
+++ b/test/controllers/hvd/LinkedCashPaymentsControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.hvd.LinkedCashPaymentsFormProvider
 import models.hvd.{Hvd, LinkedCashPayments}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/hvd/PercentageOfCashPaymentOver15000ControllerSpec.scala
+++ b/test/controllers/hvd/PercentageOfCashPaymentOver15000ControllerSpec.scala
@@ -24,7 +24,7 @@ import models.hvd.PercentageOfCashPaymentOver15000.First
 import models.hvd.{Hvd, PercentageOfCashPaymentOver15000}
 import models.status.NotCompleted
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/hvd/ReceiveCashPaymentsControllerSpec.scala
+++ b/test/controllers/hvd/ReceiveCashPaymentsControllerSpec.scala
@@ -22,7 +22,7 @@ import models.businessmatching.BusinessActivity.HighValueDealing
 import models.businessmatching.updateservice.ServiceChangeRegister
 import models.hvd.{Hvd, PaymentMethods}
 import models.status.{NotCompleted, SubmissionDecisionApproved}
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/hvd/SummaryControllerSpec.scala
+++ b/test/controllers/hvd/SummaryControllerSpec.scala
@@ -26,7 +26,7 @@ import models.status.{NotCompleted, SubmissionDecisionApproved}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/msb/BranchesOrAgentsHasCountriesControllerSpec.scala
+++ b/test/controllers/msb/BranchesOrAgentsHasCountriesControllerSpec.scala
@@ -21,7 +21,7 @@ import forms.msb.BranchesOrAgentsFormProvider
 import models.Country
 import models.moneyservicebusiness.{BranchesOrAgents, BranchesOrAgentsHasCountries, BranchesOrAgentsWhichCountries, MoneyServiceBusiness}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/msb/BranchesOrAgentsWhichCountriesControllerSpec.scala
+++ b/test/controllers/msb/BranchesOrAgentsWhichCountriesControllerSpec.scala
@@ -21,7 +21,7 @@ import forms.msb.BranchesOrAgentsWhichCountriesFormProvider
 import models.Country
 import models.moneyservicebusiness.{BranchesOrAgents, BranchesOrAgentsHasCountries, BranchesOrAgentsWhichCountries, MoneyServiceBusiness}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Results.Redirect

--- a/test/controllers/msb/BusinessUseAnIPSPControllerSpec.scala
+++ b/test/controllers/msb/BusinessUseAnIPSPControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.msb.BusinessUseAnIPSPFormProvider
 import models.moneyservicebusiness.{BusinessUseAnIPSPYes, FundsTransfer, MoneyServiceBusiness}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/msb/CurrencyExchangesInNext12MonthsControllerSpec.scala
+++ b/test/controllers/msb/CurrencyExchangesInNext12MonthsControllerSpec.scala
@@ -22,7 +22,7 @@ import models.businessmatching.BusinessActivity.{MoneyServiceBusiness => MoneySe
 import models.businessmatching.updateservice.ServiceChangeRegister
 import models.moneyservicebusiness._
 import models.status.NotCompleted
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/msb/ExpectedThroughputControllerSpec.scala
+++ b/test/controllers/msb/ExpectedThroughputControllerSpec.scala
@@ -24,7 +24,7 @@ import models.moneyservicebusiness.ExpectedThroughput.First
 import models.moneyservicebusiness.MoneyServiceBusiness
 import models.status.{NotCompleted, SubmissionDecisionApproved}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/msb/FXTransactionsInNext12MonthsControllerSpec.scala
+++ b/test/controllers/msb/FXTransactionsInNext12MonthsControllerSpec.scala
@@ -22,7 +22,7 @@ import models.businessmatching.updateservice.ServiceChangeRegister
 import models.businessmatching.BusinessActivity.{MoneyServiceBusiness => MoneyServiceBusinessActivity}
 import models.moneyservicebusiness._
 import models.status.NotCompleted
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages

--- a/test/controllers/msb/FundsTransferControllerSpec.scala
+++ b/test/controllers/msb/FundsTransferControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.msb.FundsTransferFormProvider
 import models.moneyservicebusiness._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/msb/IdentifyLinkedTransactionsControllerSpec.scala
+++ b/test/controllers/msb/IdentifyLinkedTransactionsControllerSpec.scala
@@ -22,7 +22,7 @@ import models.businessmatching.BusinessMatchingMsbService._
 import models.businessmatching._
 import models.moneyservicebusiness._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/msb/MoneySourcesControllerSpec.scala
+++ b/test/controllers/msb/MoneySourcesControllerSpec.scala
@@ -25,7 +25,7 @@ import models.businessmatching.BusinessActivity.{MoneyServiceBusiness => MoneySe
 import models.moneyservicebusiness.{MoneyServiceBusiness, _}
 import models.status.{NotCompleted, SubmissionDecisionApproved}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, PatienceConfiguration, ScalaFutures}
 import org.scalatest.matchers.must.Matchers

--- a/test/controllers/msb/MostTransactionsControllerSpec.scala
+++ b/test/controllers/msb/MostTransactionsControllerSpec.scala
@@ -26,7 +26,7 @@ import models.businessmatching.updateservice.ServiceChangeRegister
 import models.moneyservicebusiness._
 import models.status.{NotCompleted, SubmissionDecisionApproved}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/msb/SendMoneyToOtherCountryControllerSpec.scala
+++ b/test/controllers/msb/SendMoneyToOtherCountryControllerSpec.scala
@@ -25,7 +25,7 @@ import models.businessmatching._
 import models.businessmatching.updateservice.ServiceChangeRegister
 import models.moneyservicebusiness._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/msb/SummaryControllerSpec.scala
+++ b/test/controllers/msb/SummaryControllerSpec.scala
@@ -24,7 +24,7 @@ import models.businessmatching.updateservice.ServiceChangeRegister
 import models.moneyservicebusiness.{MoneyServiceBusiness, _}
 import models.status.{NotCompleted, SubmissionDecisionApproved}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/msb/TransactionsInNext12MonthsControllerSpec.scala
+++ b/test/controllers/msb/TransactionsInNext12MonthsControllerSpec.scala
@@ -22,7 +22,7 @@ import models.businessmatching.BusinessActivity.{MoneyServiceBusiness => MoneySe
 import models.businessmatching.updateservice.ServiceChangeRegister
 import models.moneyservicebusiness.{MoneyServiceBusiness, SendMoneyToOtherCountry, TransactionsInNext12Months}
 import models.status.{NotCompleted, SubmissionDecisionApproved}
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/msb/UsesForeignCurrenciesControllerSpec.scala
+++ b/test/controllers/msb/UsesForeignCurrenciesControllerSpec.scala
@@ -26,7 +26,7 @@ import models.moneyservicebusiness._
 import models.status.NotCompleted
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, PatienceConfiguration, ScalaFutures}
 import org.scalatest.matchers.must.Matchers

--- a/test/controllers/msb/WhatYouNeedControllerSpec.scala
+++ b/test/controllers/msb/WhatYouNeedControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import models.businessmatching.updateservice.ServiceChangeRegister
 import models.businessmatching.BusinessMatching
 import models.businessmatching.BusinessActivity.{HighValueDealing, MoneyServiceBusiness}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/msb/WhichCurrenciesControllerSpec.scala
+++ b/test/controllers/msb/WhichCurrenciesControllerSpec.scala
@@ -24,7 +24,7 @@ import models.businessmatching.BusinessActivity.{MoneyServiceBusiness => MoneySe
 import models.moneyservicebusiness._
 import models.status.{NotCompleted, SubmissionDecisionApproved}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, PatienceConfiguration, ScalaFutures}
 import org.scalatest.matchers.must.Matchers

--- a/test/controllers/payments/BankDetailsControllerSpec.scala
+++ b/test/controllers/payments/BankDetailsControllerSpec.scala
@@ -23,7 +23,7 @@ import models.ResponseType.SubscriptionResponseType
 import models.renewal.{AMLSTurnover, AMPTurnover, BusinessTurnover, CETransactionsInLast12Months, CashPayments, CashPaymentsCustomerNotMet, CustomersOutsideIsUK, CustomersOutsideUK, HowCashPaymentsReceived, InvolvedInOtherYes, MoneySources, MostTransactions, PaymentMethods, PercentageOfCashPaymentOver15000, Renewal, SendTheLargestAmountsOfMoney, TotalThroughput, TransactionsInLast12Months, WhichCurrencies}
 import models.status.{SubmissionDecisionApproved, SubmissionReadyForReview}
 import models.{Country, FeeResponse, SubmissionRequestStatus}
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito.when
 import play.api.i18n.Messages
 import play.api.test.Helpers._

--- a/test/controllers/payments/TypeOfBankControllerSpec.scala
+++ b/test/controllers/payments/TypeOfBankControllerSpec.scala
@@ -24,7 +24,7 @@ import models.ResponseType.SubscriptionResponseType
 import models.confirmation.Currency
 import models.renewal.{AMLSTurnover, AMPTurnover, BusinessTurnover, CETransactionsInLast12Months, CashPayments, CashPaymentsCustomerNotMet, CustomersOutsideIsUK, CustomersOutsideUK, HowCashPaymentsReceived, InvolvedInOtherYes, MoneySources, MostTransactions, PaymentMethods, PercentageOfCashPaymentOver15000, Renewal, SendTheLargestAmountsOfMoney, TotalThroughput, TransactionsInLast12Months, WhichCurrencies}
 import models.status.SubmissionReady
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.play.PlaySpec
 import play.api.test.Helpers._

--- a/test/controllers/payments/WaysToPayControllerSpec.scala
+++ b/test/controllers/payments/WaysToPayControllerSpec.scala
@@ -27,7 +27,7 @@ import models.payments._
 import models.renewal._
 import models.status.{SubmissionReady, SubmissionReadyForReview}
 import models.{Country, FeeResponse, ReadStatusResponse, ReturnLocation}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verify, when}
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/renewal/AMLSTurnoverControllerSpec.scala
+++ b/test/controllers/renewal/AMLSTurnoverControllerSpec.scala
@@ -23,7 +23,7 @@ import models.businessmatching.{BusinessActivities => Activities, _}
 import models.renewal.AMLSTurnover.First
 import models.renewal.{AMLSTurnover, Renewal}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/renewal/AMPTurnoverControllerSpec.scala
+++ b/test/controllers/renewal/AMPTurnoverControllerSpec.scala
@@ -23,7 +23,7 @@ import models.businessmatching.{BusinessActivities => Activities, _}
 import models.businessmatching.BusinessActivity._
 import models.renewal.{AMPTurnover, Renewal}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/renewal/BusinessTurnoverControllerSpec.scala
+++ b/test/controllers/renewal/BusinessTurnoverControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.renewal.BusinessTurnoverFormProvider
 import models.renewal.{BusinessTurnover, Renewal}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
@@ -100,7 +100,7 @@ class BusinessTurnoverControllerSpec extends AmlsSpec with MockitoSugar with Sca
             "businessTurnover" -> ""
           )
 
-          verifyZeroInteractions(mockDataCacheConnector, mockRenewalService)
+          verifyNoInteractions(mockDataCacheConnector, mockRenewalService)
 
           status(controller.post()(newRequest)) must be(BAD_REQUEST)
         }
@@ -111,7 +111,7 @@ class BusinessTurnoverControllerSpec extends AmlsSpec with MockitoSugar with Sca
             "businessTurnover" -> "foo"
           )
 
-          verifyZeroInteractions(mockDataCacheConnector, mockRenewalService)
+          verifyNoInteractions(mockDataCacheConnector, mockRenewalService)
 
           status(controller.post()(newRequest)) must be(BAD_REQUEST)
         }

--- a/test/controllers/renewal/CETransactionsInLast12MonthsControllerSpec.scala
+++ b/test/controllers/renewal/CETransactionsInLast12MonthsControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.DataCacheConnector
 import controllers.actions.SuccessfulAuthAction
 import forms.renewal.CETransactionsInLast12MonthsFormProvider
 import models.renewal.{CETransactionsInLast12Months, Renewal}
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/renewal/CashPaymentsCustomersNotMetControllerSpec.scala
+++ b/test/controllers/renewal/CashPaymentsCustomersNotMetControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.renewal.CashPaymentsCustomersNotMetFormProvider
 import models.renewal._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/renewal/CustomersOutsideIsUKControllerSpec.scala
+++ b/test/controllers/renewal/CustomersOutsideIsUKControllerSpec.scala
@@ -22,7 +22,7 @@ import models.businessmatching.BusinessActivity._
 import models.businessmatching._
 import models.renewal._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.inject._
 import play.api.inject.guice.GuiceApplicationBuilder

--- a/test/controllers/renewal/CustomersOutsideUKControllerSpec.scala
+++ b/test/controllers/renewal/CustomersOutsideUKControllerSpec.scala
@@ -23,7 +23,7 @@ import models.businessmatching._
 import models.businessmatching.BusinessActivity._
 import models.renewal._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.i18n.Messages
 import play.api.inject._

--- a/test/controllers/renewal/FXTransactionsInLast12MonthsControllerSpec.scala
+++ b/test/controllers/renewal/FXTransactionsInLast12MonthsControllerSpec.scala
@@ -21,7 +21,7 @@ import forms.renewal.FXTransactionsInLast12MonthsFormProvider
 import models.businessmatching.BusinessActivity._
 import models.businessmatching._
 import models.renewal.{FXTransactionsInLast12Months, Renewal}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/renewal/HowCashPaymentsReceivedControllerSpec.scala
+++ b/test/controllers/renewal/HowCashPaymentsReceivedControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.renewal.HowCashPaymentsReceivedFormProvider
 import models.renewal._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/renewal/InvolvedInOtherControllerSpec.scala
+++ b/test/controllers/renewal/InvolvedInOtherControllerSpec.scala
@@ -24,7 +24,7 @@ import models.businessmatching.BusinessActivity._
 import models.businessmatching.{BusinessActivities => BMActivities, _}
 import models.renewal.{InvolvedInOtherYes, Renewal}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/renewal/MoneySourcesControllerSpec.scala
+++ b/test/controllers/renewal/MoneySourcesControllerSpec.scala
@@ -26,7 +26,7 @@ import models.businessmatching.BusinessMatchingMsbService._
 import models.renewal._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/renewal/MostTransactionsControllerSpec.scala
+++ b/test/controllers/renewal/MostTransactionsControllerSpec.scala
@@ -26,7 +26,7 @@ import models.businessmatching.BusinessActivity._
 import models.businessmatching.BusinessMatchingMsbService._
 import models.renewal.{MostTransactions, Renewal}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/renewal/PercentageOfCashPaymentOver15000ControllerSpec.scala
+++ b/test/controllers/renewal/PercentageOfCashPaymentOver15000ControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.renewal.PercentageFormProvider
 import models.renewal.{PercentageOfCashPaymentOver15000, Renewal}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/renewal/RenewalProgressControllerSpec.scala
+++ b/test/controllers/renewal/RenewalProgressControllerSpec.scala
@@ -28,7 +28,7 @@ import models.registrationprogress._
 import models.responsiblepeople.{ResponsiblePeopleValues, ResponsiblePerson}
 import models.status.{ReadyForRenewal, RenewalSubmitted}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder

--- a/test/controllers/renewal/SendMoneyToOtherCountryControllerSpec.scala
+++ b/test/controllers/renewal/SendMoneyToOtherCountryControllerSpec.scala
@@ -25,7 +25,7 @@ import models.businessmatching.BusinessActivity._
 import models.businessmatching.BusinessMatchingMsbService._
 import models.renewal.{Renewal, SendMoneyToOtherCountry}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/renewal/SendTheLargestAmountsOfMoneyControllerSpec.scala
+++ b/test/controllers/renewal/SendTheLargestAmountsOfMoneyControllerSpec.scala
@@ -23,7 +23,7 @@ import forms.renewal.SendLargestAmountsOfMoneyFormProvider
 import models.Country
 import models.renewal.{CustomersOutsideUK, Renewal, SendTheLargestAmountsOfMoney}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, PatienceConfiguration}
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/renewal/SummaryControllerSpec.scala
+++ b/test/controllers/renewal/SummaryControllerSpec.scala
@@ -24,7 +24,7 @@ import models.businessmatching.{BusinessActivities => BMBusinessActivities, _}
 import models.registrationprogress.{Completed, TaskRow}
 import models.renewal._
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/renewal/TotalThroughputControllerSpec.scala
+++ b/test/controllers/renewal/TotalThroughputControllerSpec.scala
@@ -26,7 +26,7 @@ import models.moneyservicebusiness.ExpectedThroughput
 import models.renewal._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages

--- a/test/controllers/renewal/TransactionsInLast12MonthsControllerSpec.scala
+++ b/test/controllers/renewal/TransactionsInLast12MonthsControllerSpec.scala
@@ -27,7 +27,7 @@ import models.businessmatching._
 import models.moneyservicebusiness.{SendMoneyToOtherCountry, MoneyServiceBusiness => moneyServiceBusiness}
 import models.renewal.{CustomersOutsideUK, Renewal, TransactionsInLast12Months}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Result

--- a/test/controllers/renewal/UsesForeignCurrenciesControllerSpec.scala
+++ b/test/controllers/renewal/UsesForeignCurrenciesControllerSpec.scala
@@ -26,7 +26,7 @@ import models.businessmatching.BusinessMatchingMsbService.TransmittingMoney
 import models.renewal._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/renewal/WhatYouNeedControllerSpec.scala
+++ b/test/controllers/renewal/WhatYouNeedControllerSpec.scala
@@ -21,7 +21,7 @@ import models.businessmatching.BusinessActivity.{MoneyServiceBusiness, Telephone
 import models.businessmatching.{BusinessActivities, BusinessMatching}
 import models.registrationprogress.{Completed, NotStarted, TaskRow}
 import models.renewal.Renewal
-import org.mockito.Matchers.{any, eq => meq}
+import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import play.api.mvc.MessagesControllerComponents

--- a/test/controllers/renewal/WhichCurrenciesControllerSpec.scala
+++ b/test/controllers/renewal/WhichCurrenciesControllerSpec.scala
@@ -26,7 +26,7 @@ import models.businessmatching._
 import models.renewal.{MoneySources, Renewal, UsesForeignCurrenciesYes, WhichCurrencies}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/ContactDetailsControllerSpec.scala
+++ b/test/controllers/responsiblepeople/ContactDetailsControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.responsiblepeople.ContactDetailsFormProvider
 import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople.{ContactDetails, PersonName, ResponsiblePerson}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/CountryOfBirthControllerSpec.scala
+++ b/test/controllers/responsiblepeople/CountryOfBirthControllerSpec.scala
@@ -23,7 +23,7 @@ import models.Country
 import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/DateOfBirthControllerSpec.scala
+++ b/test/controllers/responsiblepeople/DateOfBirthControllerSpec.scala
@@ -23,7 +23,7 @@ import forms.responsiblepeople.DateOfBirthFormProvider
 import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/DetailedAnswersControllerSpec.scala
+++ b/test/controllers/responsiblepeople/DetailedAnswersControllerSpec.scala
@@ -27,7 +27,7 @@ import models.responsiblepeople.ResponsiblePerson.flowFromDeclaration
 import models.responsiblepeople._
 import models.status._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.OptionValues
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/ExperienceTrainingControllerSpec.scala
+++ b/test/controllers/responsiblepeople/ExperienceTrainingControllerSpec.scala
@@ -27,7 +27,7 @@ import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople.{ExperienceTrainingNo, ExperienceTrainingYes, PersonName, ResponsiblePerson}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/FitAndProperControllerSpec.scala
+++ b/test/controllers/responsiblepeople/FitAndProperControllerSpec.scala
@@ -23,7 +23,7 @@ import models.businessmatching.BusinessMatchingMsbService.TransmittingMoney
 import models.businessmatching._
 import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople.{ApprovalFlags, PersonName, ResponsiblePerson}
-import org.mockito.Matchers.{any, eq => meq}
+import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/NationalityControllerSpec.scala
+++ b/test/controllers/responsiblepeople/NationalityControllerSpec.scala
@@ -24,7 +24,7 @@ import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/PersonNameControllerSpec.scala
+++ b/test/controllers/responsiblepeople/PersonNameControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.responsiblepeople.PersonNameFormProvider
 import models.responsiblepeople._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import utils.AmlsSpec

--- a/test/controllers/responsiblepeople/PersonNonUKPassportControllerSpec.scala
+++ b/test/controllers/responsiblepeople/PersonNonUKPassportControllerSpec.scala
@@ -23,7 +23,7 @@ import forms.responsiblepeople.PersonNonUKPassportFormProvider
 import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople.{DateOfBirth, NonUKPassportYes, PersonName, ResponsiblePerson}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/PersonResidentTypeControllerSpec.scala
+++ b/test/controllers/responsiblepeople/PersonResidentTypeControllerSpec.scala
@@ -25,7 +25,7 @@ import models.Country
 import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople._
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/PersonUKPassportControllerSpec.scala
+++ b/test/controllers/responsiblepeople/PersonUKPassportControllerSpec.scala
@@ -23,7 +23,7 @@ import forms.responsiblepeople.PersonUKPassportFormProvider
 import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/PositionWithinBusinessControllerSpec.scala
+++ b/test/controllers/responsiblepeople/PositionWithinBusinessControllerSpec.scala
@@ -27,7 +27,7 @@ import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/PositionWithinBusinessStartDateControllerSpec.scala
+++ b/test/controllers/responsiblepeople/PositionWithinBusinessStartDateControllerSpec.scala
@@ -27,7 +27,7 @@ import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/RegisteredForSelfAssessmentControllerSpec.scala
+++ b/test/controllers/responsiblepeople/RegisteredForSelfAssessmentControllerSpec.scala
@@ -23,7 +23,7 @@ import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople.{PersonName, ResponsiblePerson, SaRegisteredYes}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/RemoveResponsiblePersonControllerSpec.scala
+++ b/test/controllers/responsiblepeople/RemoveResponsiblePersonControllerSpec.scala
@@ -26,7 +26,7 @@ import models.responsiblepeople._
 import models.status._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers

--- a/test/controllers/responsiblepeople/ResponsiblePersonAddControllerSpec.scala
+++ b/test/controllers/responsiblepeople/ResponsiblePersonAddControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.responsiblepeople
 import connectors.DataCacheConnector
 import controllers.actions.SuccessfulAuthAction
 import models.responsiblepeople.{ApprovalFlags, ResponsiblePerson}
-import org.mockito.Matchers.{any, eq => meq}
+import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import play.api.mvc.Call

--- a/test/controllers/responsiblepeople/SoleProprietorOfAnotherBusinessControllerSpec.scala
+++ b/test/controllers/responsiblepeople/SoleProprietorOfAnotherBusinessControllerSpec.scala
@@ -23,7 +23,7 @@ import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople.{PersonName, ResponsiblePerson, SoleProprietorOfAnotherBusiness, VATRegisteredNo}
 import models.status.{NotCompleted, SubmissionStatus}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/TrainingControllerSpec.scala
+++ b/test/controllers/responsiblepeople/TrainingControllerSpec.scala
@@ -23,7 +23,7 @@ import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople.{PersonName, ResponsiblePerson, TrainingNo, TrainingYes}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/VATRegisteredControllerSpec.scala
+++ b/test/controllers/responsiblepeople/VATRegisteredControllerSpec.scala
@@ -23,7 +23,7 @@ import models.responsiblepeople.ResponsiblePerson._
 import models.responsiblepeople.{PersonName, ResponsiblePerson, VATRegisteredNo, VATRegisteredYes}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/WhatYouNeedControllerSpec.scala
+++ b/test/controllers/responsiblepeople/WhatYouNeedControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.responsiblepeople
 import controllers.actions.SuccessfulAuthAction
 import models.businessmatching.BusinessActivity.{MoneyServiceBusiness, TelephonePaymentService, TrustAndCompanyServices}
 import models.businessmatching.{BusinessActivities, BusinessMatching}
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/YourResponsiblePeopleControllerSpec.scala
+++ b/test/controllers/responsiblepeople/YourResponsiblePeopleControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.responsiblepeople
 import controllers.actions.SuccessfulAuthAction
 import models.responsiblepeople.{PersonName, ResponsiblePerson}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/address/AdditionalAddressControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/AdditionalAddressControllerSpec.scala
@@ -25,7 +25,7 @@ import models.responsiblepeople._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfter, OptionValues}
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/address/AdditionalAddressNonUKControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/AdditionalAddressNonUKControllerSpec.scala
@@ -27,7 +27,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/address/AdditionalAddressUKControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/AdditionalAddressUKControllerSpec.scala
@@ -26,7 +26,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/address/AdditionalExtraAddressControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/AdditionalExtraAddressControllerSpec.scala
@@ -24,7 +24,7 @@ import models.responsiblepeople.TimeAtAddress.ZeroToFiveMonths
 import models.responsiblepeople._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfter, OptionValues}
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/address/AdditionalExtraAddressNonUKControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/AdditionalExtraAddressNonUKControllerSpec.scala
@@ -25,7 +25,7 @@ import models.responsiblepeople.TimeAtAddress.ZeroToFiveMonths
 import models.responsiblepeople._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/address/AdditionalExtraAddressUKControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/AdditionalExtraAddressUKControllerSpec.scala
@@ -24,7 +24,7 @@ import models.responsiblepeople.TimeAtAddress.ZeroToFiveMonths
 import models.responsiblepeople._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/address/CurrentAddressControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/CurrentAddressControllerSpec.scala
@@ -25,7 +25,7 @@ import models.responsiblepeople._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfter, OptionValues}
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/address/CurrentAddressDateOfChangeControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/CurrentAddressDateOfChangeControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.responsiblepeople.address
 import forms.DateOfChangeFormProvider
 import models.responsiblepeople.TimeAtAddress.{ThreeYearsPlus, ZeroToFiveMonths}
 import models.responsiblepeople._
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/address/CurrentAddressNonUKControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/CurrentAddressNonUKControllerSpec.scala
@@ -33,7 +33,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/responsiblepeople/address/CurrentAddressUKControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/CurrentAddressUKControllerSpec.scala
@@ -33,7 +33,7 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.select.Elements
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/responsiblepeople/address/MovedAddressControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/MovedAddressControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import controllers.responsiblepeople.address
 import forms.responsiblepeople.address.MovedAddressFormProvider
 import models.responsiblepeople._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/address/NewHomeAddressControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/NewHomeAddressControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.responsiblepeople.address.NewHomeAddressFormProvider
 import models.Country
 import models.responsiblepeople._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{any, eq => meq}
+import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.{verify, when}
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/responsiblepeople/address/NewHomeAddressDateOfChangeControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/NewHomeAddressDateOfChangeControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.DataCacheConnector
 import controllers.actions.SuccessfulAuthAction
 import forms.responsiblepeople.address.NewHomeAddressDateOfChangeFormProvider
 import models.responsiblepeople._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/responsiblepeople/address/NewHomeAddressNonUKControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/NewHomeAddressNonUKControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.responsiblepeople.address.NewHomeAddressNonUKFormProvider
 import models.responsiblepeople.TimeAtAddress.{OneToThreeYears, SixToElevenMonths, ThreeYearsPlus, ZeroToFiveMonths}
 import models.responsiblepeople._
 import models.{Country, DateOfChange}
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/responsiblepeople/address/NewHomeAddressUKControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/NewHomeAddressUKControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.responsiblepeople.address.NewHomeAddressUKFormProvider
 import models.DateOfChange
 import models.responsiblepeople.TimeAtAddress.{OneToThreeYears, SixToElevenMonths, ThreeYearsPlus, ZeroToFiveMonths}
 import models.responsiblepeople._
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/responsiblepeople/address/TimeAtAdditionalAddressControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/TimeAtAdditionalAddressControllerSpec.scala
@@ -24,7 +24,7 @@ import models.responsiblepeople.TimeAtAddress.{OneToThreeYears, ThreeYearsPlus, 
 import models.responsiblepeople._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/address/TimeAtAdditionalExtraAddressControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/TimeAtAdditionalExtraAddressControllerSpec.scala
@@ -24,7 +24,7 @@ import models.responsiblepeople.TimeAtAddress.ZeroToFiveMonths
 import models.responsiblepeople._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/responsiblepeople/address/TimeAtCurrentAddressControllerNoRelease7Spec.scala
+++ b/test/controllers/responsiblepeople/address/TimeAtCurrentAddressControllerNoRelease7Spec.scala
@@ -22,7 +22,7 @@ import forms.responsiblepeople.address.TimeAtAddressFormProvider
 import models.responsiblepeople.TimeAtAddress.{OneToThreeYears, ZeroToFiveMonths}
 import models.responsiblepeople._
 import models.status.SubmissionDecisionApproved
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/responsiblepeople/address/TimeAtCurrentAddressControllerSpec.scala
+++ b/test/controllers/responsiblepeople/address/TimeAtCurrentAddressControllerSpec.scala
@@ -25,7 +25,7 @@ import models.responsiblepeople._
 import models.status.SubmissionReadyForReview
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/supervision/ProfessionalBodyMemberControllerSpec.scala
+++ b/test/controllers/supervision/ProfessionalBodyMemberControllerSpec.scala
@@ -23,7 +23,7 @@ import models.supervision._
 import org.jsoup.Jsoup
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import play.api.i18n.Messages
 import play.api.mvc.Result
 import play.api.test.Helpers._

--- a/test/controllers/supervision/SummaryControllerSpec.scala
+++ b/test/controllers/supervision/SummaryControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import models.asp.Asp
 import models.supervision.{Supervision, SupervisionValues}
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/supervision/WhichProfessionalBodyControllerSpec.scala
+++ b/test/controllers/supervision/WhichProfessionalBodyControllerSpec.scala
@@ -23,7 +23,7 @@ import models.supervision._
 import org.jsoup.Jsoup
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.scalatestplus.play.PlaySpec
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/tcsp/ComplexCorpStructureCreationControllerSpec.scala
+++ b/test/controllers/tcsp/ComplexCorpStructureCreationControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.tcsp.ComplexCorpStructureCreationFormProvider
 import models.tcsp._
 import models.tcsp.ProvidedServices._
 import models.tcsp.TcspTypes._
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tcsp/OnlyOffTheShelfCompsSoldControllerSpec.scala
+++ b/test/controllers/tcsp/OnlyOffTheShelfCompsSoldControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.tcsp.OnlyOffTheShelfCompsSoldFormProvider
 import models.tcsp.ProvidedServices._
 import models.tcsp.TcspTypes._
 import models.tcsp._
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tcsp/ProvidedServicesControllerSpec.scala
+++ b/test/controllers/tcsp/ProvidedServicesControllerSpec.scala
@@ -21,7 +21,7 @@ import forms.tcsp.ProvidedServicesFormProvider
 import models.tcsp.ProvidedServices.{Other, PhonecallHandling}
 import models.tcsp.{ProvidedServices, Tcsp}
 import org.jsoup.Jsoup
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tcsp/ServicesOfAnotherTCSPControllerSpec.scala
+++ b/test/controllers/tcsp/ServicesOfAnotherTCSPControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import forms.tcsp.ServicesOfAnotherTCSPFormProvider
 import generators.AmlsReferenceNumberGenerator
 import models.tcsp.{ServicesOfAnotherTCSPYes, Tcsp}
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tcsp/SummaryControllerSpec.scala
+++ b/test/controllers/tcsp/SummaryControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.actions.SuccessfulAuthAction
 import models.tcsp._
 import models.tcsp.ProvidedServices._
 import models.tcsp.TcspTypes._
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.OptionValues
 import play.api.test.Helpers._

--- a/test/controllers/tcsp/TcspTypesControllerSpec.scala
+++ b/test/controllers/tcsp/TcspTypesControllerSpec.scala
@@ -23,7 +23,7 @@ import models.tcsp.TcspTypes._
 import models.tcsp.ProvidedServices._
 import models.tcsp._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/tradingpremises/ActivityStartDateControllerSpec.scala
+++ b/test/controllers/tradingpremises/ActivityStartDateControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.tradingpremises.ActivityStartDateFormProvider
 import models.tradingpremises._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.Matchers.{any, eq => meq}
+import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tradingpremises/AgentCompanyDetailsControllerSpec.scala
+++ b/test/controllers/tradingpremises/AgentCompanyDetailsControllerSpec.scala
@@ -25,7 +25,7 @@ import models.tradingpremises.BusinessStructure.SoleProprietor
 import models.tradingpremises.TradingPremisesMsbService._
 import models.tradingpremises._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/controllers/tradingpremises/AgentNameControllerSpec.scala
+++ b/test/controllers/tradingpremises/AgentNameControllerSpec.scala
@@ -28,7 +28,7 @@ import models.tradingpremises._
 import models.tradingpremises.TradingPremisesMsbService._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tradingpremises/AgentPartnershipControllerSpec.scala
+++ b/test/controllers/tradingpremises/AgentPartnershipControllerSpec.scala
@@ -22,7 +22,7 @@ import generators.tradingpremises.TradingPremisesGenerator
 import models.TradingPremisesSection
 import models.tradingpremises.{AgentPartnership, TradingPremises}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tradingpremises/BusinessStructureControllerSpec.scala
+++ b/test/controllers/tradingpremises/BusinessStructureControllerSpec.scala
@@ -23,7 +23,7 @@ import models.TradingPremisesSection
 import models.tradingpremises.BusinessStructure._
 import models.tradingpremises._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tradingpremises/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/tradingpremises/CheckYourAnswersControllerSpec.scala
@@ -23,7 +23,7 @@ import models.businessmatching.BusinessMatchingMsbService.{CurrencyExchange, Tra
 import models.businessmatching.{BusinessMatching, BusinessActivities => BusinessMatchingActivities, _}
 import models.status.SubmissionDecisionApproved
 import models.tradingpremises.{Address, TradingPremises, YourTradingPremises}
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers.{OK, contentAsString, status, _}

--- a/test/controllers/tradingpremises/ConfirmAddressControllerSpec.scala
+++ b/test/controllers/tradingpremises/ConfirmAddressControllerSpec.scala
@@ -26,7 +26,7 @@ import models.businesscustomer.{Address, ReviewDetails}
 import models.businessmatching.{BusinessMatching, BusinessType}
 import models.registrationdetails.RegistrationDetails
 import models.tradingpremises.{TradingPremises, YourTradingPremises}
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages

--- a/test/controllers/tradingpremises/IsResidentialControllerSpec.scala
+++ b/test/controllers/tradingpremises/IsResidentialControllerSpec.scala
@@ -21,7 +21,7 @@ import forms.tradingpremises.IsResidentialFormProvider
 import models.businessmatching.BusinessMatching
 import models.tradingpremises._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tradingpremises/MSBServicesControllerSpec.scala
+++ b/test/controllers/tradingpremises/MSBServicesControllerSpec.scala
@@ -32,7 +32,7 @@ import models.tradingpremises.TradingPremisesMsbService.{
   TransmittingMoney => TPTransmittingMoney,
 }
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tradingpremises/RegisteringAgentPremisesControllerSpec.scala
+++ b/test/controllers/tradingpremises/RegisteringAgentPremisesControllerSpec.scala
@@ -24,7 +24,7 @@ import models.businessmatching.{BusinessActivities => BusinessMatchingActivities
 import models.businessmatching.BusinessActivity._
 import models.tradingpremises.{RegisteringAgentPremises, TradingPremises}
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/tradingpremises/RemoveAgentPremisesReasonsControllerSpec.scala
+++ b/test/controllers/tradingpremises/RemoveAgentPremisesReasonsControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.tradingpremises.RemoveAgentPremisesReasonsFormProvider
 import models.tradingpremises.AgentRemovalReason.Other
 import models.tradingpremises.TradingPremises
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.JsValue

--- a/test/controllers/tradingpremises/RemoveTradingPremisesControllerSpec.scala
+++ b/test/controllers/tradingpremises/RemoveTradingPremisesControllerSpec.scala
@@ -25,7 +25,7 @@ import models.tradingpremises.BusinessStructure.SoleProprietor
 import models.tradingpremises.TradingPremisesMsbService._
 import models.tradingpremises._
 import org.jsoup.Jsoup
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/controllers/tradingpremises/TPControllerHelperSpec.scala
+++ b/test/controllers/tradingpremises/TPControllerHelperSpec.scala
@@ -20,7 +20,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import uk.gov.hmrc.http.cache.client.CacheMap
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import cats.implicits._
 import config.ApplicationConfig
 import models.tradingpremises.{RegisteringAgentPremises, TradingPremises}

--- a/test/controllers/tradingpremises/TradingPremisesAddControllerSpec.scala
+++ b/test/controllers/tradingpremises/TradingPremisesAddControllerSpec.scala
@@ -22,7 +22,7 @@ import generators.tradingpremises.TradingPremisesGenerator
 import models.businessmatching._
 import models.businessmatching.BusinessActivity._
 import models.tradingpremises.TradingPremises
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.test.Helpers._

--- a/test/controllers/tradingpremises/WhatDoesYourBusinessDoControllerSpec.scala
+++ b/test/controllers/tradingpremises/WhatDoesYourBusinessDoControllerSpec.scala
@@ -30,7 +30,7 @@ import models.{DateOfChange, TradingPremisesSection}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tradingpremises/WhatYouNeedControllerSpec.scala
+++ b/test/controllers/tradingpremises/WhatYouNeedControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.actions.SuccessfulAuthAction
 import models.businessmatching.BusinessActivity._
 import models.businessmatching.BusinessMatchingMsbService.{ChequeCashingNotScrapMetal, TransmittingMoney}
 import models.businessmatching._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tradingpremises/WhereAreTradingPremisesControllerSpec.scala
+++ b/test/controllers/tradingpremises/WhereAreTradingPremisesControllerSpec.scala
@@ -25,7 +25,7 @@ import models.status.{ReadyForRenewal, SubmissionDecisionApproved, SubmissionDec
 import models.tradingpremises._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/controllers/tradingpremises/YourTradingPremisesControllerSpec.scala
+++ b/test/controllers/tradingpremises/YourTradingPremisesControllerSpec.scala
@@ -22,7 +22,7 @@ import models.businessmatching.BusinessActivity._
 import models.businessmatching.{BusinessMatching, BusinessActivities => BusinessMatchingActivities}
 import models.status.{SubmissionDecisionApproved, SubmissionReady, SubmissionReadyForReview}
 import models.tradingpremises._
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.Messages

--- a/test/controllers/withdrawal/WithdrawApplicationControllerSpec.scala
+++ b/test/controllers/withdrawal/WithdrawApplicationControllerSpec.scala
@@ -23,7 +23,7 @@ import models.ReadStatusResponse
 import models.businesscustomer.ReviewDetails
 import models.registrationdetails.RegistrationDetails
 import models.status.SubmissionReadyForReview
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import services.{AuthEnrolmentsService, StatusService}

--- a/test/controllers/withdrawal/WithdrawalReasonControllerSpec.scala
+++ b/test/controllers/withdrawal/WithdrawalReasonControllerSpec.scala
@@ -24,7 +24,7 @@ import models.withdrawal.WithdrawalReason.{Other, OutOfScope}
 import models.withdrawal.{WithdrawSubscriptionRequest, WithdrawSubscriptionResponse, WithdrawalReason}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Injecting}

--- a/test/filters/ConfirmationFilterSpec.scala
+++ b/test/filters/ConfirmationFilterSpec.scala
@@ -18,7 +18,7 @@ package filters
 
 import connectors.{AuthenticatorConnector, KeystoreConnector}
 import models.status.ConfirmationStatus
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec

--- a/test/models/autocomplete/GovUkCountryDataProviderSpec.scala
+++ b/test/models/autocomplete/GovUkCountryDataProviderSpec.scala
@@ -17,7 +17,7 @@
 package models.autocomplete
 
 import java.io.ByteArrayInputStream
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec

--- a/test/models/bankdetails/BankDetailsSpec.scala
+++ b/test/models/bankdetails/BankDetailsSpec.scala
@@ -242,7 +242,7 @@ class BankDetailsSpec extends AmlsSpec with CharacterSets with DependencyMocks w
 
         val updatedTaskRow = TaskRow(
           "bankdetails",
-          controllers.bankdetails.routes.YourBankAccountsController.get.url,
+          controllers.bankdetails.routes.YourBankAccountsController.get().url,
           true,
           Updated,
           TaskRow.updatedTag
@@ -257,7 +257,7 @@ class BankDetailsSpec extends AmlsSpec with CharacterSets with DependencyMocks w
         val deleted = Seq(completeModel.copy(status = Some(StatusConstants.Deleted), hasChanged = true, hasAccepted = true))
         val updatedTaskRow = TaskRow(
           "bankdetails",
-          controllers.bankdetails.routes.YourBankAccountsController.get.url,
+          controllers.bankdetails.routes.YourBankAccountsController.get().url,
           true,
           Updated,
           TaskRow.updatedTag
@@ -272,7 +272,7 @@ class BankDetailsSpec extends AmlsSpec with CharacterSets with DependencyMocks w
       val incomplete = Seq(accountTypePartialModel)
       val startedTaskRow = TaskRow(
         "bankdetails",
-        controllers.bankdetails.routes.YourBankAccountsController.get.url,
+        controllers.bankdetails.routes.YourBankAccountsController.get().url,
         false,
         Started,
         TaskRow.incompleteTag

--- a/test/models/businessactivities/BusinessActivitiesSpec.scala
+++ b/test/models/businessactivities/BusinessActivitiesSpec.scala
@@ -21,7 +21,7 @@ import models.businessmatching.BusinessActivity._
 import models.businessmatching.{BusinessActivities => ba, _}
 import models.registrationprogress._
 import models.{Country, DateOfChange}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.http.cache.client.CacheMap

--- a/test/models/businessdetails/BusinessDetailsSpec.scala
+++ b/test/models/businessdetails/BusinessDetailsSpec.scala
@@ -17,7 +17,7 @@
 package models.businessdetails
 
 import models.registrationprogress._
-import org.mockito.Matchers.{any, eq => meq}
+import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito._
 import play.api.libs.json.{JsNull, Json}
 import uk.gov.hmrc.http.cache.client.CacheMap

--- a/test/models/businessmatching/BusinessMatchingSpec.scala
+++ b/test/models/businessmatching/BusinessMatchingSpec.scala
@@ -22,7 +22,7 @@ import models.businesscustomer.{Address, ReviewDetails}
 import models.businessmatching.BusinessActivity._
 import models.businessmatching.BusinessMatchingMsbService._
 import models.registrationprogress._
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import utils.AmlsSpec

--- a/test/models/eab/EabSpec.scala
+++ b/test/models/eab/EabSpec.scala
@@ -17,7 +17,7 @@
 package models.eab
 
 import models.registrationprogress._
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import play.api.libs.json._
 import uk.gov.hmrc.http.cache.client.CacheMap

--- a/test/models/responsiblepeople/ResponsiblePersonSpec.scala
+++ b/test/models/responsiblepeople/ResponsiblePersonSpec.scala
@@ -16,7 +16,7 @@
 
 package models.responsiblepeople
 
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec

--- a/test/models/tradingpremises/TradingPremisesSpec.scala
+++ b/test/models/tradingpremises/TradingPremisesSpec.scala
@@ -20,7 +20,7 @@ import models.businessmatching.BusinessActivity._
 import models.registrationprogress._
 import models.tradingpremises.BusinessStructure._
 import models.tradingpremises.TradingPremisesMsbService._
-import org.mockito.Matchers.{eq => meq, _}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
 import org.mockito.Mockito._
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.cache.client.CacheMap

--- a/test/services/AuthEnrolmentsServiceSpec.scala
+++ b/test/services/AuthEnrolmentsServiceSpec.scala
@@ -20,7 +20,7 @@ import config.ApplicationConfig
 import connectors.{EnrolmentStubConnector, TaxEnrolmentsConnector}
 import generators.{AmlsReferenceNumberGenerator, BaseGenerator}
 import models.enrolment.{AmlsEnrolmentKey, EnrolmentIdentifier, GovernmentGatewayEnrolment, TaxEnrolment}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import play.api.test.Helpers._

--- a/test/services/ConfirmationServiceSpec.scala
+++ b/test/services/ConfirmationServiceSpec.scala
@@ -33,7 +33,7 @@ package services
  */
 import connectors.DataCacheConnector
 import models.renewal.Renewal
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import utils.AmlsSpec

--- a/test/services/DataCacheServiceSpec.scala
+++ b/test/services/DataCacheServiceSpec.scala
@@ -17,7 +17,7 @@
 package services
 
 import connectors.DataCacheConnector
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/services/FeeResponseServiceSpec.scala
+++ b/test/services/FeeResponseServiceSpec.scala
@@ -20,7 +20,7 @@ import cats.implicits._
 import connectors.FeeConnector
 import models.FeeResponse
 import models.ResponseType.{AmendOrVariationResponseType, SubscriptionResponseType}
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import uk.gov.hmrc.http.UpstreamErrorResponse

--- a/test/services/GovernmentGatewayServiceSpec.scala
+++ b/test/services/GovernmentGatewayServiceSpec.scala
@@ -20,7 +20,7 @@ import connectors.GovernmentGatewayConnector
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.http.Status._
 

--- a/test/services/LandingServiceSpec.scala
+++ b/test/services/LandingServiceSpec.scala
@@ -39,7 +39,7 @@ import models.supervision.Supervision
 import models.tcsp.TcspTypes._
 import models.tcsp._
 import models.tradingpremises.TradingPremises
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import play.api.libs.json.{Json, Writes}

--- a/test/services/NotificationServiceSpec.scala
+++ b/test/services/NotificationServiceSpec.scala
@@ -19,7 +19,7 @@ package services
 import connectors.AmlsNotificationConnector
 import models.notifications.ContactType._
 import models.notifications.{ContactType, IDType, NotificationDetails, NotificationRow}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks

--- a/test/services/PaymentsServiceSpec.scala
+++ b/test/services/PaymentsServiceSpec.scala
@@ -23,7 +23,7 @@ import models.FeeResponse
 import models.ResponseType.{AmendOrVariationResponseType, SubscriptionResponseType}
 import models.confirmation.Currency
 import models.payments._
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.PrivateMethodTester
 import org.scalatest.concurrent.ScalaFutures

--- a/test/services/RenewalServiceSpec.scala
+++ b/test/services/RenewalServiceSpec.scala
@@ -24,7 +24,7 @@ import models.businessmatching._
 import models.registrationprogress._
 import models.renewal._
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._

--- a/test/services/SectionsProviderSpec.scala
+++ b/test/services/SectionsProviderSpec.scala
@@ -32,7 +32,7 @@ import models.responsiblepeople.ResponsiblePerson
 import models.supervision.Supervision
 import models.tcsp.Tcsp
 import models.tradingpremises.TradingPremises
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.IntegrationPatience
 import uk.gov.hmrc.http.cache.client.CacheMap

--- a/test/services/StatusServiceSpec.scala
+++ b/test/services/StatusServiceSpec.scala
@@ -21,19 +21,20 @@ import models.ReadStatusResponse
 import models.businessmatching.BusinessMatching
 import models.registrationprogress.{Completed, NotStarted, TaskRow, Updated}
 import models.status._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.Messages
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers
 import play.api.{Application, Environment}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.ZoneOffset.UTC
-import java.time.{Clock, Instant, LocalDate, LocalDateTime, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time._
 import scala.concurrent.{ExecutionContext, Future}
 
 class StatusServiceSpec extends PlaySpec with MockitoSugar with ScalaFutures with GuiceOneAppPerSuite {
@@ -61,9 +62,9 @@ class StatusServiceSpec extends PlaySpec with MockitoSugar with ScalaFutures wit
   val accountTypeId = ("accountType", "accountId")
   val credId = "123412345"
   
-  implicit val hc = mock[HeaderCarrier]
-  implicit val ec = app.injector.instanceOf[ExecutionContext]
-  implicit val messages = Helpers.stubMessages()
+  implicit val hc: HeaderCarrier = mock[HeaderCarrier]
+  implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+  implicit val messages: Messages = Helpers.stubMessages()
 
   val readStatusResponse: ReadStatusResponse = ReadStatusResponse(LocalDateTime.now(), "Pending", None, None, None, None, false)
 

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -36,7 +36,7 @@ import models.renewal._
 import models.responsiblepeople.ResponsiblePerson
 import models.tradingpremises.TradingPremises
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalacheck.Gen
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}

--- a/test/services/UpdateMongoCacheServiceSpec.scala
+++ b/test/services/UpdateMongoCacheServiceSpec.scala
@@ -43,7 +43,7 @@ import models.tcsp.TcspTypes._
 import models.tcsp.ProvidedServices.{PhonecallHandling, Other => PSOther}
 import models.tradingpremises.TradingPremises
 import models.{DataImport, _}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.verify
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers._

--- a/test/services/asp/ServicesOfBusinessDateOfChangeServiceSpec.scala
+++ b/test/services/asp/ServicesOfBusinessDateOfChangeServiceSpec.scala
@@ -20,8 +20,8 @@ import connectors.DataCacheConnector
 import models.DateOfChange
 import models.asp.{Asp, Service, ServicesOfBusiness}
 import models.businessdetails.{ActivityStartDate, BusinessDetails}
-import org.mockito.Matchers.{any, eq => eqTo}
-import org.mockito.Mockito.{reset, verifyZeroInteractions, when}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.{reset, verifyNoInteractions, when}
 import org.scalatest.BeforeAndAfterEach
 import uk.gov.hmrc.http.cache.client.CacheMap
 import utils.AmlsSpec
@@ -124,7 +124,7 @@ class ServicesOfBusinessDateOfChangeServiceSpec extends AmlsSpec with BeforeAndA
 
           service.updateAsp(emptyAsp, DateOfChange(date), cacheId).futureValue mustBe Some(emptyAsp)
 
-          verifyZeroInteractions(mockCacheConnector, mockCacheMap)
+          verifyNoInteractions(mockCacheConnector, mockCacheMap)
         }
       }
     }

--- a/test/services/businessactivities/BusinessFranchiseServiceSpec.scala
+++ b/test/services/businessactivities/BusinessFranchiseServiceSpec.scala
@@ -18,7 +18,7 @@ package services.businessactivities
 
 import connectors.DataCacheConnector
 import models.businessactivities.{BusinessActivities, BusinessFranchiseYes}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import uk.gov.hmrc.http.cache.client.CacheMap

--- a/test/services/businessactivities/DocumentRiskAssessmentServiceSpec.scala
+++ b/test/services/businessactivities/DocumentRiskAssessmentServiceSpec.scala
@@ -19,7 +19,7 @@ package services.businessactivities
 import connectors.DataCacheConnector
 import models.businessactivities._
 import models.businessmatching.BusinessMatching
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import uk.gov.hmrc.http.cache.client.CacheMap

--- a/test/services/businessactivities/EmployeeCountAMLSSupervisionServiceSpec.scala
+++ b/test/services/businessactivities/EmployeeCountAMLSSupervisionServiceSpec.scala
@@ -18,7 +18,7 @@ package services.businessactivities
 
 import connectors.DataCacheConnector
 import models.businessactivities.{BusinessActivities, EmployeeCountAMLSSupervision, HowManyEmployees}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.IntegrationPatience

--- a/test/services/businessactivities/ExpectedAMLSTurnoverServiceSpec.scala
+++ b/test/services/businessactivities/ExpectedAMLSTurnoverServiceSpec.scala
@@ -20,7 +20,7 @@ import connectors.DataCacheConnector
 import models.businessactivities.BusinessActivities
 import models.businessactivities.ExpectedAMLSTurnover.First
 import models.businessmatching.BusinessMatching
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.IntegrationPatience

--- a/test/services/businessactivities/HowManyEmployeesServiceSpec.scala
+++ b/test/services/businessactivities/HowManyEmployeesServiceSpec.scala
@@ -18,7 +18,7 @@ package services.businessactivities
 
 import connectors.DataCacheConnector
 import models.businessactivities.{BusinessActivities, EmployeeCount, HowManyEmployees}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.IntegrationPatience

--- a/test/services/businessdetails/BusinessEmailAddressServiceSpec.scala
+++ b/test/services/businessdetails/BusinessEmailAddressServiceSpec.scala
@@ -18,7 +18,7 @@ package services.businessdetails
 
 import connectors.DataCacheConnector
 import models.businessdetails.{BusinessDetails, ContactingYou, ContactingYouEmail}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.IntegrationPatience

--- a/test/services/businessdetails/ConfirmRegisteredOfficeServiceSpec.scala
+++ b/test/services/businessdetails/ConfirmRegisteredOfficeServiceSpec.scala
@@ -21,7 +21,7 @@ import models.Country
 import models.businesscustomer.{Address, ReviewDetails}
 import models.businessdetails.{BusinessDetails, ConfirmRegisteredOffice, RegisteredOfficeUK}
 import models.businessmatching.BusinessMatching
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.BeforeAndAfterEach
 import uk.gov.hmrc.http.cache.client.CacheMap

--- a/test/services/businessdetails/PreviouslyRegisteredServiceSpec.scala
+++ b/test/services/businessdetails/PreviouslyRegisteredServiceSpec.scala
@@ -18,7 +18,7 @@ package services.businessdetails
 
 import connectors.DataCacheConnector
 import models.businessdetails.{BusinessDetails, PreviouslyRegisteredNo, PreviouslyRegisteredYes}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import uk.gov.hmrc.http.cache.client.CacheMap

--- a/test/services/businessmatching/BusinessMatchingServiceSpec.scala
+++ b/test/services/businessmatching/BusinessMatchingServiceSpec.scala
@@ -32,7 +32,7 @@ import models.hvd.Hvd
 import models.moneyservicebusiness.{MoneyServiceBusiness => Msb}
 import models.status.SubmissionDecisionApproved
 import models.tcsp.Tcsp
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/services/businessmatching/BusinessTypeServiceSpec.scala
+++ b/test/services/businessmatching/BusinessTypeServiceSpec.scala
@@ -21,7 +21,7 @@ import models.Country
 import models.businesscustomer.{Address, ReviewDetails}
 import models.businessmatching.BusinessType.LPrLLP
 import models.businessmatching.{BusinessMatching, BusinessType}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalacheck.Gen
 import org.scalatest.BeforeAndAfterEach

--- a/test/services/businessmatching/RecoverActivitiesServiceSpec.scala
+++ b/test/services/businessmatching/RecoverActivitiesServiceSpec.scala
@@ -22,7 +22,7 @@ import models.businessmatching.BusinessActivity.ArtMarketParticipant
 import models.businessmatching.{BusinessActivities, BusinessMatching}
 import models.declaration.AddPerson
 import models.declaration.release7.RoleWithinBusinessRelease7
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.AnyContentAsEmpty

--- a/test/services/businessmatching/updateservice/ServiceFlowSpec.scala
+++ b/test/services/businessmatching/updateservice/ServiceFlowSpec.scala
@@ -27,7 +27,7 @@ import models.eab.Eab
 import models.hvd.Hvd
 import models.moneyservicebusiness.{MoneyServiceBusiness => MsbModel}
 import models.tcsp.Tcsp
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers

--- a/test/services/flowmanagement/flowrouters/AddBusinessTypeRouterSpec.scala
+++ b/test/services/flowmanagement/flowrouters/AddBusinessTypeRouterSpec.scala
@@ -21,7 +21,7 @@ import controllers.businessmatching.updateservice.add.{routes => addRoutes}
 import models.businessmatching.BusinessActivity._
 import models.businessmatching._
 import models.flowmanagement._
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.mvc.Results.Redirect
 import play.api.test.Helpers._

--- a/test/services/flowmanagement/flowrouters/RemoveBusinessTypeRouterSpec.scala
+++ b/test/services/flowmanagement/flowrouters/RemoveBusinessTypeRouterSpec.scala
@@ -44,11 +44,7 @@ class RemoveBusinessTypeRouterSpec extends AmlsSpec with TradingPremisesGenerato
     val mockBusinessMatchingService = mock[BusinessMatchingService]
     val mockApplicationConfig = mock[ApplicationConfig]
 
-    val removeBusinessTypeHelper = new RemoveBusinessTypeHelper(
-      SuccessfulAuthAction,
-      mockApplicationConfig,
-      mockCacheConnector
-    )
+    val removeBusinessTypeHelper = new RemoveBusinessTypeHelper()(mockCacheConnector)
 
     val router = new RemoveBusinessTypeRouter(
       businessMatchingService = mockBusinessMatchingService,

--- a/test/services/flowmanagement/flowrouters/businessmatching/ChangeBusinessTypeRouterSpec.scala
+++ b/test/services/flowmanagement/flowrouters/businessmatching/ChangeBusinessTypeRouterSpec.scala
@@ -23,7 +23,7 @@ import models.businessmatching.BusinessActivity._
 import models.businessmatching._
 import models.businessmatching.updateservice.{Add, Remove}
 import models.flowmanagement.ChangeBusinessTypesPageId
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.mvc.Results.Redirect
 import play.api.test.Helpers._

--- a/test/services/msb/BranchesOrAgentsWhichCountriesServiceSpec.scala
+++ b/test/services/msb/BranchesOrAgentsWhichCountriesServiceSpec.scala
@@ -19,7 +19,7 @@ package services.msb
 import connectors.DataCacheConnector
 import models.Country
 import models.moneyservicebusiness.{BranchesOrAgents, BranchesOrAgentsHasCountries, BranchesOrAgentsWhichCountries, MoneyServiceBusiness}
-import org.mockito.Matchers.{any, eq => meq}
+import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.{reset, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import play.api.mvc.Results.Redirect

--- a/test/services/notifications/v1m0/MessageDetailsSpec.scala
+++ b/test/services/notifications/v1m0/MessageDetailsSpec.scala
@@ -19,7 +19,7 @@ package services.notifications.v1m0
 import connectors.AmlsNotificationConnector
 import models.notifications.ContactType._
 import models.notifications.{ContactType, IDType, NotificationDetails, NotificationRow}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.MessagesApi

--- a/test/services/notifications/v2m0/MessageDetailsSpec.scala
+++ b/test/services/notifications/v2m0/MessageDetailsSpec.scala
@@ -19,7 +19,7 @@ package services.notifications.v2m0
 import connectors.AmlsNotificationConnector
 import models.notifications.ContactType._
 import models.notifications.{ContactType, IDType, NotificationDetails, NotificationRow}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.MessagesApi

--- a/test/services/notifications/v3m0/MessageDetailsSpec.scala
+++ b/test/services/notifications/v3m0/MessageDetailsSpec.scala
@@ -19,7 +19,7 @@ package services.notifications.v3m0
 import connectors.AmlsNotificationConnector
 import models.notifications.ContactType._
 import models.notifications.{ContactType, IDType, NotificationDetails, NotificationRow}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.MessagesApi

--- a/test/services/notifications/v4m0/MessageDetailsSpec.scala
+++ b/test/services/notifications/v4m0/MessageDetailsSpec.scala
@@ -19,7 +19,7 @@ package services.notifications.v4m0
 import connectors.AmlsNotificationConnector
 import models.notifications.ContactType._
 import models.notifications.{ContactType, IDType, NotificationDetails, NotificationRow}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.MessagesApi

--- a/test/services/notifications/v5m0/MessageDetailsSpec.scala
+++ b/test/services/notifications/v5m0/MessageDetailsSpec.scala
@@ -19,7 +19,7 @@ package services.notifications.v5m0
 import connectors.AmlsNotificationConnector
 import models.notifications.ContactType._
 import models.notifications.{ContactType, IDType, NotificationDetails, NotificationRow}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.i18n.MessagesApi

--- a/test/services/responsiblepeople/PersonResidentTypeServiceSpec.scala
+++ b/test/services/responsiblepeople/PersonResidentTypeServiceSpec.scala
@@ -20,7 +20,7 @@ import connectors.DataCacheConnector
 import models.Country
 import models.responsiblepeople._
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import play.api.mvc.AnyContentAsEmpty
@@ -134,7 +134,7 @@ class PersonResidentTypeServiceSpec extends AmlsSpec with ResponsiblePeopleValue
 
           when(mockDataCacheConnector.fetchAll(any())(any())).thenReturn(Future.successful(None))
 
-          verifyZeroInteractions(mockCacheMap)
+          verifyNoInteractions(mockCacheMap)
 
           verify(mockDataCacheConnector, times(0))
             .save[Seq[ResponsiblePerson]](any(), any(), any())(any())

--- a/test/services/responsiblepeople/YourResponsiblePeopleServiceSpec.scala
+++ b/test/services/responsiblepeople/YourResponsiblePeopleServiceSpec.scala
@@ -18,7 +18,7 @@ package services.responsiblepeople
 
 import connectors.DataCacheConnector
 import models.responsiblepeople.{PersonName, ResponsiblePeopleValues, ResponsiblePerson}
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import utils.{AmlsSpec, StatusConstants}
 

--- a/test/utils/BusinessNameSpec.scala
+++ b/test/utils/BusinessNameSpec.scala
@@ -23,7 +23,7 @@ import models.businesscustomer.ReviewDetails
 import models.businessmatching.BusinessMatching
 import models.registrationdetails.RegistrationDetails
 import models.status.SubmissionReady
-import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import services.StatusService

--- a/test/utils/CacheMocks.scala
+++ b/test/utils/CacheMocks.scala
@@ -18,7 +18,7 @@ package utils
 
 import connectors.DataCacheConnector
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/test/utils/DeclarationHelperSpec.scala
+++ b/test/utils/DeclarationHelperSpec.scala
@@ -21,7 +21,7 @@ import models.registrationprogress.{Completed, Started, TaskRow, Updated}
 import models.renewal._
 import models.responsiblepeople._
 import models.status._
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/utils/FeeHelperSpec.scala
+++ b/test/utils/FeeHelperSpec.scala
@@ -20,7 +20,7 @@ import generators.AmlsReferenceNumberGenerator
 import generators.submission.SubscriptionResponseGenerator
 import models.ResponseType.SubscriptionResponseType
 import models.{FeeResponse, ResponseType}
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/utils/RouterMocks.scala
+++ b/test/utils/RouterMocks.scala
@@ -17,7 +17,7 @@
 package utils
 
 import models.flowmanagement.PageId
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.Results.Redirect

--- a/test/utils/ServiceFlowMocks.scala
+++ b/test/utils/ServiceFlowMocks.scala
@@ -20,7 +20,7 @@ import models.businessmatching.BusinessActivity
 import org.scalatestplus.mockito.MockitoSugar
 import services.businessmatching.ServiceFlow
 import org.mockito.Mockito.when
-import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 
 import scala.concurrent.Future
 

--- a/test/utils/StatusMocks.scala
+++ b/test/utils/StatusMocks.scala
@@ -17,7 +17,7 @@
 package utils
 
 import models.status.SubmissionStatus
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import services.StatusService


### PR DESCRIPTION
I didn't touch bootstrap or play-partials as these both bring in a later version of crypto which causes problems addressed in another ticket (no idea why play-partials does this).

play-frontend-hmrc was upgraded with the help of the guidance in the library's changelog. One notable change is that it has changed the capitalisation of the content inside govuk tags, so for AMLS this is the row statuses such as Completed, Updated, etc. Because of this there is also an AT PR as it is matching on the tag content: https://github.com/hmrc/amls-acceptance-test/pull/368

Most of the test changes are due to removal of explicit mockito dep in favour of using the one provided by bootstrap. I also addressed a few warnings in the service but didn't go too far with it to prevent overwhelming the PR. 