### PR TITLE
DDCYLS-5562 - differentiate between registration and renewal journey for bacs confirmation screen

### DIFF
--- a/app/controllers/BacsConfirmationController.scala
+++ b/app/controllers/BacsConfirmationController.scala
@@ -19,6 +19,7 @@ package controllers
 import cats.data.OptionT
 import cats.implicits._
 import connectors._
+import models.renewal.Renewal
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.{AuthEnrolmentsService, StatusService}
 import utils.{AuthAction, BusinessName}
@@ -37,13 +38,14 @@ class BacsConfirmationController @Inject()(authAction: AuthAction,
                                            view: ConfirmationBacsView) extends AmlsBaseController(ds, cc) {
 
   def bacsConfirmation(): Action[AnyContent] = authAction.async {
-      implicit request =>
-        val okResult = for {
-          refNo <- OptionT(enrolmentService.amlsRegistrationNumber(request.amlsRefNumber, request.groupIdentifier))
-          status <- OptionT.liftF(statusService.getReadStatus(refNo, request.accountTypeId))
-          name <- BusinessName.getName(request.credId, status.safeId, request.accountTypeId)
-        } yield Ok (view (name, refNo))
+    implicit request =>
+      val okResult = for {
+        refNo <- OptionT(enrolmentService.amlsRegistrationNumber(request.amlsRefNumber, request.groupIdentifier))
+        status <- OptionT.liftF(statusService.getReadStatus(refNo, request.accountTypeId))
+        name <- BusinessName.getName(request.credId, status.safeId, request.accountTypeId)
+        isRenewal <- OptionT.liftF(dataCacheConnector.fetch[Renewal](request.credId, Renewal.key).map(_.isDefined))
+      } yield Ok(view(name, refNo, isRenewal))
 
-        okResult getOrElse InternalServerError("Unable to get BACS confirmation")
+      okResult getOrElse InternalServerError("Unable to get BACS confirmation")
   }
 }

--- a/app/controllers/testonly/TestOnlyController.scala
+++ b/app/controllers/testonly/TestOnlyController.scala
@@ -134,7 +134,7 @@ class TestOnlyController @Inject()(implicit val dataCacheConnector: DataCacheCon
 
   def confirmationBacs = authAction.async {
     implicit request =>
-      Future.successful(Ok(confirmationBacsView("Company Name", "X123456789")))
+      Future.successful(Ok(confirmationBacsView("Company Name", "X123456789", false)))
   }
 
   def confirmationBacsTransitionalRenewal = confirmationBacs

--- a/app/views/confirmation/ConfirmationBacsView.scala.html
+++ b/app/views/confirmation/ConfirmationBacsView.scala.html
@@ -25,7 +25,7 @@
     feedbackSurveyLink: FeedbackSurveyLink
 )
 
-@(businessName: String, refNo: String)(implicit request: Request[_], messages: Messages, appConfig: ApplicationConfig)
+@(businessName: String, refNo: String, isRenewal : Boolean = false)(implicit request: Request[_], messages: Messages, appConfig: ApplicationConfig)
 
 @panelContent = {
                 <p>@businessName</p>
@@ -40,7 +40,7 @@
 
     @govukPanel(
         Panel(
-            title = Text(messages("confirmation.payment.bacs.header")),
+            title = Text(messages(if(isRenewal) "confirmation.payment.bacs.header.renewal" else "confirmation.payment.bacs.header")),
             content = HtmlContent(panelContent)
         )
     )
@@ -52,7 +52,7 @@
     @informationNotice()
 
     <p class="govuk-body">
-        <a href="@controllers.routes.LandingController.get.url" id="goto-reg-link" class="govuk-link">@messages("link.navigate.registration.Goto")</a>
+        <a href="@controllers.routes.LandingController.get.url" id="goto-reg-link" class="govuk-link">@messages(if(isRenewal) "link.navigate.registration.Returnto" else "link.navigate.registration.Goto")</a>
     </p>
 
     @feedbackSurveyLink()

--- a/conf/messages
+++ b/conf/messages
@@ -1218,6 +1218,7 @@ confirmation.payment.amendvariation.info.keep_up_to_date = If any of your inform
 
 confirmation.payment.bacs.title = You have submitted the application
 confirmation.payment.bacs.header = Application complete
+confirmation.payment.bacs.header.renewal = Re-registration complete
 
 confirmation.payment.renewal.lede = You have submitted your renewal and paid
 confirmation.payment.renewal.title = You have submitted your renewal and paid

--- a/test/controllers/BacsConfirmationControllerSpec.scala
+++ b/test/controllers/BacsConfirmationControllerSpec.scala
@@ -25,6 +25,7 @@ import models.businesscustomer.{Address, ReviewDetails}
 import models.businessdetails.{BusinessDetails, PreviouslyRegisteredNo, PreviouslyRegisteredYes}
 import models.businessmatching.BusinessMatching
 import models.payments._
+import models.renewal.Renewal
 import models.registrationdetails.RegistrationDetails
 import models.status._
 import models.{status => _, _}
@@ -114,6 +115,10 @@ class BacsConfirmationControllerSpec extends AmlsSpec
       controller.dataCacheConnector.fetch[BusinessDetails](any(), eqTo(BusinessDetails.key))(any())
     } thenReturn Future.successful(Some(businessDetails))
 
+    when {
+      controller.dataCacheConnector.fetch[Renewal](any(), eqTo(Renewal.key))(any())
+    } thenReturn Future.successful(None)
+
     val applicationConfig = app.injector.instanceOf[ApplicationConfig]
 
     def paymentsReturnLocation(ref: String) = ReturnLocation(
@@ -156,11 +161,8 @@ class BacsConfirmationControllerSpec extends AmlsSpec
         when {
           controller.statusService.getReadStatus(any[String](), any[(String, String)]())(any(), any())
         } thenReturn Future.successful(ReadStatusResponse(LocalDateTime.now(), "", None, None, None, None, false))
-
         val result = controller.bacsConfirmation()(request)
-
         status(result) mustBe OK
-
         Jsoup.parse(contentAsString(result)).getElementsByTag("h1").first().text() must include(
           messages("confirmation.payment.bacs.header")
         )


### PR DESCRIPTION
As part of the AMLS registration and renewal journeys, the shared bacs confirmation screen now differentiates between the journey, displaying a new panel heading and text for the link to return to the dashboard.