### PR TITLE
DDYCLS-6026: retrieve latest business name from ETMP

### DIFF
--- a/test/controllers/RegistrationProgressControllerSpec.scala
+++ b/test/controllers/RegistrationProgressControllerSpec.scala
@@ -18,6 +18,7 @@ package controllers
 
 import cats.data.OptionT
 import cats.implicits._
+import connectors.AmlsConnector
 import controllers.actions.SuccessfulAuthAction
 import generators.AmlsReferenceNumberGenerator
 import generators.businesscustomer.ReviewDetailsGenerator
@@ -70,6 +71,7 @@ class RegistrationProgressControllerSpec extends AmlsSpec
       sectionsProvider = mockSectionsProvider,
       businessMatchingService = mockBusinessMatchingService,
       serviceFlow = mockServiceFlow,
+      amlsConnector = mock[AmlsConnector],
       renewalService = renewalService,
       ds = commonDependencies,
       cc = mockMcc,
@@ -96,6 +98,9 @@ class RegistrationProgressControllerSpec extends AmlsSpec
     } thenReturn Some(BusinessActivities(Set(AccountancyServices, BillPaymentServices, EstateAgentBusinessService)))
 
     when(mockCacheMap.getEntry[BusinessMatching](any())(any())).thenReturn(Some(mockBusinessMatching))
+
+    when(controller.statusService.getDetailedStatus(any[Option[String]](), any(), any())(any(), any(), any()))
+      .thenReturn(Future.successful((NotCompleted, None)))
   }
 
   "RegistrationProgressController" when {
@@ -143,8 +148,6 @@ class RegistrationProgressControllerSpec extends AmlsSpec
               TaskRow("TESTSECTION1", "/foo", false, Completed, TaskRow.completedTag),
               TaskRow("TESTSECTION2", "/bar", true, Completed, TaskRow.completedTag)
             ))
-
-          mockCacheFetch[Renewal](Some(Renewal(Some(InvolvedInOtherNo))))
 
           mockApplicationStatus(RenewalSubmitted(None))
 


### PR DESCRIPTION
Calling out to ETMP to retrieve latest business name as currently displaying an old name after a user has updated.