### PR TITLE
DDCYLS-4657 - Validation of passport number does not allow spaces

### DIFF
--- a/app/forms/responsiblepeople/PersonNonUKPassportFormProvider.scala
+++ b/app/forms/responsiblepeople/PersonNonUKPassportFormProvider.scala
@@ -36,7 +36,9 @@ class PersonNonUKPassportFormProvider @Inject()() extends Mappings {
       booleanFieldName -> boolean(emptyError, emptyError),
       "nonUKPassportNumber" -> mandatoryIfTrue(
         booleanFieldName,
-        text(s"$emptyError.number").verifying(
+        text(s"$emptyError.number")
+          .transform[String](_.replace(" ", "").trim, x => x)
+          .verifying(
           firstError(
             maxLength(length, "error.invalid.non.uk.passport.number.length.40"),
             regexp(basicPunctuationRegex, "error.invalid.non.uk.passport.number")

--- a/app/forms/responsiblepeople/PersonUKPassportFormProvider.scala
+++ b/app/forms/responsiblepeople/PersonUKPassportFormProvider.scala
@@ -38,13 +38,15 @@ class PersonUKPassportFormProvider @Inject()() extends Mappings {
       booleanFieldName -> boolean(booleanError, booleanError),
       "ukPassportNumber" -> mandatoryIfTrue(
         booleanFieldName,
-        text(s"$booleanError.number").verifying(
-          firstError(
-            maxLength(length, lengthError),
-            minLength(length, lengthError),
-            regexp(regex, "error.invalid.uk.passport")
+        text(s"$booleanError.number")
+          .transform[String](_.replace(" ", "").trim, x => x)
+          .verifying(
+            firstError(
+              maxLength(length, lengthError),
+              minLength(length, lengthError),
+              regexp(regex, "error.invalid.uk.passport")
+            )
           )
-        )
       )
     )(apply)(unapply)
   )

--- a/test/forms/responsiblepeople/PersonNonUKPassportFormProviderSpec.scala
+++ b/test/forms/responsiblepeople/PersonNonUKPassportFormProviderSpec.scala
@@ -59,6 +59,20 @@ class PersonNonUKPassportFormProviderSpec extends StringFieldBehaviours with Con
       }
     }
 
+    "true is submitted with a Password number which contains spaces" in {
+
+      val passString = " 1 2 34 5 6 78 9 "
+      val passStringTransformed = "123456789"
+
+      val result = form.bind(Map(
+        booleanFieldName -> "true",
+        stringFieldName -> passString
+      ))
+
+      result.value shouldBe Some(NonUKPassportYes(passStringTransformed))
+      assert(result.errors.isEmpty)
+    }
+
     "fail to bind" when {
 
       s"$booleanFieldName is an invalid value" in {

--- a/test/forms/responsiblepeople/PersonUKPassportFormProviderSpec.scala
+++ b/test/forms/responsiblepeople/PersonUKPassportFormProviderSpec.scala
@@ -59,6 +59,20 @@ class PersonUKPassportFormProviderSpec extends StringFieldBehaviours with Constr
       }
     }
 
+    "true is submitted with a Password number which contains spaces" in {
+
+      val passString = " 1 2 34 5 6 78 9 "
+      val passStringTransformed = "123456789"
+
+      val result = form.bind(Map(
+        booleanFieldName -> "true",
+        stringFieldName -> passString
+      ))
+
+      result.value shouldBe Some(UKPassportYes(passStringTransformed))
+      assert(result.errors.isEmpty)
+    }
+
     "fail to bind" when {
 
       s"$booleanFieldName is an invalid value" in {


### PR DESCRIPTION
Trim and removal of white space in passport number validation. 