### PR TITLE
DDCYLS-4866 - Autocomplete fields missing link to error message 

### DIFF
--- a/app/views/renewal/CustomersOutsideUKView.scala.html
+++ b/app/views/renewal/CustomersOutsideUKView.scala.html
@@ -16,6 +16,7 @@
 
 @import views.html.components.forms.{ErrorSummary, InputCountry}
 @import views.html.components.{SectionSubtitle, Heading, Button, ReturnLink}
+@import views.html.helper.CSPNonce
 
 @this(
     layout: Layout,
@@ -51,6 +52,7 @@
 @layout(
     pageTitle = messages("renewal.customer.outside.uk.countries.title") + " - " + messages("summary.renewal")
 ) {
+    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("autocomplete-polyfill.css")' />
 
     @errorSummary(preparedForm, preparedErrorSummaryMapping)
 
@@ -78,4 +80,5 @@
 
         @returnLink(true, Some("renewal"))
     }
+    <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("autocomplete-polyfill.js")'></script>
 }

--- a/app/views/renewal/MostTransactionsView.scala.html
+++ b/app/views/renewal/MostTransactionsView.scala.html
@@ -16,6 +16,7 @@
 
 @import views.html.components.forms.{ErrorSummary, InputCountry}
 @import views.html.components.{SectionSubtitle, Heading, Button, ReturnLink}
+@import views.html.helper.CSPNonce
 
 @this(
     layout: Layout,
@@ -51,6 +52,7 @@
 @layout(
     pageTitle = messages("renewal.msb.most.transactions.title") + " - " + messages("summary.renewal")
 ) {
+    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("autocomplete-polyfill.css")' />
 
     @errorSummary(preparedForm, preparedErrorSummaryMapping)
 
@@ -76,4 +78,5 @@
 
         @returnLink(true, Some("renewal"))
     }
+    <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("autocomplete-polyfill.js")'></script>
 }

--- a/app/views/renewal/SendLargestAmountsOfMoneyView.scala.html
+++ b/app/views/renewal/SendLargestAmountsOfMoneyView.scala.html
@@ -15,6 +15,7 @@
  *@
 
 @import views.html.components.forms.{ErrorSummary, InputCountry}
+@import views.html.helper.CSPNonce
 @import views.html.components.{SectionSubtitle, Heading, Button, ReturnLink}
 
 @this(
@@ -51,6 +52,7 @@
 @layout(
     pageTitle = messages("renewal.msb.largest.amounts.title") + " - " + messages("summary.renewal")
 ) {
+    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("autocomplete-polyfill.css")' />
 
     @errorSummary(preparedForm, preparedErrorSummaryMapping)
 
@@ -76,4 +78,5 @@
 
         @returnLink(true, Some("renewal"))
     }
+    <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("autocomplete-polyfill.js")'></script>
 }

--- a/app/views/renewal/WhichCurrenciesView.scala.html
+++ b/app/views/renewal/WhichCurrenciesView.scala.html
@@ -18,7 +18,7 @@
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.accessibleautocomplete.AccessibleAutocomplete
 @import views.html.components.forms.ErrorSummary
 @import views.html.components.{SectionSubtitle, Heading, Button, ReturnLink}
-
+@import views.html.helper.CSPNonce
 @this(
     layout: Layout,
     errorSummary: ErrorSummary,
@@ -53,6 +53,7 @@
 @layout(
     pageTitle = messages("renewal.msb.whichcurrencies.header") + " - " + messages("summary.renewal")
 ) {
+    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("autocomplete-polyfill.css")' />
 
     @errorSummary(preparedForm, preparedErrorSummaryMapping)
 
@@ -86,4 +87,5 @@
     }
 
     @returnLink(true, Some("renewal"))
+    <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("autocomplete-polyfill.js")'></script>
 }

--- a/app/views/responsiblepeople/CountryOfBirthView.scala.html
+++ b/app/views/responsiblepeople/CountryOfBirthView.scala.html
@@ -17,6 +17,7 @@
 @import views.html.components.{Button, Heading, SectionSubtitle, ReturnLink}
 @import views.html.components.forms.{ErrorSummary, InputYesNo, InputCountry}
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
+@import views.html.helper.CSPNonce
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 @import uk.gov.hmrc.hmrcfrontend.views.config.HmrcYesNoRadioItems
 
@@ -70,6 +71,8 @@
 
 @layout(pageTitle = messages("responsiblepeople.country.of.birth.title") + " - " + messages("summary.responsiblepeople")) {
 
+    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("autocomplete-polyfill.css")' />
+
     @errorSummary(form, preparedErrorSummaryMapping)
 
     @subtitle("summary.responsiblepeople")
@@ -95,4 +98,6 @@
 
         @returnLink(true)
     }
+    <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("autocomplete-polyfill.js")'></script>
+
 }

--- a/app/views/responsiblepeople/NationalityView.scala.html
+++ b/app/views/responsiblepeople/NationalityView.scala.html
@@ -17,6 +17,7 @@
 @import views.html.components.{Button, Heading, SectionSubtitle, ReturnLink}
 @import views.html.components.forms.{ErrorSummary, InputYesNo, InputCountry}
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
+@import views.html.helper.CSPNonce
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
 @import uk.gov.hmrc.hmrcfrontend.views.config.HmrcYesNoRadioItems
 
@@ -70,8 +71,10 @@
 }
 
 @layout(pageTitle = messages("responsiblepeople.nationality.title", personName) + " - " + messages("summary.responsiblepeople")) {
+    <link rel="stylesheet" href='@controllers.routes.Assets.versioned("autocomplete-polyfill.css")' />
 
-    @errorSummary(form, preparedErrorSummaryMapping)
+
+@errorSummary(form, preparedErrorSummaryMapping)
 
     @subtitle("summary.responsiblepeople")
 
@@ -96,4 +99,5 @@
 
         @returnLink(true)
     }
