### PR TITLE
DDCYLS-8388 AMLS: Radio group should be enclosed by a fieldset WCAG2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ pc.stdout.log
 .jvmopts
 .DS_Store
 .bsp
+/.metals
+/.vscode

--- a/app/views/hvd/CashPaymentView.scala.html
+++ b/app/views/hvd/CashPaymentView.scala.html
@@ -26,14 +26,26 @@
     errorSummary: ErrorSummary,
     subtitle: SectionSubtitle,
     heading: Heading,
-    cashPaymentText: CashPaymentText,
     formHelper: FormWithCSRF,
+    govukFieldset: GovukFieldset,
     inputYesNo: InputYesNo,
     button: Button,
     returnLink: ReturnLink
 )
 
 @(form: Form[_], edit: Boolean)(implicit requestHeader: RequestHeader, messages: Messages, appConfig: ApplicationConfig)
+
+@fieldsetHtml = {
+    <p class="govuk-body">@messages("hvd.cash.payment.convert.currency.summary")</p>
+
+    @inputYesNo(
+        Radios(
+            name = "acceptedAnyPayment",
+            items = HmrcYesNoRadioItems(),
+            classes = "govuk-radios govuk-radios--inline"
+        ).withFormField(form("acceptedAnyPayment"))
+    )
+}
 
 @layout(pageTitle = messages("hvd.cash.payment.title") + " - " + messages("summary.hvd")) {
 
@@ -51,19 +63,15 @@
         <li>@messages("hvd.cash.payment.data.summary.details.03")</li>
     </ul>
 
-    <h2 class = govuk-heading-m>@messages("hvd.cash.accepted.payment")</h2>
-
-    <p class="govuk-body">@messages("hvd.cash.payment.convert.currency.summary")</p>
-
     @formHelper(action = controllers.hvd.routes.CashPaymentController.post(edit)) {
 
-        @inputYesNo(
-            Radios(
-                name = "acceptedAnyPayment",
-                items = HmrcYesNoRadioItems(),
-                classes = "govuk-radios govuk-radios--inline"
-            ).withFormField(form("acceptedAnyPayment"))
-        )
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = HtmlContent(s"""<h2 class="govuk-heading-m">${messages("hvd.cash.accepted.payment")}</h2>"""),
+                classes = "govuk-fieldset__legend--m"
+            )),
+            html = fieldsetHtml
+        ))
 
         @button()
 

--- a/app/views/hvd/LinkedCashPaymentsView.scala.html
+++ b/app/views/hvd/LinkedCashPaymentsView.scala.html
@@ -19,15 +19,15 @@
 @import uk.gov.hmrc.hmrcfrontend.views.config.HmrcYesNoRadioItems
 @import views.html.hvd.CashPaymentText
 @import views.html.components.forms.{ErrorSummary, InputYesNo}
-@import views.html.components.{Button, ReturnLink, SectionSubtitle, Heading}
+@import views.html.components.{Button, ReturnLink, SectionSubtitle}
 
 @this(
     layout: Layout,
     errorSummary: ErrorSummary,
     subtitle: SectionSubtitle,
-    heading: Heading,
     cashPaymentText: CashPaymentText,
     formHelper: FormWithCSRF,
+    govukFieldset: GovukFieldset,
     inputYesNo: InputYesNo,
     button: Button,
     returnLink: ReturnLink
@@ -35,25 +35,33 @@
 
 @(form: Form[_], edit: Boolean)(implicit requestHeader: RequestHeader, messages: Messages, appConfig: ApplicationConfig)
 
+@fieldsetHtml = {
+    @cashPaymentText()
+
+    @inputYesNo(
+        Radios(
+            name = "linkedCashPayments",
+            items = HmrcYesNoRadioItems(),
+            classes = "govuk-radios govuk-radios--inline"
+        ).withFormField(form("linkedCashPayments"))
+    )
+}
+
 @layout(pageTitle = messages("hvd.identify.linked.cash.payment.title") + " - " + messages("summary.hvd")) {
 
     @errorSummary(form)
 
     @subtitle("summary.hvd")
 
-    @heading("hvd.identify.linked.cash.payment.title")
-
-    @cashPaymentText()
-
     @formHelper(action = controllers.hvd.routes.LinkedCashPaymentsController.post(edit)) {
 
-        @inputYesNo(
-            Radios(
-                name = "linkedCashPayments",
-                items = HmrcYesNoRadioItems(),
-                classes = "govuk-radios govuk-radios--inline"
-            ).withFormField(form("linkedCashPayments"))
-        )
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = HtmlContent(s"""<h1 class="govuk-heading-xl">${messages("hvd.identify.linked.cash.payment.title")}</h1>"""),
+                classes = "govuk-fieldset__legend--xl"
+            )),
+            html = fieldsetHtml
+        ))
 
         @button()
 

