### PR TITLE
DDCYLS-5484 Reverted regex for transaction inputs

### DIFF
--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -30,7 +30,7 @@ trait Constraints {
   protected val numbersOnlyRegex = "^[0-9]*$"
   protected val vrnRegex: String = "^[0-9]{9}$"
   protected val utrRegex: String = "^[0-9]{10}$"
-  protected val transactionsRegex: String = "^\\s*\\d+,*\\d+\\s*$"
+  protected val transactionsRegex: String = "^[0-9]{1,11}$"
   protected val postcodeRegex: String = "^[A-Za-z]{1,2}[0-9][0-9A-Za-z]?\\s?[0-9][A-Za-z]{2}$"
 
   protected def firstError[A](constraints: Constraint[A]*): Constraint[A] =

--- a/test/forms/renewal/CETransactionsInLast12MonthsFormProviderSpec.scala
+++ b/test/forms/renewal/CETransactionsInLast12MonthsFormProviderSpec.scala
@@ -38,13 +38,28 @@ class CETransactionsInLast12MonthsFormProviderSpec extends StringFieldBehaviours
 
     behave like fieldWithMaxLength(form, fieldName, fp.length, FormError(fieldName, lengthAndRegexError, Seq(fp.length)))
 
-    "strip spaces and commas from input" in {
+    "bind a single digit value" in {
+      val result = form.bind(Map(fieldName -> "1"))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(CETransactionsInLast12Months("1"))
+    }
 
-      val input = s" 12,345,678,901 "
-      form.bind(Map(fieldName -> input)).fold(
-        error => fail("Invalid input, cannot bind: " + error.errors.toString),
-        data => assert(data.ceTransaction == input.trim.replace(",", ""))
-      )
+    "strip spaces from input" in {
+      val result = form.bind(Map(fieldName -> "  5 "))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(CETransactionsInLast12Months("5"))
+    }
+
+    "strip commas from input" in {
+      val result = form.bind(Map(fieldName -> "1,000"))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(CETransactionsInLast12Months("1000"))
+    }
+
+    "strip spaces and commas from input" in {
+      val result = form.bind(Map(fieldName -> " 12,345,678,901 "))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(CETransactionsInLast12Months("12345678901"))
     }
 
     "fail to bind non-numbers" in {

--- a/test/forms/renewal/FXTransactionsInLast12MonthsFormProviderSpec.scala
+++ b/test/forms/renewal/FXTransactionsInLast12MonthsFormProviderSpec.scala
@@ -38,13 +38,28 @@ class FXTransactionsInLast12MonthsFormProviderSpec extends StringFieldBehaviours
 
     behave like fieldWithMaxLength(form, fieldName, fp.length, FormError(fieldName, invalidError, Seq(fp.length)))
 
-    "strip spaces and commas from input" in {
+    "bind a single digit value" in {
+      val result = form.bind(Map(fieldName -> "1"))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(FXTransactionsInLast12Months("1"))
+    }
 
-      val input = s" 12,345,678,901 "
-      form.bind(Map(fieldName -> input)).fold(
-        error => fail("Invalid input, cannot bind: " + error.errors.toString),
-        data => assert(data.fxTransaction == input.trim.replace(",", ""))
-      )
+    "strip spaces from input" in {
+      val result = form.bind(Map(fieldName -> "  5 "))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(FXTransactionsInLast12Months("5"))
+    }
+
+    "strip commas from input" in {
+      val result = form.bind(Map(fieldName -> "1,000"))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(FXTransactionsInLast12Months("1000"))
+    }
+
+    "strip spaces and commas from input" in {
+      val result = form.bind(Map(fieldName -> " 12,345,678,901 "))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(FXTransactionsInLast12Months("12345678901"))
     }
 
     "fail to bind non-numbers" in {

--- a/test/forms/renewal/TransactionsInLast12MonthsFormProviderSpec.scala
+++ b/test/forms/renewal/TransactionsInLast12MonthsFormProviderSpec.scala
@@ -38,13 +38,28 @@ class TransactionsInLast12MonthsFormProviderSpec extends StringFieldBehaviours w
 
     behave like fieldWithMaxLength(form, fieldName, fp.length, FormError(fieldName, s"$baseError.length", Seq(fp.length)))
 
-    "strip spaces and commas from input" in {
+    "bind a single digit value" in {
+      val result = form.bind(Map(fieldName -> "1"))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(TransactionsInLast12Months("1"))
+    }
 
-      val input = s" 12,345,678,901 "
-      form.bind(Map(fieldName -> input)).fold(
-        error => fail("Invalid input, cannot bind: " + error.errors.toString),
-        data => assert(data.transfers == input.trim.replace(",", ""))
-      )
+    "strip spaces from input" in {
+      val result = form.bind(Map(fieldName -> "  5 "))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(TransactionsInLast12Months("5"))
+    }
+
+    "strip commas from input" in {
+      val result = form.bind(Map(fieldName -> "1,000"))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(TransactionsInLast12Months("1000"))
+    }
+
+    "strip spaces and commas from input" in {
+      val result = form.bind(Map(fieldName -> " 12,345,678,901 "))
+      result.hasErrors shouldBe false
+      result.value shouldBe Some(TransactionsInLast12Months("12345678901"))
     }
 
     "fail to bind non-numbers" in {


### PR DESCRIPTION
The regex can stay as digits only because the forms strip out spaces/commas prior to the regex check