+    <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("autocomplete-polyfill.js")'></script>
 }

--- a/public/autocomplete-polyfill.css
+++ b/public/autocomplete-polyfill.css
@@ -1,0 +1,18 @@
+// Ensure the error styling is presented (powered by adding the govuk-input-error class in js)
+// This can't be done just by adding the class due to conflicting specificity
+.autocomplete__input.govuk-input--error {
+    border-color: #d4351c;
+}
+// Ensure the down arrow for 'show all' option sits above the input so it is visible
+// (there was a change - possibly either input or page background which effectively hid the arrow due to its z-index)
+.autocomplete__dropdown-arrow-down {
+    z-index: 0;
+    pointer-events: none;
+}
+// Constrain the input (and drop-down) so they site with the other address inputs
+// important to do this on the wrapper rather than the input itself otherwise the down-arrow will be floating by itself
+@media (min-width: 40.0625em){
+    .autocomplete__wrapper {
+        width: 75%!important;
+    }
+}

--- a/public/autocomplete-polyfill.js
+++ b/public/autocomplete-polyfill.js
@@ -1,0 +1,113 @@
+document.addEventListener("DOMContentLoaded", function() {
+    console.log("autocomplete thing is loaded and running");
+
+    if (typeof HMRCAccessibleAutocomplete != 'undefined' && document.querySelector('[data-module="hmrc-accessible-autocomplete"]') != null) {
+        var originalSelect = document.querySelector('[data-module="hmrc-accessible-autocomplete"]');
+        // load autocomplete - now handled by the HMRC component wrapper in Twirl
+        // accessibleAutocomplete.enhanceSelectElement({
+        //     selectElement: originalSelect,
+        //     showAllValues: true
+        // });
+
+        // =====================================================
+        // Polyfill autocomplete once loaded
+        // =====================================================
+        var checkForLoad = setInterval(checkForAutocompleteLoad, 50);
+        var parentForm = upTo(originalSelect, 'form');
+
+        function polyfillAutocomplete() {
+            var combo = parentForm.querySelector('[role="combobox"]');
+
+            // =====================================================
+            // Update autocomplete once loaded with fallback's aria attributes
+            // Ensures hint and error are read out before usage instructions
+            // =====================================================
+            if (originalSelect && originalSelect.getAttribute('aria-describedby') > "") {
+                if (parentForm) {
+                    if (combo) {
+                        combo.setAttribute('aria-describedby', originalSelect.getAttribute('aria-describedby') + ' ' + combo.getAttribute('aria-describedby'));
+                    }
+                }
+            }
+            // =====================================================
+            // Update autocomplete once loaded with error styling if needed
+            // This won't work if the autocomplete css is loaded after the frontend library css because
+            // the autocomplete's border will override the error class's border (they are both the same specificity)
+            // but we can use the class assigned to build a more specific rule
+            // =====================================================
+            setErrorClass();
+            function setErrorClass() {
+                if (originalSelect && originalSelect.classList.contains("govuk-select--error")) {
+                    if (parentForm) {
+                        if (combo) {
+                            combo.classList.add("govuk-input--error");
+                            // Also set up an event listener to check for changes to input so we know when to repeat the copy
+                            combo.addEventListener('focus', function() { setErrorClass() });
+                            combo.addEventListener('blur', function() { setErrorClass() });
+                            combo.addEventListener('change', function() { setErrorClass() });
+                        }
+                    }
+                }
+            }
+
+            // =====================================================
+            // Ensure when user replaces valid answer with a non-valid answer, then valid answer is not retained
+            // =====================================================
+            var holdSubmit = true;
+            parentForm.addEventListener('submit', function(e) {
+                if (holdSubmit) {
+                    e.preventDefault();
+                    if (originalSelect.querySelectorAll('[selected]').length > 0 || originalSelect.value > "") {
+
+                        var resetSelect = false;
+
+                        if (originalSelect.value) {
+                            if (combo.value != originalSelect.querySelector('option[value="' + originalSelect.value + '"]').text) {
+                                resetSelect = true;
+                            }
+                        }
+                        if (resetSelect) {
+                            originalSelect.value = "";
+                            if (originalSelect.querySelectorAll('[selected]').length > 0) {
+                                originalSelect.querySelectorAll('[selected]')[0].removeAttribute('selected');
+                            }
+                        }
+                    }
+
+                    holdSubmit = false;
+                    //parentForm.submit();
+                    HTMLFormElement.prototype.submit.call(parentForm); // because submit buttons have id of "submit" which masks the form's natural form.submit() function
+                }
+            });
+
+
+        }
+
+
+        function checkForAutocompleteLoad() {
+            if (parentForm.querySelector('[role="combobox"]')) {
+                clearInterval(checkForLoad);
+                polyfillAutocomplete();
+            }
+        }
+    }
+
+    // Find first ancestor of el with tagName
+    // or undefined if not found
+    function upTo(el, tagName) {
+        tagName = tagName.toLowerCase();
+
+        while (el && el.parentNode) {
+            el = el.parentNode;
+            if (el.tagName && el.tagName.toLowerCase() == tagName) {
+                return el;
+            }
+        }
+
+        // Many DOM methods return null if they don't
+        // find the element they are searching for
+        // It would be OK to omit the following and just
+        // return undefined
+        return null;
+    }
+});


### PR DESCRIPTION
### Fix for aria-describedby in autocomplete fields

- Applied the autocomplete polyfill to resolve an accessibility issue where error messages were not correctly announced to screen readers.

- Ensured that when an error occurs, the aria-describedby attribute points to both the error message and any associated hint for the visible input element