--- a/app/views/hvd/ReceiveCashView.scala.html
+++ b/app/views/hvd/ReceiveCashView.scala.html
@@ -19,15 +19,15 @@
 @import uk.gov.hmrc.hmrcfrontend.views.config.HmrcYesNoRadioItems
 @import views.html.hvd.CashPaymentText
 @import views.html.components.forms.{ErrorSummary, InputYesNo}
-@import views.html.components.{Button, ReturnLink, SectionSubtitle, Heading}
+@import views.html.components.{Button, ReturnLink, SectionSubtitle}
 
 @this(
     layout: Layout,
     errorSummary: ErrorSummary,
     subtitle: SectionSubtitle,
-    heading: Heading,
     cashPaymentText: CashPaymentText,
     formHelper: FormWithCSRF,
+    govukFieldset: GovukFieldset,
     inputYesNo: InputYesNo,
     button: Button,
     returnLink: ReturnLink
@@ -35,25 +35,33 @@
 
 @(form: Form[_], edit: Boolean)(implicit requestHeader: RequestHeader, messages: Messages, appConfig: ApplicationConfig)
 
+@fieldsetHtml = {
+    @cashPaymentText()
+
+    @inputYesNo(
+        Radios(
+            name = "receivePayments",
+            items = HmrcYesNoRadioItems(),
+            classes = "govuk-radios govuk-radios--inline"
+        ).withFormField(form("receivePayments"))
+    )
+}
+
 @layout(pageTitle = messages("hvd.receiving.title") + " - " + messages("summary.hvd")) {
 
     @errorSummary(form)
 
     @subtitle("summary.hvd")
 
-    @heading("hvd.receiving.title")
-
-    @cashPaymentText()
-
     @formHelper(action = controllers.hvd.routes.ReceiveCashPaymentsController.post(edit)) {
 
-        @inputYesNo(
-            Radios(
-                name = "receivePayments",
-                items = HmrcYesNoRadioItems(),
-                classes = "govuk-radios govuk-radios--inline"
-            ).withFormField(form("receivePayments"))
-        )
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = HtmlContent(s"""<h1 class="govuk-heading-xl">${messages("hvd.receiving.title")}</h1>"""),
+                classes = "govuk-fieldset__legend--xl"
+            )),
+            html = fieldsetHtml
+        ))
 
         @button()
 

--- a/app/views/msb/BusinessUseAnIPSPView.scala.html
+++ b/app/views/msb/BusinessUseAnIPSPView.scala.html
@@ -18,14 +18,14 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import models.moneyservicebusiness.BusinessUseAnIPSP
 @import views.html.components.forms.{ErrorSummary, InputYesNo, InputText}
-@import views.html.components.{Button, ReturnLink, SectionSubtitle, Heading}
+@import views.html.components.{Button, ReturnLink, SectionSubtitle}
 
 @this(
     layout: Layout,
     errorSummary: ErrorSummary,
     subtitle: SectionSubtitle,
-    heading: Heading,
     formHelper: FormWithCSRF,
+    govukFieldset: GovukFieldset,
     inputYesNo: InputYesNo,
     inputText: InputText,
     button: Button,
@@ -66,25 +66,33 @@
     )
 }
 
+@fieldsetHtml = {
+    <p class="govuk-body">@messages("msb.throughput.ipsp.hint")</p>
+
+    @inputYesNo(
+        Radios(
+            name = "useAnIPSP",
+            items = BusinessUseAnIPSP.formValues(conditionalNameInput, conditionalReferenceInput),
+            classes = "govuk-radios"
+        ).withFormField(form("useAnIPSP"))
+    )
+}
+
 @layout(pageTitle = messages("msb.ipsp.title") + " - " + messages("summary.msb")) {
 
     @errorSummary(form)
 
     @subtitle("summary.msb")
 
-    @heading("msb.ipsp.title")
-
-    <p class="govuk-body">@messages("msb.throughput.ipsp.hint")</p>
-
     @formHelper(action = controllers.msb.routes.BusinessUseAnIPSPController.post(edit)) {
 
-        @inputYesNo(
-            Radios(
-                name = "useAnIPSP",
-                items = BusinessUseAnIPSP.formValues(conditionalNameInput, conditionalReferenceInput),
-                classes = "govuk-radios"
-            ).withFormField(form("useAnIPSP"))
-        )
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = HtmlContent(s"""<h1 class="govuk-heading-xl">${messages("msb.ipsp.title")}</h1>"""),
+                classes = "govuk-fieldset__legend--xl"
+            )),
+            html = fieldsetHtml
+        ))
 
         @button()
 

--- a/app/views/msb/FundsTransferView.scala.html
+++ b/app/views/msb/FundsTransferView.scala.html
@@ -18,13 +18,12 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import uk.gov.hmrc.hmrcfrontend.views.config.HmrcYesNoRadioItems
 @import views.html.components.forms.{ErrorSummary, InputYesNo}
-@import views.html.components.{Button, ReturnLink, SectionSubtitle, Heading}
+@import views.html.components.{Button, ReturnLink, SectionSubtitle}
 
 @this(
     layout: Layout,
     errorSummary: ErrorSummary,
     subtitle: SectionSubtitle,
-    heading: Heading,
     formHelper: FormWithCSRF,
     inputYesNo: InputYesNo,
     button: Button,
@@ -39,12 +38,16 @@
 
     @subtitle("summary.msb")
 
-    @heading("msb.fundstransfer.title")
-
     @formHelper(action = controllers.msb.routes.FundsTransferController.post(edit)) {
 
         @inputYesNo(
             Radios(
+                fieldset = Some(Fieldset(
+                    legend = Some(Legend(
+                        content = HtmlContent(s"""<h1 class="govuk-heading-xl">${messages("msb.fundstransfer.title")}</h1>"""),
+                        classes = "govuk-fieldset__legend--xl"
+                    ))
+                )),
                 name = "transferWithoutFormalSystems",
                 items = HmrcYesNoRadioItems(),
                 classes = "govuk-radios govuk-radios--inline"

--- a/app/views/msb/SendMoneyToOtherCountryView.scala.html
+++ b/app/views/msb/SendMoneyToOtherCountryView.scala.html
@@ -18,13 +18,12 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import uk.gov.hmrc.hmrcfrontend.views.config.HmrcYesNoRadioItems
 @import views.html.components.forms.{ErrorSummary, InputYesNo}
-@import views.html.components.{Button, ReturnLink, SectionSubtitle, Heading}
+@import views.html.components.{Button, ReturnLink, SectionSubtitle}
 
 @this(
     layout: Layout,
     errorSummary: ErrorSummary,
     subtitle: SectionSubtitle,
-    heading: Heading,
     formHelper: FormWithCSRF,
     inputYesNo: InputYesNo,
     button: Button,
@@ -39,12 +38,16 @@
 
     @subtitle("summary.msb")
 
-    @heading("msb.send.money.title")
-
     @formHelper(action = controllers.msb.routes.SendMoneyToOtherCountryController.post(edit)) {
 
         @inputYesNo(
             Radios(
+                fieldset = Some(Fieldset(
+                    legend = Some(Legend(
+                        content = HtmlContent(s"""<h1 class="govuk-heading-xl">${messages("msb.send.money.title")}</h1>"""),
+                        classes = "govuk-fieldset__legend--xl"
+                    ))
+                )),
                 name = "money",
                 items = HmrcYesNoRadioItems(),
                 classes = "govuk-radios govuk-radios--inline"

--- a/app/views/renewal/CashPaymentsCustomersNotMetView.scala.html
+++ b/app/views/renewal/CashPaymentsCustomersNotMetView.scala.html
@@ -68,7 +68,7 @@
             Radios(
                 fieldset = Some(Fieldset(
                     legend = Some(Legend(
-                        content = Text(messages("renewal.cash.payments.not.met")),
+                        content = HtmlContent(s"""<h2 class="govuk-heading-m">${messages("renewal.cash.payments.not.met")}</h2>"""),
                         classes = "govuk-fieldset__legend--m"
                     ))
                 )),

--- a/app/views/renewal/CashPaymentsCustomersNotMetView.scala.html
+++ b/app/views/renewal/CashPaymentsCustomersNotMetView.scala.html
@@ -62,14 +62,16 @@
         <div/>
     </details>
 
-    <h2 class="govuk-heading-m">@messages("renewal.cash.payments.not.met")</h2>
-
-
-
     @formHelper(controllers.renewal.routes.CashPaymentsCustomersNotMetController.post(edit)) {
 
         @inputYesNo(
             Radios(
+                fieldset = Some(Fieldset(
+                    legend = Some(Legend(
+                        content = Text(messages("renewal.cash.payments.not.met")),
+                        classes = "govuk-fieldset__legend--m"
+                    ))
+                )),
                 name = "receiveCashPayments",
                 items = HmrcYesNoRadioItems(),
                 classes = "govuk-radios govuk-radios--inline"


### PR DESCRIPTION
Changes - 

DDCYLS-8388 Added fieldsets to  radio groups

- Amended CashPaymentsCustomersNotMetView.scala.html 
- Amended LinkedCashPaymentsView.scala.html
- Amended ReceiveCashView.scala.html`
- Amended CashPaymentView.scala.html
- Amended FundsTransferView.scala.html
- Amended BusinessUseAnIPSPView.scala.html
- Amended SendMoneyToOtherCountryView.scala.html`
- amended .gitignore


## Related / Dependant PRs?


## How Has This Been Tested?

manual accessibility test
Ran unit tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [ ] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
